### PR TITLE
use `FutureWarning` for deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ class PastCls(NewCls):
         You place the decorator around __init__ as you want
          to warn user just at the time of creating object.
         """
-        return void(c, d)
+        void(c, d)
 
 
 # call this function will raise deprecation warning:

--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ def any_pow(base, c1: float = 0, nc1: float = 0, nc2: float = 2) -> float:
 
 
 # call this function will raise deprecation warning:
-#   DeprecationWarning('Depr: v0.3 rm v0.6 for args: `c1` -> `nc1`.')
-#   DeprecationWarning('Depr: v0.4 rm v0.7 for args: `nc1` -> `nc2`.')
+#   FutureWarning('Depr: v0.3 rm v0.6 for args: `c1` -> `nc1`.')
+#   FutureWarning('Depr: v0.4 rm v0.7 for args: `nc1` -> `nc2`.')
 print(any_pow(2, 3))
 ```
 

--- a/deprecate/deprecation.py
+++ b/deprecate/deprecation.py
@@ -21,7 +21,7 @@ TEMPLATE_WARNING_NO_TARGET = (
     "The `%(source_name)s` was deprecated since v%(deprecated_in)s. It will be removed in v%(remove_in)s."
 )
 
-deprecation_warning = partial(warn, category=DeprecationWarning)
+deprecation_warning = partial(warn, category=FutureWarning)
 
 
 def get_func_arguments_types_defaults(func: Callable) -> List[Tuple[str, Tuple, Any]]:

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -21,9 +21,10 @@ class ThisCls(NewCls):
 
 
 def test_deprecated_class_forward() -> None:
-    with pytest.deprecated_call(
+    with pytest.warns(
+        FutureWarning,
         match="The `PastCls` was deprecated since v0.2 in favor of `tests.collection_targets.NewCls`."
-        " It will be removed in v0.4."
+        " It will be removed in v0.4.",
     ):
         past = PastCls(2, e=0.1)
     assert past.my_c == 2
@@ -37,7 +38,7 @@ def test_deprecated_class_forward() -> None:
         assert PastCls(c=2, d="", e=0.9999)
 
     PastCls.__init__._warned = False
-    with pytest.deprecated_call(match="It will be removed in v0.4."):
+    with pytest.warns(FutureWarning, match="It will be removed in v0.4."):
         PastCls(2)
 
 
@@ -47,9 +48,10 @@ def test_deprecated_class_self() -> None:
     assert this.my_c == 1
     assert isinstance(this, ThisCls)
 
-    with pytest.deprecated_call(
+    with pytest.warns(
+        FutureWarning,
         match="The `ThisCls` uses deprecated arguments: `c` -> `nc`."
-        " They were deprecated since v0.3 and will be removed in v0.5."
+        " They were deprecated since v0.3 and will be removed in v0.5.",
     ):
         this = ThisCls(2)
     assert this.my_c == 2

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -27,8 +27,8 @@ from tests.collection_deprecate import (
 
 
 def test_deprecated_func_warn_only() -> None:
-    with pytest.deprecated_call(
-        match="The `depr_sum_warn_only` was deprecated since v0.2. It will be removed in v0.3."
+    with pytest.warns(
+        FutureWarning, match="The `depr_sum_warn_only` was deprecated since v0.2. It will be removed in v0.3."
     ):
         assert depr_sum_warn_only(2) is None
 
@@ -38,19 +38,20 @@ def test_deprecated_func_arguments() -> None:
     with no_warning_call():
         assert depr_pow_self(2, new_coef=3) == 8
 
-    with pytest.deprecated_call(
+    with pytest.warns(
+        FutureWarning,
         match="The `depr_pow_self` uses deprecated arguments: `coef` -> `new_coef`."
-        " They were deprecated since v0.1 and will be removed in v0.5."
+        " They were deprecated since v0.1 and will be removed in v0.5.",
     ):
         assert depr_pow_self(2, 3) == 8
 
-    with pytest.deprecated_call(match="The `depr_pow_self_double` uses depr. args: `c1` -> `nc1`."):
+    with pytest.warns(FutureWarning, match="The `depr_pow_self_double` uses depr. args: `c1` -> `nc1`."):
         assert depr_pow_self_double(2, c1=3) == 32
 
     with no_warning_call():
         assert depr_pow_self_double(2, c1=3) == 32
 
-    with pytest.deprecated_call(match="The `depr_pow_self_double` uses depr. args: `c2` -> `nc2`."):
+    with pytest.warns(FutureWarning, match="The `depr_pow_self_double` uses depr. args: `c2` -> `nc2`."):
         assert depr_pow_self_double(2, c2=2) == 8
 
     with no_warning_call():
@@ -66,7 +67,7 @@ def test_deprecated_func_arguments() -> None:
 
 def test_deprecated_func_chain() -> None:
     """Test chaining deprecation wrappers."""
-    with pytest.warns(DeprecationWarning) as warns:
+    with pytest.warns(FutureWarning) as warns:
         assert depr_pow_self_twice(2, 3) == 8
     assert len(warns) == 2
 
@@ -76,42 +77,44 @@ def test_deprecated_func_chain() -> None:
 
 def test_deprecated_func_default() -> None:
     """Testing some base/default configurations."""
-    with pytest.deprecated_call(
+    with pytest.warns(
+        FutureWarning,
         match="The `depr_sum` was deprecated since v0.1 in favor of `tests.collection_targets.base_sum_kwargs`."
-        " It will be removed in v0.5."
+        " It will be removed in v0.5.",
     ):
         assert depr_sum(2) == 7
 
     # check that the warning is raised only once per function
-    with no_warning_call(DeprecationWarning):
+    with no_warning_call(FutureWarning):
         assert depr_sum(3) == 8
 
     # and does not affect other functions
-    with pytest.deprecated_call(
+    with pytest.warns(
+        FutureWarning,
         match="The `depr_pow_mix` was deprecated since v0.1 in favor of `tests.collection_targets.base_pow_args`."
-        " It will be removed in v0.5."
+        " It will be removed in v0.5.",
     ):
         assert depr_pow_mix(2, 1) == 2
 
 
 def test_deprecated_func_stream_calls() -> None:
     # check that the warning is raised only once per function
-    with no_warning_call(DeprecationWarning):
+    with no_warning_call(FutureWarning):
         assert depr_sum_no_stream(3) == 8
 
     # check that the warning is raised only once per function
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(FutureWarning) as record:
         for _ in range(5):
             assert depr_sum_calls_2(3) == 8
     assert len(record) == 2
 
     # check that the warning is raised only once per function
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(FutureWarning) as record:
         for _ in range(5):
             assert depr_sum_calls_inf(3) == 8
     assert len(record) == 5
 
-    with pytest.deprecated_call(match="v0.1: `depr_sum_msg` was deprecated, use `base_sum_kwargs`"):
+    with pytest.warns(FutureWarning, match="v0.1: `depr_sum_msg` was deprecated, use `base_sum_kwargs`"):
         assert depr_sum_msg(3) == 8
 
 
@@ -127,13 +130,13 @@ def test_deprecated_func_incomplete() -> None:
         depr_pow_wrong(2)
 
     # check that the warning is raised only once per function
-    with no_warning_call(DeprecationWarning):
+    with no_warning_call(FutureWarning):
         assert depr_pow_args(2, 1) == 2
 
     # reset the warning
     depr_pow_args._warned = False
     # does not affect other functions
-    with pytest.deprecated_call(match="`depr_pow_args` >> `base_pow_args` in v1.0 rm v1.3."):
+    with pytest.warns(FutureWarning, match="`depr_pow_args` >> `base_pow_args` in v1.0 rm v1.3."):
         assert depr_pow_args(b=2, a=1) == 1
 
 
@@ -145,10 +148,10 @@ def test_deprecated_func_skip_if() -> None:
     with no_warning_call():
         assert depr_pow_skip_if_func(2, c1=2) == 2
 
-    with pytest.deprecated_call(match="Depr: v0.1 rm v0.2 for args: `c1` -> `nc1`."):
+    with pytest.warns(FutureWarning, match="Depr: v0.1 rm v0.2 for args: `c1` -> `nc1`."):
         assert depr_pow_skip_if_true_false(2, c1=2) == 0.5
 
-    with pytest.deprecated_call(match="Depr: v0.1 rm v0.2 for args: `c1` -> `nc1`."):
+    with pytest.warns(FutureWarning, match="Depr: v0.1 rm v0.2 for args: `c1` -> `nc1`."):
         assert depr_pow_skip_if_false_true(2, c1=2) == 0.5
 
     with pytest.raises(TypeError, match="User function `shall_skip` shall return bool, but got: <class 'int'>"):
@@ -157,11 +160,11 @@ def test_deprecated_func_skip_if() -> None:
 
 def test_deprecated_func_mapping() -> None:
     """Test mapping to external functions."""
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         assert depr_accuracy_map([1, 0, 1, 2]) == 0.5
 
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         assert depr_accuracy_skip([1, 0, 1, 2]) == 0.5
 
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         assert depr_accuracy_extra([1, 0, 1, 2]) == 0.75


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

- **exception `DeprecationWarning`** Base class for warnings about deprecated features when those warnings are **intended for other Python developers**. _Ignored by the default warning filters_, except in the `__main__` module (PEP 565). Enabling the Python Development Mode shows this warning.

- **exception `FutureWarning`** Base class for warnings about deprecated features when those warnings are **intended for end users of applications** that are written in Python.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
