### PR TITLE
Add support for Python 3.12, 3.13, and 3.14 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,9 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+        "Topic :: Software Development :: Libraries",
     ],
 )


### PR DESCRIPTION
I also added tox test to be sure all versions are fine. 

```bash
  py38: OK (9.06=setup[7.38]+cmd[1.68] seconds)
  py39: OK (14.89=setup[12.94]+cmd[1.95] seconds)
  py310: OK (7.60=setup[5.70]+cmd[1.90] seconds)
  py311: OK (9.45=setup[7.52]+cmd[1.94] seconds)
  py312: OK (6.32=setup[4.22]+cmd[2.10] seconds)
  py313: OK (9.91=setup[7.68]+cmd[2.23] seconds)
  py314: OK (10.83=setup[8.42]+cmd[2.41] seconds)
  congratulations :) (68.09 seconds)
```