### PR TITLE
update dependabot with grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,12 @@ updates:
     schedule:
       interval: "monthly"
     # Labels on pull requests for version updates only
-    labels: ["CI / tests"]
+    labels: ["dependencies"]
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
       separator: "-"
     # Allow up to 5 open pull requests for pip dependencies
     open-pull-requests-limit: 5
-    reviewers:
-      - "borda"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -26,11 +24,12 @@ updates:
     schedule:
       interval: "monthly"
     # Labels on pull requests for version updates only
-    labels: ["CI / tests"]
+    labels: ["CI"]
     pull-request-branch-name:
-      # Separate sections of the branch name with a hyphen for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
       separator: "-"
     # Allow up to 5 open pull requests for GitHub Actions
-    open-pull-requests-limit: 5
-    reviewers:
-      - "borda"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This pull request updates the Dependabot configuration to improve how dependency update pull requests are managed and labeled. The changes mainly focus on updating labels, limiting the number of open pull requests, and grouping GitHub Actions updates.

Configuration and workflow improvements:

* Changed the label for pip dependency update pull requests from `"CI / tests"` to `"dependencies"` in `.github/dependabot.yml` to better reflect the nature of these PRs.
* Changed the label for GitHub Actions update pull requests from `"CI / tests"` to `"CI"` in `.github/dependabot.yml`.
* Reduced the maximum number of open Dependabot pull requests for GitHub Actions from 5 to 1 to minimize noise and make updates more manageable.
* Added grouping for GitHub Actions updates under the `github-actions` group, allowing related updates to be bundled together.
* Removed the default reviewer assignment (`"borda"`) for both pip and GitHub Actions update pull requests, so PRs will no longer be automatically assigned to this reviewer. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-L20) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L29-R35)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
