### PR TITLE
docs: add Agent HQ configuration and guidelines

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,93 @@
+# Agent HQ Configuration for pyDeprecate
+
+## 🧠 Agents
+
+### Engineer
+
+**Role**: Deprecation utilities and Python compatibility specialist
+**Tools**: Python, pytest, setuptools
+**Behavior**:
+
+- Review PRs modifying code in the `src/` folder
+- Validate deprecation warnings and function/class deprecations
+- Ensure correct use of Python patterns for backwards compatibility
+- Check reproducibility: fixed seeds, versioned dependencies, consistent configs
+
+### Doc-Scribe
+
+**Role**: Documentation and reproducibility assistant
+**Tools**: Markdown
+**Behavior**:
+
+- Maintain README with setup, usage, and migration instructions
+- Auto-generate documentation from code and configuration metadata
+- Ensure deprecation examples and API changes are documented
+- Track changes to deprecation configurations and document rationale
+
+### Mentor-Bot
+
+**Role**: Communication and feedback facilitator
+**Tools**: GitHub Issues, Discussions
+**Behavior**:
+
+- Draft follow-ups after releases or PR merges
+- Summarize feedback from reviewers and suggest next steps
+- Help onboard new contributors with deprecation-specific guides
+
+## 🔐 Permissions
+
+| Agent      | Branch Access  | PR Review | Issue Commenting |
+| ---------- | -------------- | --------- | ---------------- |
+| engineer   | `main`, `dev`  | ✅        | ✅               |
+| doc-scribe | `docs`, `main` | ✅        | ✅               |
+| mentor-bot | `main`         | ❌        | ✅               |
+
+## 📚 Context
+
+Agents may read and reference:
+
+- `README.md`, `setup.py` and `pyproject.toml` for project setup and usage
+- `src/` for core deprecation logic
+- `tests/` (unit tests for deprecation logic)
+- Configuration files and deprecation metadata
+
+## 🧭 Mission Rules
+
+- Never commit `.env` or API keys
+- PRs touching deprecation code or API changes must be reviewed by `engineer`
+- All deprecations must include proper warnings and migration paths
+- Dependency updates must be documented with version information
+- Follow Python best practices for library development
+
+## 🧪 Protocols
+
+### Deprecation Validation
+
+- Confirm deprecation decorators and warnings are correctly applied
+- Validate backwards compatibility and test coverage
+- Ensure proper error handling and logging for deprecated features
+- Check for proper migration examples in documentation
+
+### Documentation Update
+
+- Update README if API, config, or deprecation logic changes
+- Include example usage:
+  ```python
+  from pydeprecate import deprecated
+
+
+  @deprecated("Use new_function instead", version="1.0.0")
+  def old_function():
+      pass
+  ```
+
+## 📋 Best Practices
+
+### Code Comments
+
+When writing or modifying code, add comments if the code is not self-explanatory.
+This improves readability, maintainability, and helps other contributors understand complex logic or non-obvious decisions.
+
+## Related Documentation
+
+For comprehensive development guidelines, coding standards, and GitHub Copilot instructions, see [GitHub Copilot Instructions](../copilot-instructions.md).


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This pull request adds a new configuration document for agent roles and protocols related to deprecation utilities and documentation in the project. The document outlines the responsibilities, permissions, and best practices for three specialized agents, as well as protocols for validating deprecations and updating documentation.

Agent roles and responsibilities:

* Defined three agent roles—Engineer, Doc-Scribe, and Mentor-Bot—with clear responsibilities, tools, and behaviors for managing deprecation logic, documentation, and contributor onboarding.
* Specified branch access, PR review, and issue commenting permissions for each agent in a permissions table.

Deprecation and documentation protocols:

* Outlined protocols for deprecation validation, including decorator usage, backwards compatibility, and migration documentation requirements.
* Established documentation update procedures to ensure README and example usage are kept current with API and deprecation changes.

Project best practices and context:

* Listed best practices for code comments and referenced relevant files and documentation for agent context.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
