### PR TITLE
docs: update deprecation references

### DIFF
--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -302,7 +302,7 @@ def _update_docstring_with_deprecation(wrapped_fn: Callable) -> None:
         <BLANKLINE>
         .. deprecated:: 1.0
            Will be removed in 2.0.
-           Use `deprecate.deprecation.new_func` instead.
+           Use :func:`deprecate.deprecation.new_func` instead.
 
     Note:
         Does nothing if the function has no docstring or no __deprecated__ attribute.
@@ -315,7 +315,10 @@ def _update_docstring_with_deprecation(wrapped_fn: Callable) -> None:
     remove_in_val = dep_info.get("remove_in", "")
     target_val = dep_info.get("target")
     remove_text = f"Will be removed in {remove_in_val}." if remove_in_val else ""
-    target_text = f"Use `{target_val.__module__}.{target_val.__name__}` instead." if callable(target_val) else ""
+    target_text = ""
+    if callable(target_val):
+        ref_type = "class" if inspect.isclass(target_val) else "func"
+        target_text = f"Use :{ref_type}:`{target_val.__module__}.{target_val.__name__}` instead."
     lines.append(
         TEMPLATE_DOC_DEPRECATED
         % {

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -59,7 +59,7 @@ def test_deprecated_func_docstring() -> None:
         "An old function that is deprecated.\n\n"
         ".. deprecated:: 0.1\n"
         "   Will be removed in 0.3.\n"
-        "   Use `tests.test_docs.new_function` instead.\n"
+        "   Use :func:`tests.test_docs.new_function` instead.\n"
     )
 
 
@@ -74,7 +74,7 @@ def test_deprecated_class_docstring() -> None:
         "Initialize the old class.\n\n"
         ".. deprecated:: 0.2\n"
         "   Will be removed in 0.4.\n"
-        "   Use `tests.test_docs.NewClass` instead.\n"
+        "   Use :class:`tests.test_docs.NewClass` instead.\n"
     )
 
 


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This pull request updates the way deprecation notices reference replacement functions and classes in generated docstrings, ensuring they use Sphinx-style cross-references for better documentation rendering. It also updates related tests to match the new format.

Improvements to deprecation docstring formatting:

* Updated the deprecation docstring template in `src/deprecate/deprecation.py` to use Sphinx-style references (`:func:` and `:class:`) instead of inline code formatting for replacement callables. [[1]](diffhunk://#diff-10f6a668c55149debe15400e9033be8448ab5b75c6246161f3a980677bed054aL305-R305) [[2]](diffhunk://#diff-10f6a668c55149debe15400e9033be8448ab5b75c6246161f3a980677bed054aL318-R321)

Test updates for new formatting:

* Modified `test_deprecated_func_docstring` and `test_deprecated_class_docstring` in `tests/test_docs.py` to expect the new Sphinx-style references in the generated docstrings. [[1]](diffhunk://#diff-5c6dddc0c85981eb75bdb49d400e82c9271918e138990baba53ac34cbcf2aaacL62-R62) [[2]](diffhunk://#diff-5c6dddc0c85981eb75bdb49d400e82c9271918e138990baba53ac34cbcf2aaacL77-R77)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
