### PR TITLE
refactor(tests): consolidate test cases using parameterization

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: 📦 Install requirements
         run: |
-          pip install -r tests/requirements.txt
+          pip install ".[cli]" -r tests/requirements.txt
           pip list
         shell: bash
 

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: 📦 Install requirements
         run: |
-          pip install ".[cli]" -r tests/requirements.txt
+          pip install ".[audit,cli]" -r tests/requirements.txt
           pip list
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ Not sure which API to reach for? Start here.
 | Deprecating a class, Enum, or dataclass name  | `@deprecated_class(target=NewClass)`                    |
 | Deprecating a module-level constant or object | `deprecated_instance(obj, ...)`                         |
 
-**All `@deprecated` parameters at a glance:**
+<details>
+  <summary><strong>All `@deprecated` parameters at a glance:</strong></summary>
 
 | Param              | Default               | Purpose                                                                     |
 | ------------------ | --------------------- | --------------------------------------------------------------------------- |
@@ -213,6 +214,8 @@ Not sure which API to reach for? Start here.
 > [!TIP]
 > `@deprecated_class()` shares `target`, `deprecated_in`, `remove_in`, `num_warns`, `stream`, and `args_mapping`.
 > `deprecated_instance()` shares `deprecated_in`, `remove_in`, `num_warns`, and `stream`; it requires `obj` and adds `name` (display name) and `read_only`.
+
+</details>
 
 ## 📚 Use-cases and Applications
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     install_requires=[],
     extras_require={
         "audit": ["packaging>=20.0"],  # For validate_deprecation_expiry and validation tools
-        "cli": ["jsonargparse[signatures]>=4.47.0", "rich>=14.3.3"],
+        "cli": ["jsonargparse[signatures]>=4.47.0", "rich>=14.0.0"],  # For command-line interface
     },
     project_urls={"Source Code": ABOUT.__source_code__, "Home page": ABOUT.__homepage__},
     entry_points={

--- a/src/deprecate/docstring/sphinx_ext.py
+++ b/src/deprecate/docstring/sphinx_ext.py
@@ -46,7 +46,8 @@ _logger = logging.getLogger(__name__)
 _PROXY_AVAILABLE: bool = False
 
 try:
-    from sphinx.ext.autodoc import ClassDocumenter, prepare_docstring
+    from sphinx.ext.autodoc import ClassDocumenter
+    from sphinx.util.docstrings import prepare_docstring
 
     _SPHINX_AVAILABLE = True
 except ImportError:  # pragma: no cover

--- a/tests/integration/test_docs.py
+++ b/tests/integration/test_docs.py
@@ -1,5 +1,7 @@
 """Tests for deprecation documentation strings."""
 
+import pytest
+
 from tests.collection_docstrings import (
     OldClass,
     OldClassPlain,

--- a/tests/integration/test_docs.py
+++ b/tests/integration/test_docs.py
@@ -1,7 +1,5 @@
 """Tests for deprecation documentation strings."""
 
-import pytest
-
 from tests.collection_docstrings import (
     OldClass,
     OldClassPlain,

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -247,15 +247,17 @@ class TestArgumentMapping:
         ):
             assert func(2, 3) == 8
 
-    def test_arguments_double_deprecated_c1(self) -> None:
-        """Test double mapping, calling with first deprecated argument."""
-        with pytest.warns(FutureWarning, match="The `depr_pow_self_double` uses depr. args: `c1` -> `nc1`."):
-            assert depr_pow_self_double(2, c1=3) == 32
-
-    def test_arguments_double_deprecated_c2(self) -> None:
-        """Test double mapping, calling with second deprecated argument."""
-        with pytest.warns(FutureWarning, match="The `depr_pow_self_double` uses depr. args: `c2` -> `nc2`."):
-            assert depr_pow_self_double(2, c2=2) == 8
+    @pytest.mark.parametrize(
+        ("kwargs", "match_fragment", "expected"),
+        [
+            pytest.param({"c1": 3}, r"`c1` -> `nc1`", 32, id="c1-deprecated"),
+            pytest.param({"c2": 2}, r"`c2` -> `nc2`", 8, id="c2-deprecated"),
+        ],
+    )
+    def test_arguments_double_deprecated(self, kwargs: dict, match_fragment: str, expected: int) -> None:
+        """Test double mapping, calling with each deprecated argument individually."""
+        with pytest.warns(FutureWarning, match=f"The `depr_pow_self_double` uses depr. args: {match_fragment}."):
+            assert depr_pow_self_double(2, **kwargs) == expected
 
     def test_arguments_double_mixed(self) -> None:
         """Testing that preferable use the new arguments when both are provided."""
@@ -319,16 +321,17 @@ def test_skip_if_func(func: Callable) -> None:
         assert func(2, c1=2) == 2
 
 
-def test_skip_if_true_false() -> None:
-    """Test conditional wrapper skip with decorator order: @skip_if=True then @skip_if=False (outer skips)."""
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param(depr_pow_skip_if_true_false, id="outer-skips"),
+        pytest.param(depr_pow_skip_if_false_true, id="inner-skips"),
+    ],
+)
+def test_skip_if_mixed(func: Callable) -> None:
+    """Test conditional wrapper skip with mixed skip_if=True/False decorator stacking."""
     with pytest.warns(FutureWarning, match="Depr: v0.1 rm v0.2 for args: `c1` -> `nc1`."):
-        assert depr_pow_skip_if_true_false(2, c1=2) == 0.5
-
-
-def test_skip_if_false_true() -> None:
-    """Test conditional wrapper skip with decorator order: @skip_if=False then @skip_if=True (outer skips)."""
-    with pytest.warns(FutureWarning, match="Depr: v0.1 rm v0.2 for args: `c1` -> `nc1`."):
-        assert depr_pow_skip_if_false_true(2, c1=2) == 0.5
+        assert func(2, c1=2) == 0.5
 
 
 class TestErrorHandling:
@@ -367,22 +370,18 @@ class TestErrorHandling:
             depr_pow_skip_if_func_int(2, c1=2)
 
 
-def test_deprecated_func_accuracy_map() -> None:
-    """Test mapping to external accuracy_map function."""
+@pytest.mark.parametrize(
+    ("func", "expected"),
+    [
+        pytest.param(depr_accuracy_map, 0.5, id="accuracy-map"),
+        pytest.param(depr_accuracy_skip, 0.5, id="accuracy-skip"),
+        pytest.param(depr_accuracy_extra, 0.75, id="accuracy-extra"),
+    ],
+)
+def test_deprecated_func_accuracy(func: Callable, expected: float) -> None:
+    """Test deprecated accuracy wrappers with various arg mapping strategies."""
     with pytest.warns(FutureWarning):
-        assert depr_accuracy_map([1, 0, 1, 2]) == 0.5
-
-
-def test_deprecated_func_accuracy_skip() -> None:
-    """Test mapping to external accuracy_skip function."""
-    with pytest.warns(FutureWarning):
-        assert depr_accuracy_skip([1, 0, 1, 2]) == 0.5
-
-
-def test_deprecated_func_accuracy_extra() -> None:
-    """Test mapping to external accuracy_extra function."""
-    with pytest.warns(FutureWarning):
-        assert depr_accuracy_extra([1, 0, 1, 2]) == 0.75
+        assert func([1, 0, 1, 2]) == expected
 
 
 def test_deprecated_func_attribute_set_at_decoration_time() -> None:

--- a/tests/integration/test_sphinx_ext.py
+++ b/tests/integration/test_sphinx_ext.py
@@ -7,7 +7,7 @@ import pytest
 
 from deprecate.docstring.sphinx_ext import _PROXY_AVAILABLE, _SPHINX_AVAILABLE
 
-pytestmark = pytest.mark.skipif(
+_skipif_sphinx_missing = pytest.mark.skipif(
     not (_SPHINX_AVAILABLE and _PROXY_AVAILABLE),
     reason="sphinx or _DeprecatedProxy not available",
 )
@@ -24,6 +24,7 @@ def _make_proxy() -> tuple[object, type]:
     return old, _New
 
 
+@_skipif_sphinx_missing
 class TestCanDocumentMember:
     """Tests for _DeprecatedProxyClassDocumenter.can_document_member."""
 
@@ -48,6 +49,7 @@ class TestCanDocumentMember:
         assert result is False
 
 
+@_skipif_sphinx_missing
 class TestImportObject:
     """Tests for _DeprecatedProxyClassDocumenter.import_object."""
 
@@ -117,6 +119,7 @@ class TestImportObject:
         assert not hasattr(doc, "_proxy_doc")
 
 
+@_skipif_sphinx_missing
 class TestGetDoc:
     """Tests for _DeprecatedProxyClassDocumenter.get_doc."""
 

--- a/tests/integration/test_sphinx_ext.py
+++ b/tests/integration/test_sphinx_ext.py
@@ -5,8 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytest.importorskip("sphinx", reason="sphinx not installed")
-
 from deprecate.docstring.sphinx_ext import _PROXY_AVAILABLE, _SPHINX_AVAILABLE
 
 pytestmark = pytest.mark.skipif(
@@ -124,7 +122,7 @@ class TestGetDoc:
 
     def test_returns_prepared_proxy_doc_when_set(self) -> None:
         """Returns prepare_docstring() of _proxy_doc when available."""
-        from sphinx.ext.autodoc import prepare_docstring
+        from sphinx.util.docstrings import prepare_docstring
 
         from deprecate.docstring.sphinx_ext import _DeprecatedProxyClassDocumenter
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,3 @@ pytest-cov >2.10
 scikit-learn >=0.17
 phmdoctest >1.0
 dataclasses  # needed for phmdoctest
-
-check-manifest
-twine >=3.2
-mypy >=1.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,7 @@ pytest-cov >2.10
 scikit-learn >=0.17
 phmdoctest >1.0
 dataclasses  # needed for phmdoctest
+
+# Docs extensions
+griffe  # for MKDocs
+sphinx

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -144,41 +144,61 @@ class TestMain:
         assert result == 0
 
 
-class TestReportIssuesPlain:
-    """Tests for _report_issues with the plain-text path (_HAS_RICH = False)."""
+_REPORT_ISSUES_CASES = [
+    pytest.param(
+        [DeprecationWrapperInfo(module="mod", function="fn", invalid_args=["bad"])],
+        True,
+        id="invalid-args",
+    ),
+    pytest.param(
+        [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"])],
+        True,
+        id="identity-mapping",
+    ),
+    pytest.param(
+        [DeprecationWrapperInfo(module="mod", function="fn", empty_mapping=True, no_effect=True)],
+        True,
+        id="no-effect-empty-mapping",
+    ),
+    pytest.param(
+        [DeprecationWrapperInfo(module="mod", function="fn", self_reference=True, no_effect=True)],
+        True,
+        id="no-effect-self-reference",
+    ),
+    pytest.param(
+        [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"], no_effect=True)],
+        True,
+        id="no-effect-identity-only",
+    ),
+    pytest.param(
+        [DeprecationWrapperInfo(module="mod", function="fn")],
+        False,
+        id="no-issues",
+    ),
+]
 
-    def test_invalid_args(self) -> None:
-        """Test plain text reporter with invalid args."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", invalid_args=["bad"])]
-        with patch("deprecate._cli._HAS_RICH", False):
-            assert _report_issues(results) is True
 
-    def test_identity_mapping(self) -> None:
-        """Test plain text reporter with identity mappings."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"])]
-        with patch("deprecate._cli._HAS_RICH", False):
-            assert _report_issues(results) is True
+class TestReportIssues:
+    """Tests for _report_issues covering both the rich and plain-text output paths."""
 
-    def test_no_effect_empty_mapping(self) -> None:
-        """Test plain text reporter with no-effect empty mapping."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", empty_mapping=True, no_effect=True)]
-        with patch("deprecate._cli._HAS_RICH", False):
-            assert _report_issues(results) is True
+    @pytest.mark.parametrize("has_rich", [True, False], ids=["rich", "plain"])
+    @pytest.mark.parametrize(("results", "expected"), _REPORT_ISSUES_CASES)
+    def test_flag(self, results: list, expected: bool, has_rich: bool) -> None:
+        """_report_issues returns the correct has-issues flag for both rich and plain paths."""
+        with patch("deprecate._cli._HAS_RICH", has_rich):
+            assert _report_issues(results) is expected
 
-    def test_no_effect_self_reference(self) -> None:
-        """Test plain text reporter with no-effect self-reference."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", self_reference=True, no_effect=True)]
-        with patch("deprecate._cli._HAS_RICH", False):
-            assert _report_issues(results) is True
-
-    def test_no_effect_identity_only(self) -> None:
-        """Test plain text reporter with no-effect identity-only mapping."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"], no_effect=True)]
-        with patch("deprecate._cli._HAS_RICH", False):
-            assert _report_issues(results) is True
-
-    def test_no_effect_partial_identity_with_self_reference(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Partial identity mappings should not be reported as all-identity."""
+    @pytest.mark.parametrize(
+        ("has_rich", "expected_present", "expected_absent"),
+        [
+            pytest.param(True, "Self reference", "All identity mappings", id="rich"),
+            pytest.param(False, "Reason: Self reference", "Reason: All identity mappings", id="plain"),
+        ],
+    )
+    def test_partial_identity_with_self_reference(
+        self, capsys: pytest.CaptureFixture[str], has_rich: bool, expected_present: str, expected_absent: str
+    ) -> None:
+        """Partial identity mappings should not be reported as all-identity in either output path."""
         results = [
             DeprecationWrapperInfo(
                 module="mod",
@@ -189,70 +209,11 @@ class TestReportIssuesPlain:
                 no_effect=True,
             )
         ]
-
-        with patch("deprecate._cli._HAS_RICH", False):
+        with patch("deprecate._cli._HAS_RICH", has_rich):
             assert _report_issues(results) is True
         captured = capsys.readouterr()
-        assert "Reason: Self reference" in captured.out
-        assert "Reason: All identity mappings" not in captured.out
-
-    def test_no_issues(self) -> None:
-        """Test plain text reporter with no issues."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn")]
-        with patch("deprecate._cli._HAS_RICH", False):
-            assert _report_issues(results) is False
-
-
-class TestReportIssuesRich:
-    """Tests for _report_issues with the Rich path (_HAS_RICH = True)."""
-
-    def test_invalid_args(self) -> None:
-        """Test rich reporter with invalid args."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", invalid_args=["bad"])]
-        assert _report_issues(results) is True
-
-    def test_identity_mapping(self) -> None:
-        """Test rich reporter with identity mappings."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"])]
-        assert _report_issues(results) is True
-
-    def test_no_effect_empty_mapping(self) -> None:
-        """Test rich reporter with no-effect empty mapping."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", empty_mapping=True, no_effect=True)]
-        assert _report_issues(results) is True
-
-    def test_no_effect_self_reference(self) -> None:
-        """Test rich reporter with no-effect self-reference."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", self_reference=True, no_effect=True)]
-        assert _report_issues(results) is True
-
-    def test_no_effect_identity_only(self) -> None:
-        """Test rich reporter with no-effect identity-only mapping."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"], no_effect=True)]
-        assert _report_issues(results) is True
-
-    def test_no_effect_partial_identity_with_self_reference(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Rich reporter should not list all-identity for partial identity mappings."""
-        results = [
-            DeprecationWrapperInfo(
-                module="mod",
-                function="fn",
-                deprecated_info=DeprecationConfig(args_mapping={"a": "a", "b": "c"}),
-                identity_mapping=["a"],
-                self_reference=True,
-                no_effect=True,
-            )
-        ]
-
-        assert _report_issues(results) is True
-        captured = capsys.readouterr()
-        assert "Self reference" in captured.out
-        assert "All identity mappings" not in captured.out
-
-    def test_no_issues(self) -> None:
-        """Test rich reporter with no issues."""
-        results = [DeprecationWrapperInfo(module="mod", function="fn")]
-        assert _report_issues(results) is False
+        assert expected_present in captured.out
+        assert expected_absent not in captured.out
 
 
 def test_report_issues_dispatches() -> None:

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -144,45 +144,45 @@ class TestMain:
         assert result == 0
 
 
-_REPORT_ISSUES_CASES = [
-    pytest.param(
-        [DeprecationWrapperInfo(module="mod", function="fn", invalid_args=["bad"])],
-        True,
-        id="invalid-args",
-    ),
-    pytest.param(
-        [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"])],
-        True,
-        id="identity-mapping",
-    ),
-    pytest.param(
-        [DeprecationWrapperInfo(module="mod", function="fn", empty_mapping=True, no_effect=True)],
-        True,
-        id="no-effect-empty-mapping",
-    ),
-    pytest.param(
-        [DeprecationWrapperInfo(module="mod", function="fn", self_reference=True, no_effect=True)],
-        True,
-        id="no-effect-self-reference",
-    ),
-    pytest.param(
-        [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"], no_effect=True)],
-        True,
-        id="no-effect-identity-only",
-    ),
-    pytest.param(
-        [DeprecationWrapperInfo(module="mod", function="fn")],
-        False,
-        id="no-issues",
-    ),
-]
-
-
 class TestReportIssues:
     """Tests for _report_issues covering both the rich and plain-text output paths."""
 
     @pytest.mark.parametrize("has_rich", [True, False], ids=["rich", "plain"])
-    @pytest.mark.parametrize(("results", "expected"), _REPORT_ISSUES_CASES)
+    @pytest.mark.parametrize(
+        ("results", "expected"),
+        [
+            pytest.param(
+                [DeprecationWrapperInfo(module="mod", function="fn", invalid_args=["bad"])],
+                True,
+                id="invalid-args",
+            ),
+            pytest.param(
+                [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"])],
+                True,
+                id="identity-mapping",
+            ),
+            pytest.param(
+                [DeprecationWrapperInfo(module="mod", function="fn", empty_mapping=True, no_effect=True)],
+                True,
+                id="no-effect-empty-mapping",
+            ),
+            pytest.param(
+                [DeprecationWrapperInfo(module="mod", function="fn", self_reference=True, no_effect=True)],
+                True,
+                id="no-effect-self-reference",
+            ),
+            pytest.param(
+                [DeprecationWrapperInfo(module="mod", function="fn", identity_mapping=["a"], no_effect=True)],
+                True,
+                id="no-effect-identity-only",
+            ),
+            pytest.param(
+                [DeprecationWrapperInfo(module="mod", function="fn")],
+                False,
+                id="no-issues",
+            ),
+        ],
+    )
     def test_flag(self, results: list, expected: bool, has_rich: bool) -> None:
         """_report_issues returns the correct has-issues flag for both rich and plain paths."""
         with patch("deprecate._cli._HAS_RICH", has_rich):

--- a/tests/unittests/test_docs.py
+++ b/tests/unittests/test_docs.py
@@ -1,6 +1,7 @@
 """Unit tests for private helpers in deprecate.docstring.inject."""
 
 import importlib
+import importlib.util
 from typing import cast
 
 import pytest
@@ -259,9 +260,9 @@ class TestUpdateDocstringIdempotent:
 class TestDocstringSubpackageImports:
     """Smoke tests: docstring sub-modules are importable and expose expected symbols."""
 
+    @pytest.mark.skipif(importlib.util.find_spec("griffe") is None, reason="griffe not installed")
     def test_griffe_ext_importable(self) -> None:
         """deprecate.docstring.griffe_ext imports without error and exposes RuntimeDocstrings."""
-        pytest.importorskip("griffe", reason="griffe not installed")
         mod = importlib.import_module("deprecate.docstring.griffe_ext")
         assert hasattr(mod, "RuntimeDocstrings")
 

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -3,6 +3,7 @@
 import inspect
 import warnings
 from collections.abc import Callable
+from typing import Any, cast
 
 import pytest
 
@@ -608,7 +609,7 @@ class TestTypeProtocol:
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            isinstance(obj, proxy)
+            isinstance(obj, cast(Any, proxy))
 
         assert not caught  # no warning from isinstance
         with pytest.warns(FutureWarning):
@@ -659,7 +660,7 @@ class TestTypeProtocol:
         proxy = _DeprecatedProxy(obj=Base, name="old_cls", deprecated_in="1.0", remove_in="2.0")
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            issubclass(Sub, proxy)
+            issubclass(Sub, cast(Any, proxy))
         assert not caught
         with pytest.warns(FutureWarning):
             proxy()  # warning budget remains untouched
@@ -667,4 +668,4 @@ class TestTypeProtocol:
     def test_isinstance_returns_false_for_non_type_active(self) -> None:
         """isinstance(x, proxy) returns False when the active object is not a type."""
         proxy = _DeprecatedProxy(obj={"key": "val"}, name="old_cfg", deprecated_in="1.0", remove_in="2.0")
-        assert not isinstance(42, proxy)
+        assert not isinstance(42, cast(Any, proxy))

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -127,33 +127,22 @@ class TestProxyReadOnly:
         proxy = _DeprecatedProxy(obj={}, name="d", deprecated_in="1.0", remove_in="2.0", read_only=False)
         proxy._check_read_only("Test operation")  # must not raise
 
-    def test_setitem_raises_when_read_only(self) -> None:
-        """__setitem__ raises AttributeError in read_only mode via _check_read_only."""
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            pytest.param(lambda p: p.__setitem__("k", 2), id="setitem"),
+            pytest.param(lambda p: p.__delitem__("k"), id="delitem"),
+            pytest.param(lambda p: setattr(p, "some_attr", "value"), id="setattr"),
+            pytest.param(lambda p: delattr(p, "some_attr"), id="delattr"),
+        ],
+    )
+    def test_mutation_raises_when_read_only(self, operation: Callable) -> None:
+        """All write operations raise AttributeError in read_only mode."""
         proxy = _DeprecatedProxy(
             obj={"k": 1}, name="d", deprecated_in="1.0", remove_in="2.0", read_only=True, stream=None
         )
         with pytest.raises(AttributeError, match="read-only"):
-            proxy["k"] = 2
-
-    def test_delitem_raises_when_read_only(self) -> None:
-        """__delitem__ raises AttributeError in read_only mode via _check_read_only."""
-        proxy = _DeprecatedProxy(
-            obj={"k": 1}, name="d", deprecated_in="1.0", remove_in="2.0", read_only=True, stream=None
-        )
-        with pytest.raises(AttributeError, match="read-only"):
-            del proxy["k"]
-
-    def test_setattr_raises_when_read_only(self) -> None:
-        """__setattr__ raises AttributeError in read_only mode via _check_read_only."""
-        proxy = _DeprecatedProxy(obj={}, name="d", deprecated_in="1.0", remove_in="2.0", read_only=True, stream=None)
-        with pytest.raises(AttributeError, match="read-only"):
-            proxy.some_attr = "value"
-
-    def test_delattr_raises_when_read_only(self) -> None:
-        """__delattr__ raises AttributeError in read_only mode via _check_read_only."""
-        proxy = _DeprecatedProxy(obj={}, name="d", deprecated_in="1.0", remove_in="2.0", read_only=True, stream=None)
-        with pytest.raises(AttributeError, match="read-only"):
-            del proxy.some_attr
+            operation(proxy)
 
     def test_setitem_forwards_to_source(self) -> None:
         """__setitem__ mutates the source object when not read-only, without emitting a warning."""
@@ -619,7 +608,7 @@ class TestTypeProtocol:
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            isinstance(obj, proxy)  # type: ignore[arg-type]
+            isinstance(obj, proxy)
 
         assert not caught  # no warning from isinstance
         with pytest.warns(FutureWarning):
@@ -670,7 +659,7 @@ class TestTypeProtocol:
         proxy = _DeprecatedProxy(obj=Base, name="old_cls", deprecated_in="1.0", remove_in="2.0")
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            issubclass(Sub, proxy)  # type: ignore[arg-type]
+            issubclass(Sub, proxy)
         assert not caught
         with pytest.warns(FutureWarning):
             proxy()  # warning budget remains untouched
@@ -678,4 +667,4 @@ class TestTypeProtocol:
     def test_isinstance_returns_false_for_non_type_active(self) -> None:
         """isinstance(x, proxy) returns False when the active object is not a type."""
         proxy = _DeprecatedProxy(obj={"key": "val"}, name="old_cfg", deprecated_in="1.0", remove_in="2.0")
-        assert not isinstance(42, proxy)  # type: ignore[arg-type]
+        assert not isinstance(42, proxy)

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -2,33 +2,50 @@
 
 import inspect
 import warnings
+from collections.abc import Callable
+
+import pytest
 
 from deprecate.utils import _get_signature, _get_signature_cached, _warns_repr, get_func_arguments_types_defaults, void
 
 
-class TestGetSignature:
-    """Tests for _get_signature — the LRU-cached signature fetcher."""
+class TestSignatureFunctions:
+    """Tests for _get_signature (with unhashable fallback) and _get_signature_cached (raw LRU)."""
 
-    def test_returns_signature_for_hashable_func(self) -> None:
-        """Returns a valid Signature for a regular annotated function."""
+    @pytest.mark.parametrize(
+        "sig_func",
+        [
+            pytest.param(_get_signature, id="get-signature"),
+            pytest.param(_get_signature_cached, id="get-signature-cached"),
+        ],
+    )
+    def test_returns_valid_signature(self, sig_func: Callable) -> None:
+        """Returns a valid Signature with correct parameters for a standard annotated function."""
 
         def my_func(x: int, y: str = "hi") -> None:
             pass
 
-        sig = _get_signature(my_func)
+        sig = sig_func(my_func)
         assert isinstance(sig, inspect.Signature)
         assert list(sig.parameters) == ["x", "y"]
 
-    def test_caches_result_for_same_func(self) -> None:
+    @pytest.mark.parametrize(
+        "sig_func",
+        [
+            pytest.param(_get_signature, id="get-signature"),
+            pytest.param(_get_signature_cached, id="get-signature-cached"),
+        ],
+    )
+    def test_repeated_calls_return_same_object(self, sig_func: Callable) -> None:
         """Repeated calls return the identical Signature object, confirming LRU cache is active."""
 
         def my_func(x: int) -> None:
             pass
 
-        assert _get_signature(my_func) is _get_signature(my_func)
+        assert sig_func(my_func) is sig_func(my_func)
 
     def test_unhashable_callable_falls_back_to_uncached(self) -> None:
-        """Unhashable callables cannot enter the LRU cache; falls back to direct inspection without crashing."""
+        """Unhashable callables cannot enter the LRU cache; _get_signature falls back to direct inspection."""
 
         class UnhashableCallable:
             __hash__ = None  # type: ignore[assignment]
@@ -40,28 +57,6 @@ class TestGetSignature:
         sig = _get_signature(obj)
         assert isinstance(sig, inspect.Signature)
         assert "x" in sig.parameters
-
-
-class TestGetSignatureCached:
-    """Tests for _get_signature_cached — the raw LRU-cached layer."""
-
-    def test_returns_signature(self) -> None:
-        """Returns a valid Signature for a standard function."""
-
-        def my_func(a: int, b: str = "hello") -> None:
-            pass
-
-        sig = _get_signature_cached(my_func)
-        assert isinstance(sig, inspect.Signature)
-        assert list(sig.parameters) == ["a", "b"]
-
-    def test_repeated_calls_return_same_object(self) -> None:
-        """Identity check confirms the LRU cache serves the same Signature object on subsequent calls."""
-
-        def my_func(x: int) -> None:
-            pass
-
-        assert _get_signature_cached(my_func) is _get_signature_cached(my_func)
 
 
 class TestWarnsRepr:


### PR DESCRIPTION
This pull request refactors and modernizes the test suite, focusing on improving maintainability, readability, and test coverage by leveraging `pytest` features such as parameterization and consolidating redundant test classes. It also includes minor documentation improvements. The most important changes are grouped below:

**Test Suite Refactoring and Improvements:**

* Consolidated multiple similar test functions and classes in `tests/integration/test_functions.py` and `tests/unittests/test_cli.py` using `pytest.mark.parametrize`, reducing code duplication and making tests more scalable and maintainable. [[1]](diffhunk://#diff-bd2508e74a38d082a7a28cf24a62438d4d832523f9968fa8bdde302ba976ad3aL250-R260) [[2]](diffhunk://#diff-bd2508e74a38d082a7a28cf24a62438d4d832523f9968fa8bdde302ba976ad3aL322-R334) [[3]](diffhunk://#diff-bd2508e74a38d082a7a28cf24a62438d4d832523f9968fa8bdde302ba976ad3aL370-R384) [[4]](diffhunk://#diff-5c0b37e1ded4f11860ea71a3c5d42891cee3181f6d1516e2009638da278e9e2eL147-R201) [[5]](diffhunk://#diff-5c0b37e1ded4f11860ea71a3c5d42891cee3181f6d1516e2009638da278e9e2eL246-R216)
* Unified tests for both "rich" and plain-text output paths in the CLI reporter tests, ensuring consistent coverage and output checking for both cases. [[1]](diffhunk://#diff-5c0b37e1ded4f11860ea71a3c5d42891cee3181f6d1516e2009638da278e9e2eL147-R201) [[2]](diffhunk://#diff-5c0b37e1ded4f11860ea71a3c5d42891cee3181f6d1516e2009638da278e9e2eL246-R216)
* Refactored proxy mutation tests in `tests/unittests/test_proxy.py` to use parameterization for all write operations, ensuring comprehensive coverage with less boilerplate.
* Updated some type ignore comments and improved test clarity in proxy type checks. [[1]](diffhunk://#diff-0a3f229193330f9e52ef69c483adadfb200f615ef362fa7c598e70f6e3f6f7deL622-R611) [[2]](diffhunk://#diff-0a3f229193330f9e52ef69c483adadfb200f615ef362fa7c598e70f6e3f6f7deL673-R670)
* Combined and parameterized signature utility tests in `tests/unittests/test_utils.py`, merging previously separate test classes for LRU-cached and fallback code paths. [[1]](diffhunk://#diff-02bd4da0194365402cb27357f0514a9b287f6fe7378d82b1877777f1cc721853R5-R48) [[2]](diffhunk://#diff-02bd4da0194365402cb27357f0514a9b287f6fe7378d82b1877777f1cc721853L45-L66)

**Documentation:**

* Improved the `README.md` by wrapping the list of `@deprecated` parameters in a collapsible `<details>` section for better readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R199) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R218-R219)

**Test Infrastructure:**

* Added missing `pytest` imports to test files to support new parameterized tests. [[1]](diffhunk://#diff-e6321896f070752def56236abf16e0f7e4ff1be6b13e3052212b1e0b252782fbR3-R4) [[2]](diffhunk://#diff-02bd4da0194365402cb27357f0514a9b287f6fe7378d82b1877777f1cc721853R5-R48)

These changes collectively modernize the test suite, reduce maintenance overhead, and improve test clarity and coverage.