### PR TITLE
default `target=TargetMode.NOTIFY` with guard empty-version decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ dmypy.json
 .claude/state/
 .claude/worktrees/
 docs/.claude/
+.developments/
 .plans/
 .reports/
 .temp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 ### Added
 
-- **`target` parameter of `@deprecated` now defaults to `TargetMode.NOTIFY`.** Callers can omit `target` entirely for warn-only deprecation: `@deprecated(deprecated_in="1.0", remove_in="2.0")` is now the canonical form. Passing `target=TargetMode.NOTIFY` explicitly remains valid. This default is permanent and will not change in future releases. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
-
-- **Decoration-time `FutureWarning` when `@deprecated` has no version strings.** When `target` is `TargetMode.NOTIFY` (the default or explicitly passed) and both `deprecated_in` and `remove_in` are absent, a `FutureWarning` is emitted immediately at decoration time (not at call time). Applies to functions, methods, and classes. Suppressed when `stream=None`. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
-
 - **`TargetMode` enum exported from `deprecate`.** `TargetMode.NOTIFY` replaces `target=None` and `TargetMode.ARGS_REMAP` replaces `target=True`. Both are public API. ([#150](https://github.com/Borda/pyDeprecate/pull/150))
 
 - **`args_extra` parameter for `deprecated_class()` and `deprecated_instance()`.** Injects fixed keyword arguments into forwarded calls after `args_mapping` has been applied, matching the same semantics as `@deprecated(args_extra=...)`. Ignored (with a construction-time `UserWarning`) when `target` is `TargetMode.NOTIFY`.
@@ -33,6 +29,8 @@
 - **`DeprecationConfig.target` always stores a normalised `TargetMode` or callable.** Legacy boolean sentinels (`True` / `False`) are now normalised at decoration time and are never stored verbatim in `DeprecationConfig.target`. Code that inspects `__deprecated__.target` must compare against `TargetMode.NOTIFY`, `TargetMode.ARGS_REMAP`, a callable, or `None` — never against `True` or `False`.
 - **`deprecated_class()` with `target=TargetMode.NOTIFY` now emits `UserWarning` at decoration time when `args_mapping` or `args_extra` is supplied.** These parameters are ignored in `NOTIFY` mode; passing them has always been a misconfiguration. The warning will become `TypeError` in v1.0.
 - **Docs site URL layout is now versioned.** Content is published under `https://borda.github.io/pyDeprecate/latest/` (for `main`) and `https://borda.github.io/pyDeprecate/<tag>/` (for release tags). The root URL (`https://borda.github.io/pyDeprecate/`) redirects to `latest/`. External bookmarks to flat paths like `.../pyDeprecate/troubleshooting.html` will break on first deploy — update them to `.../pyDeprecate/latest/troubleshooting.html`. ([#148](https://github.com/Borda/pyDeprecate/pull/148))
+- **`target` parameter of `@deprecated` now defaults to `TargetMode.NOTIFY`.** Callers can omit `target` entirely for warn-only deprecation: `@deprecated(deprecated_in="1.0", remove_in="2.0")` is now the canonical form. Passing `target=TargetMode.NOTIFY` explicitly remains valid. This default is permanent and will not change in future releases. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
+- **Decoration-time `FutureWarning` when `@deprecated` has no version strings.** When `target` is `TargetMode.NOTIFY` (the default or explicitly passed) and both `deprecated_in` and `remove_in` are absent, a `FutureWarning` is emitted immediately at decoration time (not at call time). Applies to functions, methods, and classes. Suppressed when `stream=None`. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,22 @@
 
 ### Added
 
+- **`target` parameter of `@deprecated` now defaults to `TargetMode.NOTIFY`.** Callers can omit `target` entirely for warn-only deprecation: `@deprecated(deprecated_in="1.0", remove_in="2.0")` is now the canonical form. Passing `target=TargetMode.NOTIFY` explicitly remains valid. This default is permanent and will not change in future releases. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
+
+- **Decoration-time `FutureWarning` when `@deprecated` has no version strings.** When `target` resolves to `TargetMode.NOTIFY` and both `deprecated_in` and `remove_in` are absent, a `FutureWarning` is emitted immediately at decoration time (not at call time). Applies to functions, methods, and classes. Suppressed when `stream=None`. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
+
 - **`TargetMode` enum exported from `deprecate`.** `TargetMode.NOTIFY` replaces `target=None` and `TargetMode.ARGS_REMAP` replaces `target=True`. Both are public API. ([#150](https://github.com/Borda/pyDeprecate/pull/150))
+
 - **`args_extra` parameter for `deprecated_class()` and `deprecated_instance()`.** Injects fixed keyword arguments into forwarded calls after `args_mapping` has been applied, matching the same semantics as `@deprecated(args_extra=...)`. Ignored (with a construction-time `UserWarning`) when `target` is `TargetMode.NOTIFY`.
+
 - **`template_mgs` parameter for `deprecated_class()` and `deprecated_instance()`.** Overrides the built-in warning message template with a `%`-style format string, matching the same semantics as `@deprecated(template_mgs=...)`. Available placeholders: `%(source_name)s`, `%(deprecated_in)s`, `%(remove_in)s`, `%(target_name)s` (callable target only), `%(target_path)s` (callable target only), `%(argument_map)s` (`args_mapping` warnings only).
+
 - **`DeprecationConfig.misconfigured` field.** Boolean field on the shared metadata dataclass; `True` when an invalid raw target sentinel (`False`) was passed at decoration time. Audit tools surface this via `DeprecationWrapperInfo.misconfigured_target`.
+
 - **Multi-page topic documentation site.** Replaced the monolithic README-copy home page with a curated 7-page MkDocs Material site: Home, Getting Started, User Guide (Use Cases / void() Helper / Audit Tools), Troubleshooting, and demo links. Switched theme to Material, added Open Graph tags, JSON-LD structured data (SoftwareApplication / FAQPage / TechArticle per page), spec-compliant `llms.txt`, and `git-revision-date-localized` plugin. README is unchanged (still the PyPI cover page).
+
 - **`pydeprecate` CLI command.** Run `pydeprecate <subcommand> path/to/your/package` to scan any package or module for misconfigured `@deprecated` wrappers — reports invalid argument mappings, identity mappings, and no-effect wrappers with rich-formatted output when `rich` is available. Also available as `python -m deprecate`. ([#76](https://github.com/Borda/pyDeprecate/pull/76))
+
 - **Four CLI subcommands: `check`, `expiry`, `chains`, `all`.** `check` validates wrapper configuration; `expiry` reports wrappers past their `remove_in` deadline (requires `pip install 'pyDeprecate[audit]'`); `chains` detects deprecated-to-deprecated forwarding chains; `all` runs all three in a single scan pass. Flags: `--norecursive`, `--skip_errors`. ([#149](https://github.com/Borda/pyDeprecate/pull/149))
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - **`target` parameter of `@deprecated` now defaults to `TargetMode.NOTIFY`.** Callers can omit `target` entirely for warn-only deprecation: `@deprecated(deprecated_in="1.0", remove_in="2.0")` is now the canonical form. Passing `target=TargetMode.NOTIFY` explicitly remains valid. This default is permanent and will not change in future releases. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
 
-- **Decoration-time `FutureWarning` when `@deprecated` has no version strings.** When `target` resolves to `TargetMode.NOTIFY` and both `deprecated_in` and `remove_in` are absent, a `FutureWarning` is emitted immediately at decoration time (not at call time). Applies to functions, methods, and classes. Suppressed when `stream=None`. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
+- **Decoration-time `FutureWarning` when `@deprecated` has no version strings.** When `target` is `TargetMode.NOTIFY` (the default or explicitly passed) and both `deprecated_in` and `remove_in` are absent, a `FutureWarning` is emitted immediately at decoration time (not at call time). Applies to functions, methods, and classes. Suppressed when `stream=None`. ([#162](https://github.com/Borda/pyDeprecate/pull/162))
 
 - **`TargetMode` enum exported from `deprecate`.** `TargetMode.NOTIFY` replaces `target=None` and `TargetMode.ARGS_REMAP` replaces `target=True`. Both are public API. ([#150](https://github.com/Borda/pyDeprecate/pull/150))
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Not sure which API to reach for? Start here.
 | --------------------------------------------- | ------------------------------------------------------------------------ |
 | Renaming a function or method                 | `@deprecated(target=new_func)`                                           |
 | Renaming an argument within the same function | `@deprecated(target=TargetMode.ARGS_REMAP, args_mapping={"old": "new"})` |
-| Warn only — original body still runs          | `@deprecated(target=TargetMode.NOTIFY)`                                  |
+| Warn only — original body still runs          | `@deprecated(deprecated_in="1.0", remove_in="2.0")`                      |
 | Deprecating a class, Enum, or dataclass name  | `@deprecated_class(target=NewClass)`                                     |
 | Deprecating a module-level constant or object | `deprecated_instance(obj, ...)`                                          |
 
@@ -202,18 +202,18 @@ Not sure which API to reach for? Start here.
 <details>
   <summary><strong>All `@deprecated` parameters at a glance:</strong></summary>
 
-| Param              | Default               | Purpose                                                                     |
-| ------------------ | --------------------- | --------------------------------------------------------------------------- |
-| `target`           | —                     | `Callable` to forward to · `True` to remap args in-place · `None` warn-only |
-| `deprecated_in`    | `""`                  | Version when deprecated (e.g. `"1.0"`)                                      |
-| `remove_in`        | `""`                  | Version when removed (e.g. `"2.0"`)                                         |
-| `stream`           | `deprecation_warning` | Warning sink callable (set `None` to silence warnings)                      |
-| `num_warns`        | `1`                   | `1` once · `-1` always · `N` exactly N times                                |
-| `args_mapping`     | `None`                | `{"old": "new"}` rename · `{"old": None}` drop                              |
-| `template_mgs`     | `None`                | Custom warning message template (`%`-style placeholders)                    |
-| `args_extra`       | `None`                | Fixed kwargs injected into the target call                                  |
-| `skip_if`          | `False`               | `bool` or `Callable → bool`; skip deprecation when true                     |
-| `update_docstring` | `False`               | Append Sphinx `.. deprecated::` notice to docstring                         |
+| Param              | Default               | Purpose                                                                                                    |
+| ------------------ | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `target`           | `TargetMode.NOTIFY`   | `Callable` to forward to · `TargetMode.ARGS_REMAP` to remap args · `TargetMode.NOTIFY` (default) warn-only |
+| `deprecated_in`    | `""`                  | Version when deprecated (e.g. `"1.0"`)                                                                     |
+| `remove_in`        | `""`                  | Version when removed (e.g. `"2.0"`)                                                                        |
+| `stream`           | `deprecation_warning` | Warning sink callable (set `None` to silence warnings)                                                     |
+| `num_warns`        | `1`                   | `1` once · `-1` always · `N` exactly N times                                                               |
+| `args_mapping`     | `None`                | `{"old": "new"}` rename · `{"old": None}` drop                                                             |
+| `template_mgs`     | `None`                | Custom warning message template (`%`-style placeholders)                                                   |
+| `args_extra`       | `None`                | Fixed kwargs injected into the target call                                                                 |
+| `skip_if`          | `False`               | `bool` or `Callable → bool`; skip deprecation when true                                                    |
+| `update_docstring` | `False`               | Append Sphinx `.. deprecated::` notice to docstring                                                        |
 
 > [!TIP]
 > `@deprecated_class()` shares `target`, `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_mapping`, `args_extra`, and `template_mgs`.

--- a/README.md
+++ b/README.md
@@ -380,10 +380,10 @@ sample output:
 Base use-case with no forwarding and just raising a warning:
 
 ```python
-from deprecate import TargetMode, deprecated
+from deprecate import deprecated
 
 
-@deprecated(target=TargetMode.NOTIFY, deprecated_in="0.1", remove_in="0.5")
+@deprecated(deprecated_in="0.1", remove_in="0.5")
 def my_sum(a: int, b: int = 5) -> int:
     """My deprecated function which still has to have implementation."""
     return a + b

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -118,13 +118,15 @@ print(depr_accuracy([1, 0, 1, 2], [0, 1, 1, 2], 1.23))
 
     Unlike `target=<callable>` (where the body is dead code), `TargetMode.NOTIFY` runs the original function body after emitting the deprecation notice. You must keep a working implementation in the function body.
 
-Use `TargetMode.NOTIFY` when a function is going away but has no replacement yet. The decorator emits a deprecation notice and then runs the function body normally. This is the right choice when callers need to update their own code, not switch to a different function.
+Use warn-only mode when a function is going away but has no replacement yet. The decorator emits a deprecation notice and then runs the function body normally. This is the right choice when callers need to update their own code, not switch to a different function.
+
+Since `target` defaults to `TargetMode.NOTIFY`, you can omit it entirely:
 
 ```python
-from deprecate import TargetMode, deprecated
+from deprecate import deprecated
 
 
-@deprecated(target=TargetMode.NOTIFY, deprecated_in="0.1", remove_in="0.5")
+@deprecated(deprecated_in="0.1", remove_in="0.5")
 def my_sum(a: int, b: int = 5) -> int:
     """My deprecated function which still has to have implementation."""
     return a + b

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -441,7 +441,7 @@ def _raise_warn_arguments(
 
 
 def deprecated(
-    target: Union[bool, None, Callable, TargetMode],
+    target: Union[bool, None, Callable, TargetMode] = TargetMode.NOTIFY,
     deprecated_in: str = "",
     remove_in: str = "",
     stream: Optional[Callable] = deprecation_warning,
@@ -459,10 +459,20 @@ def deprecated(
     implementation.  It supports argument mapping, custom warning messages, and flexible warning control.
 
     Args:
-        target: How to handle the deprecation:
+        target: How to handle the deprecation. Defaults to :attr:`~deprecate.TargetMode.NOTIFY` (warn-only; source
+            body executes unchanged). Pass an explicit value to forward calls or remap arguments:
+
             - ``Callable``: Forward all calls to this callable (function, method, or class target)
-            - ``True``: Self-deprecation mode (deprecate arguments within same function)
-            - ``None``: Warning-only mode (no forwarding, function body executes normally)
+            - :attr:`~deprecate.TargetMode.ARGS_REMAP` (or legacy ``True``): Self-deprecation — deprecate argument
+              names only, remapping them within the same function body
+            - :attr:`~deprecate.TargetMode.NOTIFY` (default): Warning-only mode — no forwarding, source body executes
+              normally
+
+            .. note::
+                Omitting ``target`` is the preferred way to express warn-only deprecation.  Passing ``target=None``
+                is a legacy synonym that also resolves to :attr:`~deprecate.TargetMode.NOTIFY` but emits a
+                :class:`FutureWarning` directing you to use the enum form.
+
         deprecated_in: Version when the function was deprecated (e.g., "1.0.0"). Default is empty string.
         remove_in: Version when the function will be removed (e.g., "2.0.0"). Default is empty string.
         stream: Function to output warnings (default: :func:`~deprecate.deprecation.deprecation_warning`, which is
@@ -539,6 +549,11 @@ def deprecated(
         ... def my_func(old_arg: int = 0, new_arg: int = 0) -> int:
         ...     return new_arg * 2
 
+        >>> # Warn-only (default — no target needed)
+        >>> @deprecated(deprecated_in="1.0", remove_in="2.0")
+        ... def legacy_func(x: int) -> int:
+        ...     return x
+
     """
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
@@ -605,6 +620,14 @@ def deprecated(
                 docstring_style=docstring_style,
                 _misconfigured_override=force_misconfigured,
             )(source)
+        if not deprecated_in and not remove_in:
+            warnings.warn(
+                f"`@deprecated` on `{source.__name__}` has no `deprecated_in` or `remove_in` set."
+                " The emitted warning will contain empty version strings."
+                " Pass at least `deprecated_in` for a meaningful deprecation notice.",
+                UserWarning,
+                stacklevel=2,
+            )
         # Cross-class guard runs before remapping; class targets skip it because
         # constructor forwarding (target=NewCls on __init__) is always valid.
         if callable(target) and not inspect.isclass(target):

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -563,7 +563,7 @@ def deprecated(
             and not deprecated_in
             and not remove_in
             and stream is not None
-            and template_mgs is None
+            and not template_mgs
             and not inspect.isclass(source)
         ):
             warnings.warn(

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -468,10 +468,9 @@ def deprecated(
             - :attr:`~deprecate.TargetMode.NOTIFY` (default): Warning-only mode — no forwarding, source body executes
               normally
 
-            .. note::
-                Omitting ``target`` is the preferred way to express warn-only deprecation.  Passing ``target=None``
-                is a legacy synonym that also resolves to :attr:`~deprecate.TargetMode.NOTIFY` but emits a
-                :class:`FutureWarning` directing you to use the enum form.
+            Omitting ``target`` is the preferred way to express warn-only deprecation.  Passing ``target=None``
+            is a legacy synonym that also resolves to :attr:`~deprecate.TargetMode.NOTIFY` but emits a
+            :class:`FutureWarning` directing you to use the enum form.
 
         deprecated_in: Version when the function was deprecated (e.g., "1.0.0"). Default is empty string.
         remove_in: Version when the function will be removed (e.g., "2.0.0"). Default is empty string.
@@ -545,7 +544,8 @@ def deprecated(
         ...     pass
 
         >>> # Self-deprecation
-        >>> @deprecated(target=True, args_mapping={'old_arg': 'new_arg'})
+        >>> from deprecate import TargetMode
+        >>> @deprecated(target=TargetMode.ARGS_REMAP, args_mapping={'old_arg': 'new_arg'})
         ... def my_func(old_arg: int = 0, new_arg: int = 0) -> int:
         ...     return new_arg * 2
 
@@ -558,6 +558,15 @@ def deprecated(
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
     def packing(source: Callable) -> Callable:
+        if target is TargetMode.NOTIFY and not deprecated_in and not remove_in and stream is not None:
+            warnings.warn(
+                f"`@deprecated` on `{source.__name__}` has no `deprecated_in` or `remove_in` set."
+                " Depending on configuration, deprecation notices or generated documentation may"
+                " contain empty version strings."
+                " Pass at least `deprecated_in` for a meaningful deprecation notice.",
+                FutureWarning,
+                stacklevel=2,
+            )
         if inspect.isclass(source):
             import importlib
 
@@ -620,15 +629,6 @@ def deprecated(
                 docstring_style=docstring_style,
                 _misconfigured_override=force_misconfigured,
             )(source)
-        if not deprecated_in and not remove_in:
-            warnings.warn(
-                f"`@deprecated` on `{source.__name__}` has no `deprecated_in` or `remove_in` set."
-                " Depending on configuration, deprecation notices or generated documentation may"
-                " contain empty version strings."
-                " Pass at least `deprecated_in` for a meaningful deprecation notice.",
-                UserWarning,
-                stacklevel=2,
-            )
         # Cross-class guard runs before remapping; class targets skip it because
         # constructor forwarding (target=NewCls on __init__) is always valid.
         if callable(target) and not inspect.isclass(target):

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -558,7 +558,14 @@ def deprecated(
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
     def packing(source: Callable) -> Callable:
-        if target is TargetMode.NOTIFY and not deprecated_in and not remove_in and stream is not None:
+        if (
+            target is TargetMode.NOTIFY
+            and not deprecated_in
+            and not remove_in
+            and stream is not None
+            and template_mgs is None
+            and not inspect.isclass(source)
+        ):
             warnings.warn(
                 f"`@deprecated` on `{source.__name__}` has no `deprecated_in` or `remove_in` set."
                 " Depending on configuration, deprecation notices or generated documentation may"

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -623,7 +623,8 @@ def deprecated(
         if not deprecated_in and not remove_in:
             warnings.warn(
                 f"`@deprecated` on `{source.__name__}` has no `deprecated_in` or `remove_in` set."
-                " The emitted warning will contain empty version strings."
+                " Depending on configuration, deprecation notices or generated documentation may"
+                " contain empty version strings."
                 " Pass at least `deprecated_in` for a meaningful deprecation notice.",
                 UserWarning,
                 stacklevel=2,

--- a/src/deprecate/proxy.py
+++ b/src/deprecate/proxy.py
@@ -680,7 +680,7 @@ def deprecated_instance(
     resolved_name = name or type(obj).__name__
     if stream is not None and not deprecated_in and not remove_in:
         warnings.warn(
-            f"`@deprecated_instance` on `{resolved_name}` has no `deprecated_in` or `remove_in` set."
+            f"`deprecated_instance()` on `{resolved_name}` has no `deprecated_in` or `remove_in` set."
             " Depending on configuration, deprecation notices or generated documentation may"
             " contain empty version strings."
             " Pass at least `deprecated_in` for a meaningful deprecation notice.",

--- a/src/deprecate/proxy.py
+++ b/src/deprecate/proxy.py
@@ -25,6 +25,7 @@ Example:
 """
 
 import types
+import warnings
 from collections.abc import Iterator
 from typing import Any, Callable, Literal, Optional, cast
 
@@ -588,6 +589,15 @@ def deprecated_class(
     """
 
     def decorator(cls: type) -> "_DeprecatedProxy":
+        if stream is not None and not deprecated_in and not remove_in:
+            warnings.warn(
+                f"`@deprecated_class` on `{cls.__name__}` has no `deprecated_in` or `remove_in` set."
+                " Depending on configuration, deprecation notices or generated documentation may"
+                " contain empty version strings."
+                " Pass at least `deprecated_in` for a meaningful deprecation notice.",
+                FutureWarning,
+                stacklevel=2,
+            )
         proxy = _DeprecatedProxy(
             obj=cls,
             name=cls.__name__,
@@ -668,6 +678,15 @@ def deprecated_instance(
 
     """
     resolved_name = name or type(obj).__name__
+    if stream is not None and not deprecated_in and not remove_in:
+        warnings.warn(
+            f"`@deprecated_instance` on `{resolved_name}` has no `deprecated_in` or `remove_in` set."
+            " Depending on configuration, deprecation notices or generated documentation may"
+            " contain empty version strings."
+            " Pass at least `deprecated_in` for a meaningful deprecation notice.",
+            FutureWarning,
+            stacklevel=2,
+        )
     return _DeprecatedProxy(
         obj=obj,
         name=resolved_name,

--- a/src/deprecate/proxy.py
+++ b/src/deprecate/proxy.py
@@ -589,7 +589,7 @@ def deprecated_class(
     """
 
     def decorator(cls: type) -> "_DeprecatedProxy":
-        if stream is not None and not deprecated_in and not remove_in:
+        if stream is not None and not deprecated_in and not remove_in and template_mgs is None:
             warnings.warn(
                 f"`@deprecated_class` on `{cls.__name__}` has no `deprecated_in` or `remove_in` set."
                 " Depending on configuration, deprecation notices or generated documentation may"

--- a/src/deprecate/proxy.py
+++ b/src/deprecate/proxy.py
@@ -589,7 +589,7 @@ def deprecated_class(
     """
 
     def decorator(cls: type) -> "_DeprecatedProxy":
-        if stream is not None and not deprecated_in and not remove_in and template_mgs is None:
+        if stream is not None and not deprecated_in and not remove_in and not template_mgs:
             warnings.warn(
                 f"`@deprecated_class` on `{cls.__name__}` has no `deprecated_in` or `remove_in` set."
                 " Depending on configuration, deprecation notices or generated documentation may"
@@ -678,7 +678,7 @@ def deprecated_instance(
 
     """
     resolved_name = name or type(obj).__name__
-    if stream is not None and not deprecated_in and not remove_in:
+    if stream is not None and not deprecated_in and not remove_in and not template_mgs:
         warnings.warn(
             f"`deprecated_instance()` on `{resolved_name}` has no `deprecated_in` or `remove_in` set."
             " Depending on configuration, deprecation notices or generated documentation may"

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -1226,11 +1226,50 @@ def make_default_target_with_versions() -> Callable[[int], int]:
 def make_default_target_no_versions_warns() -> Callable[[int], int]:
     """Build a @deprecated() wrapper with no versions and no target.
 
-    An empty-version UserWarning must be emitted at decoration time because
+    An empty-version FutureWarning must be emitted at decoration time because
     the resulting deprecation notice would contain empty version strings.
     """
 
     @deprecated()
+    def fn(x: int) -> int:
+        return identity_value(x)
+
+    return fn
+
+
+def make_partial_version_no_guard_warn() -> Callable[[int], int]:
+    """Build @deprecated(deprecated_in='1.0') with only deprecated_in set.
+
+    Guard must NOT fire — requires both version parameters to be empty.
+    """
+
+    @deprecated(deprecated_in="1.0")
+    def fn(x: int) -> int:
+        return identity_value(x)
+
+    return fn
+
+
+def make_callable_target_no_versions_no_guard_warn() -> Callable[[int], int]:
+    """Build @deprecated(target=identity_value) with no version strings.
+
+    Guard must NOT fire — scoped to TargetMode.NOTIFY only; callable target skips it.
+    """
+
+    @deprecated(target=identity_value)
+    def fn(x: int) -> int:
+        return identity_value(x)
+
+    return fn
+
+
+def make_explicit_notify_no_versions_warns() -> Callable[[int], int]:
+    """Build @deprecated(target=TargetMode.NOTIFY) with no version strings.
+
+    Guard MUST fire — explicit NOTIFY + both versions empty triggers the warning.
+    """
+
+    @deprecated(target=TargetMode.NOTIFY)
     def fn(x: int) -> int:
         return identity_value(x)
 

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -1204,3 +1204,34 @@ def fn_remap_with_extra(old_arg: int = 0, new_arg: int = 0, injected: int = 0) -
     reaches the body regardless of whether the caller passes the old or new name.
     """
     return fn_remap_with_extra_body(new_arg=new_arg, injected=injected)
+
+
+# ========== Default-target fixtures (target omitted → TargetMode.NOTIFY) ==========
+
+
+def make_default_target_with_versions() -> Callable[[int], int]:
+    """Build a @deprecated(deprecated_in='1.0', remove_in='2.0') wrapper with no explicit target.
+
+    No FutureWarning should be emitted at decoration time (unlike target=None).
+    Source body must execute on call and a FutureWarning must be emitted.
+    """
+
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
+    def fn(x: int) -> int:
+        return tracked_identity(x)
+
+    return fn
+
+
+def make_default_target_no_versions_warns() -> Callable[[int], int]:
+    """Build a @deprecated() wrapper with no versions and no target.
+
+    An empty-version UserWarning must be emitted at decoration time because
+    the resulting deprecation notice would contain empty version strings.
+    """
+
+    @deprecated()
+    def fn(x: int) -> int:
+        return identity_value(x)
+
+    return fn

--- a/tests/integration/test_target_mode.py
+++ b/tests/integration/test_target_mode.py
@@ -41,8 +41,11 @@ from tests.collection_deprecate import (
     depr_target_mode_args_only_with_args_extra_injects_kwargs,
     depr_target_mode_whole_executes_original_body,
     depr_target_mode_whole_warns_on_every_call,
+    make_callable_target_no_versions_no_guard_warn,
     make_default_target_no_versions_warns,
     make_default_target_with_versions,
+    make_explicit_notify_no_versions_warns,
+    make_partial_version_no_guard_warn,
     make_target_mode_args_only_without_args_mapping_warns,
     make_target_mode_whole_with_args_extra_warns,
     make_target_mode_whole_with_args_mapping_warns,
@@ -292,9 +295,29 @@ class TestDefaultTarget:
         assert tracked_identity_calls == [42]
 
     def test_empty_versions_warns_at_decoration(self) -> None:
-        """@deprecated() with no versions emits UserWarning at decoration time."""
-        with pytest.warns(UserWarning, match="deprecated_in.*remove_in|version"):
+        """@deprecated() with no versions emits FutureWarning at decoration time."""
+        with pytest.warns(FutureWarning, match=r"has no .deprecated_in. or .remove_in."):
             make_default_target_no_versions_warns()
+
+    def test_partial_version_does_not_warn_at_decoration(self) -> None:
+        """@deprecated(deprecated_in='1.0') with only one version set must not warn."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            make_partial_version_no_guard_warn()
+        assert not any(issubclass(w.category, FutureWarning) for w in caught if "deprecated_in" in str(w.message))
+
+    def test_callable_target_no_versions_does_not_warn_at_decoration(self) -> None:
+        """@deprecated(target=callable) with empty versions must not warn — guard is NOTIFY-scoped."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            make_callable_target_no_versions_no_guard_warn()
+        guard_warns = [w for w in caught if issubclass(w.category, FutureWarning) and "deprecated_in" in str(w.message)]
+        assert guard_warns == []
+
+    def test_explicit_notify_no_versions_warns_at_decoration(self) -> None:
+        """@deprecated(target=TargetMode.NOTIFY) with empty versions must warn at decoration time."""
+        with pytest.warns(FutureWarning, match=r"has no .deprecated_in. or .remove_in."):
+            make_explicit_notify_no_versions_warns()
 
 
 class TestLegacySentinels:

--- a/tests/integration/test_target_mode.py
+++ b/tests/integration/test_target_mode.py
@@ -41,6 +41,8 @@ from tests.collection_deprecate import (
     depr_target_mode_args_only_with_args_extra_injects_kwargs,
     depr_target_mode_whole_executes_original_body,
     depr_target_mode_whole_warns_on_every_call,
+    make_default_target_no_versions_warns,
+    make_default_target_with_versions,
     make_target_mode_args_only_without_args_mapping_warns,
     make_target_mode_whole_with_args_extra_warns,
     make_target_mode_whole_with_args_mapping_warns,
@@ -249,6 +251,50 @@ class TestArgsRemapMode:
             warnings.simplefilter("ignore", FutureWarning)
             result = func(old_x=old_x)
         assert result == expected
+
+
+class TestDefaultTarget:
+    """Omitting `target` defaults to TargetMode.NOTIFY — warn-only, no forwarding."""
+
+    def test_default_target_resolves_to_notify(self) -> None:
+        """Omitting target stores TargetMode.NOTIFY in __deprecated__.target."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fn = make_default_target_with_versions()
+        assert cast(_DeprecatedCallable, fn).__deprecated__.target is TargetMode.NOTIFY
+
+    def test_default_target_no_decoration_time_future_warning(self) -> None:
+        """Omitting target emits no FutureWarning at decoration time (unlike target=None)."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            make_default_target_with_versions()
+        future_warns = [w for w in caught if issubclass(w.category, FutureWarning)]
+        assert future_warns == []
+
+    def test_default_target_warns_on_call(self) -> None:
+        """Omitting target still emits FutureWarning when the decorated function is called."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fn = make_default_target_with_versions()
+        with pytest.warns(FutureWarning):
+            fn(1)
+
+    def test_default_target_executes_body(self) -> None:
+        """Omitting target executes the original function body and returns its value."""
+        tracked_identity_calls.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            fn = make_default_target_with_versions()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            result = fn(42)
+        assert result == 42
+        assert tracked_identity_calls == [42]
+
+    def test_empty_versions_warns_at_decoration(self) -> None:
+        """@deprecated() with no versions emits UserWarning at decoration time."""
+        with pytest.warns(UserWarning, match="deprecated_in.*remove_in|version"):
+            make_default_target_no_versions_warns()
 
 
 class TestLegacySentinels:

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -681,3 +681,69 @@ class TestNormalizeTargetInvalidInputs:
             result = fn(4)
 
         assert result == 5
+
+
+class TestEmptyVersionGuardOnFunctions:
+    """@deprecated() on a function with no version strings emits FutureWarning at decoration time.
+
+    Mirrors the proxy-side coverage in tests/unittests/test_proxy.py so the function form of
+    @deprecated is held to the same contract: a single FutureWarning when both ``deprecated_in``
+    and ``remove_in`` are absent, suppressed when ``stream=None``.
+    """
+
+    def test_function_empty_versions_warns_once(self) -> None:
+        """@deprecated() on a function with no version strings emits exactly one FutureWarning."""
+        with pytest.warns(FutureWarning, match=r"no `deprecated_in` or `remove_in`") as caught:
+
+            @deprecated()
+            def _fn_no_versions() -> None:
+                """Source function with no version metadata supplied."""
+
+        future_warnings = [w for w in caught.list if issubclass(w.category, FutureWarning)]
+        assert len(future_warnings) == 1
+
+    def test_function_empty_versions_stream_none_silent(self) -> None:
+        """@deprecated(stream=None) on a function with no version strings emits no FutureWarning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @deprecated(stream=None)
+            def _fn_no_versions_silent() -> None:
+                """Source function with stream=None — guard must stay silent."""
+
+        assert not caught
+
+
+class TestEmptyVersionGuardOnClasses:
+    """@deprecated() on a class with no version strings emits exactly one FutureWarning.
+
+    When ``@deprecated`` is applied to a class, ``packing()`` delegates to ``deprecated_class()``.
+    The empty-version guard must fire at the proxy layer only — duplicating it inside
+    ``packing()`` would surface two FutureWarnings for a single decoration. The inline class
+    fixtures here are mechanical one-offs per the AGENTS.md test-three-layer exception.
+    """
+
+    def test_class_empty_versions_warns_once(self) -> None:
+        """@deprecated() applied to a class with no version strings emits exactly one FutureWarning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @deprecated()
+            class _OldClassNoVersions:
+                """Source class with no version metadata supplied."""
+
+        future_warnings = [w for w in caught if issubclass(w.category, FutureWarning)]
+        assert len(future_warnings) == 1
+        assert "no `deprecated_in` or `remove_in`" in str(future_warnings[0].message)
+
+    def test_class_empty_versions_stream_none_silent(self) -> None:
+        """@deprecated(stream=None) applied to a class with no version strings emits no FutureWarning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @deprecated(stream=None)
+            class _OldClassNoVersionsSilent:
+                """Source class with stream=None — guard must stay silent."""
+
+        future_warnings = [w for w in caught if issubclass(w.category, FutureWarning)]
+        assert not future_warnings

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -785,6 +785,47 @@ class TestDeprecatedClassReadOnly:
         assert "read_only" not in inspect.signature(deprecated_class).parameters
 
 
+class TestEmptyVersionGuard:
+    """Decoration-time FutureWarning when both ``deprecated_in`` and ``remove_in`` are empty.
+
+    Both ``deprecated_class()`` and ``deprecated_instance()`` warn at construction
+    time when neither version string is provided, because the rendered notice
+    would otherwise contain empty ``v`` placeholders. ``stream=None`` suppresses
+    the guard so callers that opt out of warnings entirely remain silent.
+    """
+
+    def test_deprecated_class_empty_versions_warns(self) -> None:
+        """@deprecated_class() with empty versions emits FutureWarning at decoration time."""
+        with pytest.warns(FutureWarning, match=r"no `deprecated_in` or `remove_in`"):
+
+            @deprecated_class()
+            class OldEmptyVersions:
+                """Source class with no version metadata supplied."""
+
+    def test_deprecated_class_empty_versions_stream_none_silent(self) -> None:
+        """@deprecated_class(stream=None) suppresses the empty-versions FutureWarning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @deprecated_class(stream=None)
+            class OldEmptyVersionsSilent:
+                """Source class with stream=None — guard must stay silent."""
+
+        assert not caught
+
+    def test_deprecated_instance_empty_versions_warns(self) -> None:
+        """deprecated_instance() with empty versions emits FutureWarning at instantiation time."""
+        with pytest.warns(FutureWarning, match=r"no `deprecated_in` or `remove_in`"):
+            deprecated_instance({"k": 1})
+
+    def test_deprecated_instance_empty_versions_stream_none_silent(self) -> None:
+        """deprecated_instance(stream=None) suppresses the empty-versions FutureWarning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            deprecated_instance({"k": 1}, stream=None)
+        assert not caught
+
+
 class TestDeprecatedInstance:
     """deprecated_instance() wraps any Python object with transparent deprecation warnings."""
 

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -802,6 +802,8 @@ class TestEmptyVersionGuard:
             class OldEmptyVersions:
                 """Source class with no version metadata supplied."""
 
+                pass
+
     def test_deprecated_class_empty_versions_stream_none_silent(self) -> None:
         """@deprecated_class(stream=None) suppresses the empty-versions FutureWarning."""
         with warnings.catch_warnings(record=True) as caught:
@@ -810,6 +812,8 @@ class TestEmptyVersionGuard:
             @deprecated_class(stream=None)
             class OldEmptyVersionsSilent:
                 """Source class with stream=None — guard must stay silent."""
+
+                pass
 
         assert not caught
 


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

- `deprecated()` `target` param now optional, defaults to `TargetMode.NOTIFY` — enables `@deprecated(deprecated_in="1.0", remove_in="2.0")` without explicit target
- Decoration-time `UserWarning` emitted when both `deprecated_in` and `remove_in` are empty to prevent silent broken warning messages
- `TestDefaultTarget` class (5 tests) covering NOTIFY resolution, no decoration-time FutureWarning, call-time warning, body execution, and empty-version guard
- README API table and `docs/guide/use-cases.md` notice-only section updated to show simplified form
- `.developments/` added to `.gitignore`

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
