### PR TITLE
revert cross-class guard to TypeError; fix source-side regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking
 
-- **Cross-class method guard downgrades from `TypeError` to `UserWarning`.** `@deprecated(target=OtherClass.method)` no longer raises `TypeError` at decoration time — it emits a `UserWarning` instead. Code that previously caught `TypeError` from this guard must migrate to `warnings.filterwarnings("error", message=".*cross-class method forwarding", category=UserWarning)` for equivalent strict behaviour. The guard heuristic uses `__qualname__` and may produce false positives for metaclass-generated or decorator-rewritten qualnames — downgrading to `UserWarning` allows those cases to be suppressed. ([#166](https://github.com/Borda/pyDeprecate/pull/166))
+- **Cross-class method guard downgrades from `TypeError` to `UserWarning`.** `@deprecated(target=OtherClass.method)` no longer raises `TypeError` at decoration time — it emits a `UserWarning` instead. Code that previously caught `TypeError` from this guard must migrate to `warnings.filterwarnings("error", message=".*cross-class method forwarding", category=UserWarning)` for equivalent strict behaviour. ([#166](https://github.com/Borda/pyDeprecate/pull/166))
 
 ### Added
 
@@ -41,7 +41,10 @@
 
 ### Fixed
 
+- **Cross-class guard no longer fires false positives for metaclass-generated qualnames.** When a target callable's `__qualname__` prefix refers to a class that does not exist in the callable's module globals (e.g. qualname set by `type("Name", bases, ns)` or manual `fn.__qualname__ = "FakeOwner.method"` assignment), the guard now skips silently instead of warning. The two documented "irresolvable" false-positive scenarios are fully resolved: (1) metaclass/dynamic-class qualnames, (2) pre-applied decorators that rewrite the source's `__qualname__` — the guard now reads the enclosing class name directly from the Python class-body frame, which cannot be mutated by user decorators.
+
 - **`args_mapping` rename no longer clobbers source default when both old and new parameter names are present.** Previously, calling a deprecated wrapper with the old argument name while the source also accepted the new name could silently overwrite the new-name value. The remapping now correctly renames `old=X` to `new=X` without discarding a separately supplied `new` value. ([#150](https://github.com/Borda/pyDeprecate/pull/150))
+
 - **`target=False` sentinel now emits `UserWarning` at decoration time.** `target=False` was never a valid configuration; previously the behavior was undefined. The sentinel now surfaces a `UserWarning` immediately and will raise `TypeError` in v1.0. ([#150](https://github.com/Borda/pyDeprecate/pull/150))
 
 ______________________________________________________________________

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 [0.8.0] — 2026-05-DD — Default `TargetMode` enum & CLI audit tools
 
-### Breaking
-
-- **Cross-class method guard downgrades from `TypeError` to `UserWarning`.** `@deprecated(target=OtherClass.method)` no longer raises `TypeError` at decoration time — it emits a `UserWarning` instead. Code that previously caught `TypeError` from this guard must migrate to `warnings.filterwarnings("error", message=".*cross-class method forwarding", category=UserWarning)` for equivalent strict behaviour. ([#166](https://github.com/Borda/pyDeprecate/pull/166))
-
 ### Added
 
 - **`TargetMode` enum exported from `deprecate`.** `TargetMode.NOTIFY` replaces `target=None` and `TargetMode.ARGS_REMAP` replaces `target=True`. Both are public API. ([#150](https://github.com/Borda/pyDeprecate/pull/150))
@@ -41,7 +37,7 @@
 
 ### Fixed
 
-- **Cross-class guard no longer fires false positives for metaclass-generated qualnames.** When a target callable's `__qualname__` prefix refers to a class that does not exist in the callable's module globals (e.g. qualname set by `type("Name", bases, ns)` or manual `fn.__qualname__ = "FakeOwner.method"` assignment), the guard now skips silently instead of warning. The two documented "irresolvable" false-positive scenarios are fully resolved: (1) metaclass/dynamic-class qualnames, (2) pre-applied decorators that rewrite the source's `__qualname__` — the guard now reads the enclosing class name directly from the Python class-body frame, which cannot be mutated by user decorators.
+- **Cross-class guard false positives resolved; `TypeError` semantics preserved.** Two previously documented "irresolvable" false-positive scenarios are now handled: (1) targets with metaclass/dynamic-class qualnames (e.g. `type("Name", bases, ns)` or manual `fn.__qualname__ = "FakeOwner.method"`) — guard now skips silently when the named class is absent from the target's module globals; (2) pre-applied decorators that rewrite the source's `__qualname__` — guard reads the true enclosing class from the Python class-body frame, which cannot be mutated by user decorators. The guard continues to raise `TypeError` at decoration time for genuine cross-class forwarding.
 
 - **`args_mapping` rename no longer clobbers source default when both old and new parameter names are present.** Previously, calling a deprecated wrapper with the old argument name while the source also accepted the new name could silently overwrite the new-name value. The remapping now correctly renames `old=X` to `new=X` without discarding a separately supplied `new` value. ([#150](https://github.com/Borda/pyDeprecate/pull/150))
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -101,24 +101,22 @@ def my_func(new: int) -> int:
     return new * 2
 ```
 
-**Cross-class method forwarding — emits `UserWarning`, not `TypeError` (v0.8+)**:
-`@deprecated(target=OtherClass.method)` no longer raises `TypeError` at decoration time. Code that caught `TypeError` from this guard must update:
+**Cross-class method forwarding raises `TypeError`**:
+`@deprecated(target=OtherClass.method)` raises `TypeError` at decoration time when target is a method on a different class than source:
 
 ```python
 class OtherClass:
     def method(self): ...
 
-# v0.8+: decoration succeeds with UserWarning; TypeError is no longer raised
+# WRONG — raises TypeError at decoration time
 class MyClass:
     @deprecated(target=OtherClass.method, deprecated_in="1.0", remove_in="2.0")
     def my_method(self): ...
 
-# To restore hard-fail semantics add a warning filter before decoration:
-import warnings
-warnings.filterwarnings("error", message=".*cross-class method forwarding", category=UserWarning)
+# CORRECT — target must be on the same class, or use a full class for constructor forwarding
 ```
 
-The guard uses `__qualname__` heuristics with two automatic false-positive defences: (1) targets whose qualname prefix names a class absent from the callable's module globals are skipped silently; (2) the source's true enclosing class is read from the Python class-body frame, so pre-applied decorators that rewrite `source.__qualname__` cannot cause spurious warnings on same-class forwards.
+The guard uses `__qualname__` heuristics with two automatic false-positive defences: (1) targets whose qualname prefix names a class absent from the callable's module globals are skipped silently; (2) the source's true enclosing class is read from the Python class-body frame, so pre-applied decorators that rewrite `source.__qualname__` cannot cause spurious `TypeError` on same-class forwards.
 
 **`DeprecationWrapperInfo` field renames (v0.8+)** — `empty_mapping` → `empty_args_mapping`; `identity_mapping` → `identity_args_mapping`. Legacy names are still accepted by the compat `__init__` shim for constructor kwargs and `dataclasses.replace()`, but they emit `DeprecationWarning` and are translated to the new field names:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -109,7 +109,6 @@ class OtherClass:
     def method(self): ...
 
 # v0.8+: decoration succeeds with UserWarning; TypeError is no longer raised
-# (guard requires both source and target to be class methods — qualname contains ".")
 class MyClass:
     @deprecated(target=OtherClass.method, deprecated_in="1.0", remove_in="2.0")
     def my_method(self): ...
@@ -118,6 +117,8 @@ class MyClass:
 import warnings
 warnings.filterwarnings("error", message=".*cross-class method forwarding", category=UserWarning)
 ```
+
+The guard uses `__qualname__` heuristics with two automatic false-positive defences: (1) targets whose qualname prefix names a class absent from the callable's module globals are skipped silently; (2) the source's true enclosing class is read from the Python class-body frame, so pre-applied decorators that rewrite `source.__qualname__` cannot cause spurious warnings on same-class forwards.
 
 **`DeprecationWrapperInfo` field renames (v0.8+)** — `empty_mapping` → `empty_args_mapping`; `identity_mapping` → `identity_args_mapping`. Legacy names are still accepted by the compat `__init__` shim for constructor kwargs and `dataclasses.replace()`, but they emit `DeprecationWarning` and are translated to the new field names:
 

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -77,7 +77,7 @@ def _check_cross_class_method_target(source: Callable, target: Callable) -> None
     - **Metaclass-generated classes** (``type("Name", bases, ns)``, ``__init_subclass__``, or manual assignment
       producing qualnames like ``"FakeOwner.method"`` for unrelated types): resolved by verifying that the
       top-level class name in the qualname prefix actually exists in the callable's module globals.  When the
-      referenced class does not exist, the qualname is unreliable and the guard returns without warning.
+      referenced class does not exist, the qualname is unreliable and the guard returns without raising.
 
     Args:
         source: The callable being decorated with ``@deprecated``.

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -13,6 +13,7 @@ Copyright (C) 2020-2026 Jiri Borovec <6035284+Borda@users.noreply.github.com>
 """
 
 import inspect
+import sys
 import warnings
 from functools import partial, wraps
 from inspect import Parameter
@@ -65,16 +66,22 @@ def _check_cross_class_method_target(source: Callable, target: Callable) -> None
     - ``"outer.<locals>.<lambda>"``          → skipped; prefix ends with ``<locals>``
     - ``"base_sum_kwargs"``                  → skipped; no dot means module-level function
 
-    Known limitations — ``__qualname__`` is a display string, not an ownership API.  These scenarios may produce
-    false positive warnings that are irresolvable at decoration time:
+    False positive resolution — ``__qualname__`` is a display string, not an ownership API, so two scenarios used to
+    yield spurious warnings.  Both are now handled:
 
-    - **Metaclass-generated classes**: ``type("Name", bases, ns)`` or ``__init_subclass__`` may assign qualnames
-      like ``"Outer.Inner"`` even for unrelated types; the guard treats them as methods on ``Outer`` and warns.
-    - **Decorators that rewrite ``__qualname__``**: a decorator applied before ``@deprecated`` that sets
-      ``fn.__qualname__ = "SomeClass.method"`` (e.g. some dataclass field descriptors) causes false positives.
+    - **Decorators that rewrite ``__qualname__``** (e.g. a decorator applied before ``@deprecated`` that sets
+      ``fn.__qualname__ = "OtherClass.method"``): resolved by reading ``__qualname__`` from the enclosing class
+      body frame via :func:`sys._getframe`.  Python itself sets ``__qualname__`` in the class-body locals at
+      class-definition time, so this value reflects the true enclosing class regardless of any decorator that
+      mutated the source callable's ``__qualname__`` attribute.
+    - **Metaclass-generated classes** (``type("Name", bases, ns)``, ``__init_subclass__``, or manual assignment
+      producing qualnames like ``"FakeOwner.method"`` for unrelated types): resolved by verifying that the
+      top-level class name in the qualname prefix actually exists in the callable's module globals.  When the
+      referenced class does not exist, the qualname is unreliable and the guard returns without warning.
 
-    Both cases are irresolvable at decoration time without inspecting the live call frame.  Suppress false positives
-    via ``warnings.filterwarnings("ignore", category=UserWarning, module=...)``.
+    Remaining corner cases (callables whose ``__module__`` is missing or points to a synthetic module) can still
+    be suppressed explicitly via
+    ``warnings.filterwarnings("ignore", message=".*cross-class method forwarding", category=UserWarning)``.
 
     Args:
         source: The callable being decorated with ``@deprecated``.
@@ -96,6 +103,36 @@ def _check_cross_class_method_target(source: Callable, target: Callable) -> None
     # Skip nested functions / lambdas whose prefix ends with "<locals>"
     if src_prefix.endswith("<locals>") or tgt_prefix.endswith("<locals>"):
         return
+
+    # Fix 1 — decorator-rewriting FP: a decorator applied before @deprecated may have
+    # mutated source.__qualname__.  Python sets __qualname__ in the class body's locals
+    # at class-definition time, before any decorator runs, so the frame value is the
+    # authoritative source class name.  Frame layout when this helper executes:
+    #   0: _check_cross_class_method_target
+    #   1: packing() (closure inside `deprecated`)
+    #   2: enclosing class body (where `@deprecated(...)` is written)
+    # The final-segment bracket filter rejects lambda/comprehension/genexp scopes
+    # (whose qualname's last component is ``<lambda>`` / ``<listcomp>`` / etc.); class
+    # bodies always end in a plain identifier, even when nested inside a function
+    # (e.g. ``"outer.<locals>.MyClass"``).
+    try:
+        frame_qn = sys._getframe(2).f_locals.get("__qualname__", "")
+        if frame_qn and not frame_qn.rsplit(".", 1)[-1].startswith("<"):
+            src_prefix = frame_qn
+    except (ValueError, AttributeError):
+        pass
+
+    # Fix 2 — metaclass/synthetic-qualname FP: a target whose __qualname__ refers to a
+    # class that does not actually exist in the target's module is unreliable; the guard
+    # has no way to verify the cross-class claim, so it must skip rather than warn.
+    # Applied to both target and source (source-side acts as a fallback when frame
+    # inspection above could not refine `src_prefix`, e.g. module-scope decoration).
+    for prefix, callable_obj in ((tgt_prefix, target), (src_prefix, source)):
+        top_class = prefix.split(".", 1)[0]
+        module = sys.modules.get(getattr(callable_obj, "__module__", ""), None)
+        if module is not None and not hasattr(module, top_class):
+            return
+
     src_class_name = src_prefix.rsplit(".", 1)[-1]
     tgt_class_name = tgt_prefix.rsplit(".", 1)[-1]
     src_owner = f"{getattr(source, '__module__', '')}.{src_prefix}"

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -53,7 +53,7 @@ def _get_positional_params(params: list[inspect.Parameter]) -> list[inspect.Para
 
 
 def _check_cross_class_method_target(source: Callable, target: Callable) -> None:
-    """Warn when target is a method on a different class than source.
+    """Raise ``TypeError`` when target is a method on a different class than source.
 
     Forwarding a class method to a method on a *different* class silently passes ``self`` of the wrong type, causing
     runtime attribute errors.  This guard detects the misconfiguration at decoration time by comparing the immediate
@@ -78,10 +78,6 @@ def _check_cross_class_method_target(source: Callable, target: Callable) -> None
       producing qualnames like ``"FakeOwner.method"`` for unrelated types): resolved by verifying that the
       top-level class name in the qualname prefix actually exists in the callable's module globals.  When the
       referenced class does not exist, the qualname is unreliable and the guard returns without warning.
-
-    Remaining corner cases (callables whose ``__module__`` is missing or points to a synthetic module) can still
-    be suppressed explicitly via
-    ``warnings.filterwarnings("ignore", message=".*cross-class method forwarding", category=UserWarning)``.
 
     Args:
         source: The callable being decorated with ``@deprecated``.
@@ -124,14 +120,14 @@ def _check_cross_class_method_target(source: Callable, target: Callable) -> None
 
     # Fix 2 — metaclass/synthetic-qualname FP: a target whose __qualname__ refers to a
     # class that does not actually exist in the target's module is unreliable; the guard
-    # has no way to verify the cross-class claim, so it must skip rather than warn.
-    # Applied to both target and source (source-side acts as a fallback when frame
-    # inspection above could not refine `src_prefix`, e.g. module-scope decoration).
-    for prefix, callable_obj in ((tgt_prefix, target), (src_prefix, source)):
-        top_class = prefix.split(".", 1)[0]
-        module = sys.modules.get(getattr(callable_obj, "__module__", ""), None)
-        if module is not None and not hasattr(module, top_class):
-            return
+    # has no way to verify the cross-class claim, so it must skip rather than raise.
+    # Applied to the target only — the source class is mid-definition when this helper
+    # runs, so it cannot appear in module globals yet; applying the check to the source
+    # would silently disable the guard for all module-level class definitions.
+    tgt_top_class = tgt_prefix.split(".", 1)[0]
+    tgt_module = sys.modules.get(getattr(target, "__module__", ""), None)
+    if tgt_module is not None and not hasattr(tgt_module, tgt_top_class):
+        return
 
     src_class_name = src_prefix.rsplit(".", 1)[-1]
     tgt_class_name = tgt_prefix.rsplit(".", 1)[-1]
@@ -139,16 +135,12 @@ def _check_cross_class_method_target(source: Callable, target: Callable) -> None
     tgt_owner = f"{getattr(target, '__module__', '')}.{tgt_prefix}"
     if src_owner == tgt_owner:
         return
-    warnings.warn(
+    raise TypeError(
         f"Cannot use @deprecated on '{source.__qualname__}' with target "
         f"'{target.__qualname__}': cross-class method forwarding is not supported "
         f"because `self` would carry the wrong type. "
         f"The target must be a method on the same class ('{src_class_name}') "
-        f"or a full class (use target={tgt_class_name} for class migration). "
-        "Suppress via warnings.filterwarnings("
-        "'ignore', message='.*cross-class method forwarding', category=UserWarning).",
-        UserWarning,
-        stacklevel=3,
+        f"or a full class (use target={tgt_class_name} for class migration).",
     )
 
 
@@ -585,21 +577,14 @@ def deprecated(
         UserWarning: If applied directly to a class. The decorator delegates to
             :func:`~deprecate.proxy.deprecated_class` and emits this warning. Use ``@deprecated_class()`` directly
             to suppress it. Suppressed when ``stream=None``.
-        UserWarning: If the source is a class method and target appears to be a method on a *different* class
-            (cross-class method forwarding). The heuristic uses ``__qualname__`` and may produce false positives for
-            metaclass-generated or decorator-rewritten qualnames — suppress with ``warnings.filterwarnings``. This
-            warning is emitted with ``stacklevel=3``; this skips the internal ``packing`` frame, so the attributed
-            line is the ``@deprecated`` decoration site rather than the helper internals.
-            For CI enforcement (to restore the pre-0.8 hard-failure behaviour), escalate this warning to an error::
-
-                import warnings
-                warnings.filterwarnings("error", message=".*cross-class method forwarding", category=UserWarning)
-
         UserWarning: If ``deprecated_in`` is absent, ``stream`` is not ``None``, no ``template_mgs`` is set,
             and the decorated source is not a class. Fired at decoration time (not call time) to catch missing
             version metadata early. Suppressed by passing ``stream=None`` or ``template_mgs``.
 
     Raises:
+        TypeError: If the source is a class method and target is a method on a *different* class (cross-class
+            method forwarding detected at decoration time via ``__qualname__`` comparison). Skipped silently
+            when the target's qualname prefix names a class absent from the target's module globals.
         TypeError: If skip_if is a callable that doesn't return a bool.
         TypeError: If arguments in args_mapping don't exist in target function and target doesn't accept **kwargs.
 

--- a/tests/unittests/test_audit.py
+++ b/tests/unittests/test_audit.py
@@ -363,30 +363,30 @@ class TestDwiCompatInit:
     def test_old_empty_mapping_kwarg_is_translated(self) -> None:
         """DeprecationWrapperInfo(empty_mapping=True) emits DeprecationWarning and sets empty_args_mapping."""
         with pytest.warns(DeprecationWarning, match="renamed to 'empty_args_mapping'"):
-            info = DeprecationWrapperInfo(
+            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
                 function="f",
                 deprecated_info=DeprecationConfig(),
-                empty_mapping=True,  # type: ignore[call-arg]
+                empty_mapping=True,
             )
         assert info.empty_args_mapping is True
 
     def test_old_identity_mapping_kwarg_is_translated(self) -> None:
         """DeprecationWrapperInfo(identity_mapping=[...]) emits DeprecationWarning and sets identity_args_mapping."""
         with pytest.warns(DeprecationWarning, match="renamed to 'identity_args_mapping'"):
-            info = DeprecationWrapperInfo(
+            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
                 function="f",
                 deprecated_info=DeprecationConfig(),
-                identity_mapping=["a"],  # type: ignore[call-arg]
+                identity_mapping=["a"],
             )
         assert info.identity_args_mapping == ["a"]
 
     def test_both_old_kwargs_each_emit_deprecation_warning(self) -> None:
         """Passing both old kwargs emits one DeprecationWarning per renamed field."""
         with pytest.warns(DeprecationWarning, match="renamed") as caught:
-            DeprecationWrapperInfo(
+            DeprecationWrapperInfo(  # type: ignore[call-arg]
                 function="f",
                 deprecated_info=DeprecationConfig(),
-                empty_mapping=True,  # type: ignore[call-arg]
+                empty_mapping=True,
                 identity_mapping=["b"],
             )
         categories = [str(w.message) for w in caught.list if issubclass(w.category, DeprecationWarning)]
@@ -396,10 +396,10 @@ class TestDwiCompatInit:
     def test_conflict_old_name_wins_when_both_supplied(self) -> None:
         """When both old and new names are supplied (as in replace()), old-name value is honoured."""
         with pytest.warns(DeprecationWarning, match="renamed to 'empty_args_mapping'"):
-            info = DeprecationWrapperInfo(
+            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
                 function="f",
                 deprecated_info=DeprecationConfig(),
-                empty_mapping=True,  # type: ignore[call-arg]
+                empty_mapping=True,
                 empty_args_mapping=False,  # auto-injected by replace(); caller's old-name wins
             )
         assert info.empty_args_mapping is True

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -5,7 +5,7 @@ import sys
 import warnings
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Union, cast
+from typing import Any, Callable, Union, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -486,6 +486,71 @@ class TestCrossClassMethodGuard:
         w = cross_warns[0]
         assert w.filename == __file__, f"Warning must point to {__file__!r}, got {w.filename!r}"
         assert w.lineno > test_start_line, "Warning must point inside this test method"
+
+    def test_metaclass_generated_qualname_warns_and_is_suppressible(self) -> None:
+        """A target with a metaclass-style rewritten ``__qualname__`` yields a suppressible UserWarning."""
+
+        def replacement(instance: object, x: int) -> int:
+            void(instance)
+            return x
+
+        # Simulate a metaclass / type(...) assigning a qualname that looks like a method on FakeOwner,
+        # even though `replacement` is unrelated to any such class.  The guard cannot tell this apart from
+        # a genuine cross-class method target.
+        replacement.__qualname__ = "FakeOwner.replacement"
+
+        with pytest.warns(UserWarning, match="cross-class method forwarding is not supported"):
+
+            class RealOwner:
+                @deprecated(target=replacement, deprecated_in="1.0", remove_in="2.0")
+                def old_method(self, x: int) -> int:
+                    return void(x)
+
+        # Same construction under a filterwarnings("ignore", ...) block must emit no UserWarning.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warnings.filterwarnings("ignore", message=".*cross-class method forwarding", category=UserWarning)
+
+            class RealOwnerSuppressed:
+                @deprecated(target=replacement, deprecated_in="1.0", remove_in="2.0")
+                def old_method(self, x: int) -> int:
+                    return void(x)
+
+        cross_warns = [w for w in caught if issubclass(w.category, UserWarning) and "cross-class" in str(w.message)]
+        assert cross_warns == []
+
+    def test_decorator_rewriting_qualname_warns_and_is_suppressible(self) -> None:
+        """A pre-applied decorator that rewrites the source ``__qualname__`` yields a suppressible UserWarning."""
+
+        def rewrite_qualname(fn: Callable[..., Any]) -> Callable[..., Any]:
+            """Test fixture: an outer decorator that retags the wrapped function as living on ``OtherOwner``."""
+            fn.__qualname__ = "OtherOwner.rewritten_method"
+            return fn
+
+        class TargetOwner:
+            def target_method(self, x: int) -> int:
+                return x
+
+        with pytest.warns(UserWarning, match="cross-class method forwarding is not supported"):
+
+            class RealOwner:
+                @deprecated(target=TargetOwner.target_method, deprecated_in="1.0", remove_in="2.0")
+                @rewrite_qualname
+                def old_method(self, x: int) -> int:
+                    return void(x)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warnings.filterwarnings("ignore", message=".*cross-class method forwarding", category=UserWarning)
+
+            class RealOwnerSuppressed:
+                @deprecated(target=TargetOwner.target_method, deprecated_in="1.0", remove_in="2.0")
+                @rewrite_qualname
+                def old_method(self, x: int) -> int:
+                    return void(x)
+
+        cross_warns = [w for w in caught if issubclass(w.category, UserWarning) and "cross-class" in str(w.message)]
+        assert cross_warns == []
 
 
 class TestDocstringStyleValidation:

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -391,40 +391,24 @@ class TestDeprecatedClassGuard:
 class TestCrossClassMethodGuard:
     """@deprecated warns when target is a method on a different class."""
 
-    def test_warns_for_cross_class_method_target(self) -> None:
-        """Forwarding to a method on a different class emits UserWarning at decoration time.
+    def test_raises_for_cross_class_method_target(self) -> None:
+        """Forwarding to a method on a different class raises TypeError at decoration time.
 
         The misconfigured classes are defined inline (not in collection_deprecate.py)
         because placing ``@deprecated`` with a cross-class target at module level would
-        emit a UserWarning at import time for every test that imports the collection module.
+        raise TypeError at import time for every test that imports the collection module.
         """
 
         class OtherClass:
             def other_method(self, x: int) -> int:
                 return x
 
-        with pytest.warns(UserWarning, match="cross-class method forwarding is not supported"):
+        with pytest.raises(TypeError, match="cross-class method forwarding is not supported"):
 
             class MyClass:
                 @deprecated(target=OtherClass.other_method, deprecated_in="1.0", remove_in="2.0")
                 def old_method(self, x: int) -> int:
                     return void(x)
-
-    def test_cross_class_warn_can_be_escalated_to_error(self) -> None:
-        """filterwarnings('error') converts the UserWarning into a raised exception."""
-
-        class OtherClass:
-            def other_method(self, x: int) -> int:
-                return x
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error", message=".*cross-class method forwarding", category=UserWarning)
-            with pytest.raises(UserWarning, match="cross-class method forwarding is not supported"):
-
-                class MyClass:
-                    @deprecated(target=OtherClass.other_method, deprecated_in="1.0", remove_in="2.0")
-                    def old_method(self, x: int) -> int:
-                        return void(x)
 
     def test_raises_for_class_target_on_non_init_method(self) -> None:
         """@deprecated(target=SomeClass) on a non-__init__ class method raises TypeError.
@@ -463,30 +447,6 @@ class TestCrossClassMethodGuard:
         assert isinstance(old, CrossGuardOldClass)
         assert old.x == 3
 
-    def test_cross_class_warn_attributed_to_decoration_site(self) -> None:
-        """stacklevel=3 attributes UserWarning to the @deprecated line, not an internal frame."""
-        frame = inspect.currentframe()
-        assert frame is not None
-        test_start_line = frame.f_lineno
-
-        class OtherClass:
-            def other_method(self, x: int) -> int:
-                return x
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-
-            class MyClass:
-                @deprecated(target=OtherClass.other_method, deprecated_in="1.0", remove_in="2.0")
-                def old_method(self, x: int) -> int:
-                    return void(x)
-
-        cross_warns = [w for w in caught if issubclass(w.category, UserWarning) and "cross-class" in str(w.message)]
-        assert len(cross_warns) == 1
-        w = cross_warns[0]
-        assert w.filename == __file__, f"Warning must point to {__file__!r}, got {w.filename!r}"
-        assert w.lineno > test_start_line, "Warning must point inside this test method"
-
     def test_metaclass_generated_qualname_skips_guard(self) -> None:
         """A target with a metaclass-style rewritten ``__qualname__`` is detected and the guard returns silently.
 
@@ -504,16 +464,10 @@ class TestCrossClassMethodGuard:
         # test module, so the module-globals check in the guard detects the unreliable qualname.
         replacement.__qualname__ = "FakeOwner.replacement"
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-
-            class RealOwner:
-                @deprecated(target=replacement, deprecated_in="1.0", remove_in="2.0")
-                def old_method(self, x: int) -> int:
-                    return void(x)
-
-        cross_warns = [w for w in caught if issubclass(w.category, UserWarning) and "cross-class" in str(w.message)]
-        assert cross_warns == [], f"Unexpected cross-class warning: {[str(w.message) for w in cross_warns]}"
+        class RealOwner:  # decoration must not raise TypeError
+            @deprecated(target=replacement, deprecated_in="1.0", remove_in="2.0")
+            def old_method(self, x: int) -> int:
+                return void(x)
 
     def test_decorator_rewriting_source_qualname_same_class_no_warning(self) -> None:
         """Frame inspection resolves the FP when a decorator corrupts source qualname on a same-class forward.
@@ -528,23 +482,17 @@ class TestCrossClassMethodGuard:
             fn.__qualname__ = "AlienClass.method"
             return fn
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        class MyClass:  # decoration must not raise TypeError
+            def new_method(self, x: int) -> int:
+                return x
 
-            class MyClass:
-                def new_method(self, x: int) -> int:
-                    return x
+            @deprecated(target=new_method, deprecated_in="1.0", remove_in="2.0")
+            @rewrite_to_alien_class
+            def old_method(self, x: int) -> int:
+                return void(x)
 
-                @deprecated(target=new_method, deprecated_in="1.0", remove_in="2.0")
-                @rewrite_to_alien_class
-                def old_method(self, x: int) -> int:
-                    return void(x)
-
-        cross_warns = [w for w in caught if issubclass(w.category, UserWarning) and "cross-class" in str(w.message)]
-        assert cross_warns == [], f"Unexpected cross-class warning: {[str(w.message) for w in cross_warns]}"
-
-    def test_decorator_rewriting_qualname_warns_and_is_suppressible(self) -> None:
-        """A pre-applied decorator rewriting source qualname to a genuinely different class still warns.
+    def test_decorator_rewriting_qualname_raises_for_cross_class(self) -> None:
+        """A pre-applied decorator rewriting source qualname to a genuinely different class still raises TypeError.
 
         Fix 1 (frame inspection) overrides the corrupted source qualname with the true enclosing class taken
         from the class body's locals.  When the recovered class differs from the target's class, the guard
@@ -560,26 +508,13 @@ class TestCrossClassMethodGuard:
             def target_method(self, x: int) -> int:
                 return x
 
-        with pytest.warns(UserWarning, match="cross-class method forwarding is not supported"):
+        with pytest.raises(TypeError, match="cross-class method forwarding is not supported"):
 
             class RealOwner:
                 @deprecated(target=TargetOwner.target_method, deprecated_in="1.0", remove_in="2.0")
                 @rewrite_qualname
                 def old_method(self, x: int) -> int:
                     return void(x)
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            warnings.filterwarnings("ignore", message=".*cross-class method forwarding", category=UserWarning)
-
-            class RealOwnerSuppressed:
-                @deprecated(target=TargetOwner.target_method, deprecated_in="1.0", remove_in="2.0")
-                @rewrite_qualname
-                def old_method(self, x: int) -> int:
-                    return void(x)
-
-        cross_warns = [w for w in caught if issubclass(w.category, UserWarning) and "cross-class" in str(w.message)]
-        assert cross_warns == []
 
 
 class TestDocstringStyleValidation:

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -487,40 +487,69 @@ class TestCrossClassMethodGuard:
         assert w.filename == __file__, f"Warning must point to {__file__!r}, got {w.filename!r}"
         assert w.lineno > test_start_line, "Warning must point inside this test method"
 
-    def test_metaclass_generated_qualname_warns_and_is_suppressible(self) -> None:
-        """A target with a metaclass-style rewritten ``__qualname__`` yields a suppressible UserWarning."""
+    def test_metaclass_generated_qualname_skips_guard(self) -> None:
+        """A target with a metaclass-style rewritten ``__qualname__`` is detected and the guard returns silently.
+
+        The module-globals check verifies that the top-level class name in the target's qualname actually exists
+        in the target callable's module.  When it does not (as for a synthetic ``FakeOwner.replacement`` qualname
+        produced by ``type(...)`` or manual assignment), the qualname cannot be trusted and the guard short-circuits.
+        """
 
         def replacement(instance: object, x: int) -> int:
             void(instance)
             return x
 
         # Simulate a metaclass / type(...) assigning a qualname that looks like a method on FakeOwner,
-        # even though `replacement` is unrelated to any such class.  The guard cannot tell this apart from
-        # a genuine cross-class method target.
+        # even though `replacement` is unrelated to any such class.  FakeOwner does not exist in this
+        # test module, so the module-globals check in the guard detects the unreliable qualname.
         replacement.__qualname__ = "FakeOwner.replacement"
 
-        with pytest.warns(UserWarning, match="cross-class method forwarding is not supported"):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
 
             class RealOwner:
                 @deprecated(target=replacement, deprecated_in="1.0", remove_in="2.0")
                 def old_method(self, x: int) -> int:
                     return void(x)
 
-        # Same construction under a filterwarnings("ignore", ...) block must emit no UserWarning.
+        cross_warns = [w for w in caught if issubclass(w.category, UserWarning) and "cross-class" in str(w.message)]
+        assert cross_warns == [], f"Unexpected cross-class warning: {[str(w.message) for w in cross_warns]}"
+
+    def test_decorator_rewriting_source_qualname_same_class_no_warning(self) -> None:
+        """Frame inspection resolves the FP when a decorator corrupts source qualname on a same-class forward.
+
+        Python sets ``__qualname__`` in the class body's locals at class-definition time, before any decorator
+        runs.  Reading it from ``sys._getframe`` therefore recovers the true enclosing class name even when a
+        pre-applied decorator has overwritten ``fn.__qualname__`` on the source callable.
+        """
+
+        def rewrite_to_alien_class(fn: Callable[..., Any]) -> Callable[..., Any]:
+            """Test fixture: outer decorator that retags the wrapped function as living on ``AlienClass``."""
+            fn.__qualname__ = "AlienClass.method"
+            return fn
+
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            warnings.filterwarnings("ignore", message=".*cross-class method forwarding", category=UserWarning)
 
-            class RealOwnerSuppressed:
-                @deprecated(target=replacement, deprecated_in="1.0", remove_in="2.0")
+            class MyClass:
+                def new_method(self, x: int) -> int:
+                    return x
+
+                @deprecated(target=new_method, deprecated_in="1.0", remove_in="2.0")
+                @rewrite_to_alien_class
                 def old_method(self, x: int) -> int:
                     return void(x)
 
         cross_warns = [w for w in caught if issubclass(w.category, UserWarning) and "cross-class" in str(w.message)]
-        assert cross_warns == []
+        assert cross_warns == [], f"Unexpected cross-class warning: {[str(w.message) for w in cross_warns]}"
 
     def test_decorator_rewriting_qualname_warns_and_is_suppressible(self) -> None:
-        """A pre-applied decorator that rewrites the source ``__qualname__`` yields a suppressible UserWarning."""
+        """A pre-applied decorator rewriting source qualname to a genuinely different class still warns.
+
+        Fix 1 (frame inspection) overrides the corrupted source qualname with the true enclosing class taken
+        from the class body's locals.  When the recovered class differs from the target's class, the guard
+        still fires correctly — this guards against an over-eager FP suppression.
+        """
 
         def rewrite_qualname(fn: Callable[..., Any]) -> Callable[..., Any]:
             """Test fixture: an outer decorator that retags the wrapped function as living on ``OtherOwner``."""


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

- add `test_metaclass_generated_qualname_warns_and_is_suppressible` covering the metaclass / `type(...)` qualname rewrite false-positive of the cross-class method guard
- add `test_decorator_rewriting_qualname_warns_and_is_suppressible` covering a decorator that mutates `__qualname__` before `@deprecated`; both tests assert UserWarning fires and that `filterwarnings("ignore", ...)` suppresses it
- relocate `# type: ignore[call-arg]` annotations in `TestDwiCompatInit` from kwarg lines to call-opening lines (cosmetic; pre-existing mypy 1.20.0 `unused-ignore` warnings on these lines are unchanged by this move)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
