### PR TITLE
docs: add migration guide and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,18 +208,19 @@ Not sure which API to reach for? Start here.
 <details>
   <summary><strong>All `@deprecated` parameters at a glance:</strong></summary>
 
-| Param              | Default               | Purpose                                                                                                    |
-| ------------------ | --------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `target`           | `TargetMode.NOTIFY`   | `Callable` to forward to · `TargetMode.ARGS_REMAP` to remap args · `TargetMode.NOTIFY` (default) warn-only |
-| `deprecated_in`    | `""`                  | Version when deprecated (e.g. `"1.0"`)                                                                     |
-| `remove_in`        | `""`                  | Version when removed (e.g. `"2.0"`)                                                                        |
-| `stream`           | `deprecation_warning` | Warning sink callable (set `None` to silence warnings)                                                     |
-| `num_warns`        | `1`                   | `1` once · `-1` always · `N` exactly N times                                                               |
-| `args_mapping`     | `None`                | `{"old": "new"}` rename · `{"old": None}` drop                                                             |
-| `template_mgs`     | `None`                | Custom warning message template (`%`-style placeholders)                                                   |
-| `args_extra`       | `None`                | Fixed kwargs injected into the target call                                                                 |
-| `skip_if`          | `False`               | `bool` or `Callable → bool`; skip deprecation when true                                                    |
-| `update_docstring` | `False`               | Append Sphinx `.. deprecated::` notice to docstring                                                        |
+| Param              | Default                     | Purpose                                                                                                    |
+| ------------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `target`           | `TargetMode.NOTIFY`         | `Callable` to forward to · `TargetMode.ARGS_REMAP` to remap args · `TargetMode.NOTIFY` (default) warn-only |
+| `deprecated_in`    | `""`                        | Version when deprecated (e.g. `"1.0"`)                                                                     |
+| `remove_in`        | `""`                        | Version when removed (e.g. `"2.0"`)                                                                        |
+|                    | **Advanced: ~10% of cases** |                                                                                                            |
+| `stream`           | `deprecation_warning`       | Warning sink callable (set `None` to silence warnings)                                                     |
+| `num_warns`        | `1`                         | `1` once · `-1` always · `N` exactly N times                                                               |
+| `args_mapping`     | `None`                      | `{"old": "new"}` rename · `{"old": None}` drop                                                             |
+| `template_mgs`     | `None`                      | Custom warning message template (`%`-style placeholders)                                                   |
+| `args_extra`       | `None`                      | Fixed kwargs injected into the target call                                                                 |
+| `skip_if`          | `False`                     | `bool` or `Callable → bool`; skip deprecation when true                                                    |
+| `update_docstring` | `False`                     | Append Sphinx `.. deprecated::` notice to docstring                                                        |
 
 > [!TIP]
 > `@deprecated_class()` shares `target`, `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_mapping`, `args_extra`, and `template_mgs`.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -65,6 +65,7 @@ def my_func(old_arg: int = 0, new_arg: int = 0) -> int:
 # Legacy form — UserWarning now; invalid going forward
 from deprecate import deprecated
 
+
 @deprecated(target=False, deprecated_in="1.0", remove_in="2.0")
 def my_func(x: int) -> int:
     return x * 2

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -63,6 +63,8 @@ def my_func(old_arg: int = 0, new_arg: int = 0) -> int:
 
 ```python
 # Legacy form — UserWarning now; invalid going forward
+from deprecate import deprecated
+
 @deprecated(target=False, deprecated_in="1.0", remove_in="2.0")
 def my_func(x: int) -> int:
     return x * 2
@@ -94,6 +96,7 @@ Some `TargetMode` + argument combinations are contradictory; pyDeprecate emits a
 Two fields on `DeprecationWrapperInfo` were renamed in v0.8 to be consistent with the rest of the API. The old names still work but emit a `DeprecationWarning` on access — swapping them out is a one-line change:
 
 ```python
+# phmdoctest:skip
 # Legacy names — emit DeprecationWarning on access
 info.empty_mapping
 info.identity_mapping

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,0 +1,133 @@
+---
+id: migration
+description: 'Upgrade guide for pyDeprecate: breaking changes introduced in v1.0 and v0.8, with concrete before/after code snippets for each item.'
+---
+
+# Migration Guide
+
+## Upgrade to Latest API (v1.0)
+
+pyDeprecate v1.0 will introduce several breaking changes that were soft-deprecated with `UserWarning` or `FutureWarning` in v0.8. Each item below shows the warning you see now, explains what will break in v1.0, and gives the corrected code.
+
+### `target=None` → `TargetMode.NOTIFY`
+
+**Current behaviour (v0.8):** `target=None` is accepted but emits a `FutureWarning` at decoration time.
+
+**v1.0 behaviour:** `target=None` raises `TypeError` immediately at decoration time.
+
+```python
+# BEFORE (v0.8 — emits FutureWarning; breaks in v1.0)
+from deprecate import deprecated
+
+
+@deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+def my_func(x: int) -> int:
+    return x * 2
+
+
+# AFTER — use TargetMode.NOTIFY, or omit target entirely (defaults to NOTIFY)
+from deprecate import TargetMode, deprecated
+
+
+@deprecated(deprecated_in="1.0", remove_in="2.0")
+def my_func(x: int) -> int:
+    return x * 2
+```
+
+`TargetMode.NOTIFY` is the default when `target` is omitted; it emits a deprecation warning on every call and then executes the function body as normal.
+
+### `target=True` → `TargetMode.ARGS_REMAP`
+
+**Current behaviour (v0.8):** `target=True` is accepted but emits a `FutureWarning` at decoration time.
+
+**v1.0 behaviour:** `target=True` raises `TypeError` immediately at decoration time.
+
+```python
+# BEFORE (v0.8 — emits FutureWarning; breaks in v1.0)
+from deprecate import deprecated
+
+
+@deprecated(target=True, args_mapping={"old_arg": "new_arg"}, deprecated_in="1.0", remove_in="2.0")
+def my_func(old_arg: int = 0, new_arg: int = 0) -> int:
+    return new_arg * 2
+
+
+# AFTER — use TargetMode.ARGS_REMAP explicitly
+from deprecate import TargetMode, deprecated
+
+
+@deprecated(target=TargetMode.ARGS_REMAP, args_mapping={"old_arg": "new_arg"}, deprecated_in="1.0", remove_in="2.0")
+def my_func(old_arg: int = 0, new_arg: int = 0) -> int:
+    return new_arg * 2
+```
+
+### `target=False` → remove the decorator
+
+**Current behaviour (v0.8):** `target=False` emits a `UserWarning` at decoration time and falls through to `TargetMode.NOTIFY`.
+
+**v1.0 behaviour:** `target=False` raises `TypeError` immediately at decoration time.
+
+`target=False` was never a valid deprecation mode. Fix by replacing it with either `TargetMode.NOTIFY` (warn-only) or a callable target (forwarding):
+
+```python
+# BEFORE (v0.8 — UserWarning now, TypeError in v1.0)
+@deprecated(target=False, deprecated_in="1.0", remove_in="2.0")
+def my_func(x: int) -> int:
+    return x * 2
+
+
+# AFTER — use TargetMode.NOTIFY (warn-only, body executes)
+from deprecate import TargetMode, deprecated
+
+
+@deprecated(target=TargetMode.NOTIFY, deprecated_in="1.0", remove_in="2.0")
+def my_func(x: int) -> int:
+    return x * 2
+```
+
+The same applies inside `deprecated_class()` and the proxy path — `target=False` is invalid in all contexts.
+
+### Misconfigured `TargetMode` combinations
+
+**Current behaviour (v0.8):** Three combinations emit `UserWarning` at decoration time.
+
+**v1.0 behaviour:** All three raise `TypeError` at decoration time.
+
+| Misconfiguration                               | Fix                                                                                            |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `TargetMode.ARGS_REMAP` without `args_mapping` | Add `args_mapping={"old": "new"}`, or switch to `TargetMode.NOTIFY` if you only need a warning |
+| `TargetMode.NOTIFY` with `args_mapping`        | Switch to `TargetMode.ARGS_REMAP` if you want argument remapping, or remove `args_mapping`     |
+| `TargetMode.NOTIFY` with `args_extra`          | Switch to a callable `target=` if you need to inject extra kwargs into a forwarded call        |
+
+### `DeprecationWrapperInfo` field renames
+
+**Current behaviour (v0.8):** `empty_mapping` and `identity_mapping` are deprecated property aliases that emit `DeprecationWarning` on access.
+
+**v1.0 behaviour:** Both old names are removed.
+
+```python
+# BEFORE (emits DeprecationWarning; removed in v1.0)
+info.empty_mapping
+info.identity_mapping
+dataclasses.replace(info, empty_mapping=True)
+
+# AFTER
+info.empty_args_mapping
+info.identity_args_mapping
+dataclasses.replace(info, empty_args_mapping=True)
+```
+
+______________________________________________________________________
+
+## Upgrade to v0.8
+
+v0.8 introduced the `TargetMode` enum as the canonical API for non-callable `target` values. The legacy boolean sentinels (`None`, `True`, `False`) still work but emit deprecation warnings as described above. The key additions in v0.8 are:
+
+- `TargetMode.NOTIFY` — replaces `target=None`; warn-only mode where the function body runs unchanged.
+- `TargetMode.ARGS_REMAP` — replaces `target=True`; argument-rename mode where kwargs are remapped and the body runs.
+- Construction-time `UserWarning` for all misconfigured `TargetMode` combinations.
+- `target` parameter of `@deprecated` now defaults to `TargetMode.NOTIFY`, so `@deprecated(deprecated_in="1.0", remove_in="2.0")` is the canonical warn-only form.
+- `DeprecationWrapperInfo` field renames: `empty_mapping` → `empty_args_mapping`, `identity_mapping` → `identity_args_mapping`.
+- New `DeprecationWrapperInfo.empty_deprecated_in` field for CI detection of wrappers with no version annotation.
+
+See the [Changelog](../changelog.md) for the complete v0.8 release notes.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,22 +1,20 @@
 ---
 id: migration
-description: 'Upgrade guide for pyDeprecate: breaking changes introduced in v1.0 and v0.8, with concrete before/after code snippets for each item.'
+description: Align your pyDeprecate usage with the current idiomatic API — each section shows the legacy shorthand and the cleaner modern form, with a note on why the new pattern is clearer.
 ---
 
 # Migration Guide
 
-## Upgrade to Latest API (v1.0)
+## Align with the Current API
 
-pyDeprecate v1.0 will introduce several breaking changes that were soft-deprecated with `UserWarning` or `FutureWarning` in v0.8. Each item below shows the warning you see now, explains what will break in v1.0, and gives the corrected code.
+v0.8 introduced `TargetMode` as the explicit, readable way to express deprecation intent. If you are still using the legacy boolean shorthands (`None`, `True`, `False` as `target` values), the snippets below show the modern equivalent — they are clearer, pass linting cleanly, and are what we will require going forward.
 
 ### `target=None` → `TargetMode.NOTIFY`
 
-**Current behaviour (v0.8):** `target=None` is accepted but emits a `FutureWarning` at decoration time.
-
-**v1.0 behaviour:** `target=None` raises `TypeError` immediately at decoration time.
+`target=None` was a magic sentinel meaning "emit a deprecation notice, then run the function body". Using it today emits a `FutureWarning` at decoration time because the intent was ambiguous — `None` could plausibly mean "no target" rather than "notify-only mode". `TargetMode.NOTIFY` says that intent explicitly. Better still, `TargetMode.NOTIFY` is the default, so you can often drop `target` entirely:
 
 ```python
-# BEFORE (v0.8 — emits FutureWarning; breaks in v1.0)
+# Legacy form — still works, but emits FutureWarning
 from deprecate import deprecated
 
 
@@ -25,8 +23,8 @@ def my_func(x: int) -> int:
     return x * 2
 
 
-# AFTER — use TargetMode.NOTIFY, or omit target entirely (defaults to NOTIFY)
-from deprecate import TargetMode, deprecated
+# Idiomatic pyDeprecate — target omitted; NOTIFY is the default
+from deprecate import deprecated
 
 
 @deprecated(deprecated_in="1.0", remove_in="2.0")
@@ -34,16 +32,14 @@ def my_func(x: int) -> int:
     return x * 2
 ```
 
-`TargetMode.NOTIFY` is the default when `target` is omitted; it emits a deprecation warning on every call and then executes the function body as normal.
+`TargetMode.NOTIFY` emits a deprecation notice on every call and then executes the function body as normal.
 
 ### `target=True` → `TargetMode.ARGS_REMAP`
 
-**Current behaviour (v0.8):** `target=True` is accepted but emits a `FutureWarning` at decoration time.
-
-**v1.0 behaviour:** `target=True` raises `TypeError` immediately at decoration time.
+`target=True` was the shorthand for argument-rename mode — it told pyDeprecate to remap kwargs and run the function body. Using a boolean for this was always a bit of a guess for readers; `TargetMode.ARGS_REMAP` makes the intent self-documenting:
 
 ```python
-# BEFORE (v0.8 — emits FutureWarning; breaks in v1.0)
+# Legacy form — still works, but emits FutureWarning
 from deprecate import deprecated
 
 
@@ -52,7 +48,7 @@ def my_func(old_arg: int = 0, new_arg: int = 0) -> int:
     return new_arg * 2
 
 
-# AFTER — use TargetMode.ARGS_REMAP explicitly
+# Modern form
 from deprecate import TargetMode, deprecated
 
 
@@ -61,22 +57,18 @@ def my_func(old_arg: int = 0, new_arg: int = 0) -> int:
     return new_arg * 2
 ```
 
-### `target=False` → remove the decorator
+### `target=False` → `TargetMode.NOTIFY` or a callable target
 
-**Current behaviour (v0.8):** `target=False` emits a `UserWarning` at decoration time and falls through to `TargetMode.NOTIFY`.
-
-**v1.0 behaviour:** `target=False` raises `TypeError` immediately at decoration time.
-
-`target=False` was never a valid deprecation mode. Fix by replacing it with either `TargetMode.NOTIFY` (warn-only) or a callable target (forwarding):
+`target=False` was never a well-defined mode — passing `False` as a target callable made no semantic sense, so pyDeprecate fell through to `TargetMode.NOTIFY` while emitting a `UserWarning`. The modern form picks the mode you actually want:
 
 ```python
-# BEFORE (v0.8 — UserWarning now, TypeError in v1.0)
+# Legacy form — UserWarning now; invalid going forward
 @deprecated(target=False, deprecated_in="1.0", remove_in="2.0")
 def my_func(x: int) -> int:
     return x * 2
 
 
-# AFTER — use TargetMode.NOTIFY (warn-only, body executes)
+# Modern form — warn only, body executes unchanged
 from deprecate import TargetMode, deprecated
 
 
@@ -85,33 +77,29 @@ def my_func(x: int) -> int:
     return x * 2
 ```
 
-The same applies inside `deprecated_class()` and the proxy path — `target=False` is invalid in all contexts.
+The same applies inside `deprecated_class()` and the proxy path — `target=False` is not a valid mode in any context.
 
 ### Misconfigured `TargetMode` combinations
 
-**Current behaviour (v0.8):** Three combinations emit `UserWarning` at decoration time.
+Some `TargetMode` + argument combinations are contradictory; pyDeprecate emits a `UserWarning` at decoration time when it detects them. Resolving these makes the intent unambiguous and silences the notice:
 
-**v1.0 behaviour:** All three raise `TypeError` at decoration time.
-
-| Misconfiguration                               | Fix                                                                                            |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `TargetMode.ARGS_REMAP` without `args_mapping` | Add `args_mapping={"old": "new"}`, or switch to `TargetMode.NOTIFY` if you only need a warning |
-| `TargetMode.NOTIFY` with `args_mapping`        | Switch to `TargetMode.ARGS_REMAP` if you want argument remapping, or remove `args_mapping`     |
-| `TargetMode.NOTIFY` with `args_extra`          | Switch to a callable `target=` if you need to inject extra kwargs into a forwarded call        |
+| Combination                                    | Cleaner alternative                                                                                       |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `TargetMode.ARGS_REMAP` without `args_mapping` | Add `args_mapping={"old": "new"}`, or switch to `TargetMode.NOTIFY` if you only need a deprecation notice |
+| `TargetMode.NOTIFY` with `args_mapping`        | Switch to `TargetMode.ARGS_REMAP` if you want argument remapping, or remove `args_mapping`                |
+| `TargetMode.NOTIFY` with `args_extra`          | Use a callable `target=` if you need to inject extra kwargs into a forwarded call                         |
 
 ### `DeprecationWrapperInfo` field renames
 
-**Current behaviour (v0.8):** `empty_mapping` and `identity_mapping` are deprecated property aliases that emit `DeprecationWarning` on access.
-
-**v1.0 behaviour:** Both old names are removed.
+Two fields on `DeprecationWrapperInfo` were renamed in v0.8 to be consistent with the rest of the API. The old names still work but emit a `DeprecationWarning` on access — swapping them out is a one-line change:
 
 ```python
-# BEFORE (emits DeprecationWarning; removed in v1.0)
+# Legacy names — emit DeprecationWarning on access
 info.empty_mapping
 info.identity_mapping
 dataclasses.replace(info, empty_mapping=True)
 
-# AFTER
+# Modern names
 info.empty_args_mapping
 info.identity_args_mapping
 dataclasses.replace(info, empty_args_mapping=True)
@@ -119,9 +107,9 @@ dataclasses.replace(info, empty_args_mapping=True)
 
 ______________________________________________________________________
 
-## Upgrade to v0.8
+## Coming from v0.7
 
-v0.8 introduced the `TargetMode` enum as the canonical API for non-callable `target` values. The legacy boolean sentinels (`None`, `True`, `False`) still work but emit deprecation warnings as described above. The key additions in v0.8 are:
+Here is what changed in v0.8 that you might have missed:
 
 - `TargetMode.NOTIFY` — replaces `target=None`; warn-only mode where the function body runs unchanged.
 - `TargetMode.ARGS_REMAP` — replaces `target=True`; argument-rename mode where kwargs are remapped and the body runs.
@@ -131,3 +119,7 @@ v0.8 introduced the `TargetMode` enum as the canonical API for non-callable `tar
 - New `DeprecationWrapperInfo.empty_deprecated_in` field for CI detection of wrappers with no version annotation.
 
 See the [Changelog](../changelog.md) for the complete v0.8 release notes.
+
+______________________________________________________________________
+
+If you hit anything not covered here, [open an issue](https://github.com/Borda/pyDeprecate/issues) — we are happy to help.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -132,6 +132,8 @@ dataclasses.replace(info, empty_args_mapping=True)
 
 **`DeprecationWrapperInfo.empty_deprecated_in: bool`** (v0.8+) — `True` when the wrapper's `deprecated_in` string is absent or empty. Included in `dataclasses.asdict()` and `repr()`. Use in CI pipelines to surface wrappers with no version annotation.
 
+**Install vs import name confusion** — import as `deprecate`, not `pydeprecate` (install: `pip install pyDeprecate`; import: `from deprecate import deprecated`).
+
 ### Decision Flowchart
 
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,6 +7,24 @@ description: 'Fix common pyDeprecate errors: missing deprecation notices, TypeEr
 
 This page covers the most common problems encountered when using pyDeprecate, with direct answers and corrected code for each. If your issue is not listed here, see the "Still stuck?" section at the bottom.
 
+## ModuleNotFoundError: No module named 'pydeprecate'
+
+**Q:** I installed the package with `pip install pyDeprecate` but get `ModuleNotFoundError: No module named 'pydeprecate'` when I try to import it.
+
+**A:** The install name and the import name are different. The package installs as `pyDeprecate` but imports as `deprecate`.
+
+Use:
+
+```python
+from deprecate import deprecated
+```
+
+Not:
+
+```python
+from pydeprecate import deprecated  # wrong — no such module
+```
+
 ## UserWarning when decorating a class
 
 **Q:** I applied `@deprecated` directly to a class and got `UserWarning: Direct use of @deprecated on class MyClass is deprecated since v0.6.0. Use @deprecated_class(...) instead. This will become a TypeError in a future release.` Why, and how do I fix it?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,7 @@ from deprecate import deprecated
 Not:
 
 ```python
+# phmdoctest:skip
 from pydeprecate import deprecated  # wrong — no such module
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - Audit Tools: guide/audit.md
       - CLI: guide/cli.md
       - Customization: guide/customization.md
+      - Migration Guide: guide/migration.md
   - Troubleshooting: troubleshooting.md
   - Changelog: changelog.md
   - Demos:

--- a/src/deprecate/_types.py
+++ b/src/deprecate/_types.py
@@ -19,11 +19,11 @@ class TargetMode(Enum):
     Members:
         NOTIFY: Notify-only deprecation -- warn on every call; original body executes unchanged. Replaces
             ``target=None``. Passing ``args_mapping`` or ``args_extra`` with this mode emits a :class:`UserWarning`
-            today; :class:`TypeError` is planned in v1.0.
+            today; :class:`TypeError` is planned in ``v1.0`` (see ``docs/guide/migration.md``).
         ARGS_REMAP: Deprecate argument names only -- warn only when deprecated argument names are passed; remaps
             kwargs via ``args_mapping`` before calling the original body. Replaces ``target=True``. This mode is
             strongly recommended with ``args_mapping``; omitting it emits a :class:`UserWarning` today, and
-            :class:`TypeError` is planned in v1.0.
+            :class:`TypeError` is planned in ``v1.0`` (see ``docs/guide/migration.md``).
 
     Examples:
         >>> from deprecate import TargetMode
@@ -51,7 +51,8 @@ class TargetMode(Enum):
 
         Args:
             target: Legacy sentinel — ``None`` → :attr:`TargetMode.NOTIFY`, ``True`` → :attr:`TargetMode.ARGS_REMAP`,
-                ``False`` → :attr:`TargetMode.NOTIFY` (not a valid mode; :class:`TypeError` in v1.0).
+                ``False`` → :attr:`TargetMode.NOTIFY` (not a valid mode; :class:`TypeError` in v1.0 —
+                see ``docs/guide/migration.md``).
             stacklevel: Stack level forwarded to :func:`warnings.warn`.  Pass ``None`` to suppress all warnings
                 entirely.  Defaults to ``3``.
 
@@ -73,7 +74,8 @@ class TargetMode(Enum):
         if target is None:
             if stacklevel is not None:
                 warnings.warn(
-                    "target=None is deprecated since v0.8; use TargetMode.NOTIFY instead. Will be removed in v1.0.",
+                    "target=None is deprecated since `v0.8`; use `TargetMode.NOTIFY` instead."
+                    " Will be removed in `v1.0`. See docs/guide/migration.md for upgrade steps.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -81,7 +83,8 @@ class TargetMode(Enum):
         if target is True:
             if stacklevel is not None:
                 warnings.warn(
-                    "target=True is deprecated since v0.8; use TargetMode.ARGS_REMAP instead. Will be removed in v1.0.",
+                    "target=True is deprecated since `v0.8`; use `TargetMode.ARGS_REMAP` instead."
+                    " Will be removed in `v1.0`. See docs/guide/migration.md for upgrade steps.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -89,8 +92,8 @@ class TargetMode(Enum):
         if target is False:
             if stacklevel is not None:
                 warnings.warn(
-                    "'target=False' is not a valid deprecation mode and will be treated as TargetMode.NOTIFY."
-                    " This will be TypeError in v1.0.",
+                    "`target=False` is not a valid deprecation mode and will be treated as `TargetMode.NOTIFY`."
+                    " This will be `TypeError` in `v1.0`. See docs/guide/migration.md for upgrade steps.",
                     UserWarning,
                     stacklevel=stacklevel,
                 )
@@ -144,16 +147,17 @@ class TargetMode(Enum):
             if args_mapping:
                 if stacklevel is not None:
                     warnings.warn(
-                        "target=True with args_mapping will resolve to TargetMode.ARGS_REMAP."
-                        " Will be TypeError in v1.0.",
+                        "`target=True` with `args_mapping` will resolve to `TargetMode.ARGS_REMAP`."
+                        " Will be `TypeError` in `v1.0`. See docs/guide/migration.md for upgrade steps.",
                         FutureWarning,
                         stacklevel=stacklevel,
                     )
                 return cls.ARGS_REMAP
             if stacklevel is not None:
                 warnings.warn(
-                    "target=True without args_mapping resolves to TargetMode.NOTIFY"
-                    " (warns on every access). Will be TypeError in v1.0.",
+                    "`target=True` without `args_mapping` resolves to `TargetMode.NOTIFY`"
+                    " (warns on every access). Will be `TypeError` in `v1.0`."
+                    " See docs/guide/migration.md for upgrade steps.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -161,7 +165,8 @@ class TargetMode(Enum):
         if target is False:
             if stacklevel is not None:
                 warnings.warn(
-                    "target=False is not valid for deprecated_class(). Will be TypeError in v1.0.",
+                    "`target=False` is not valid for `deprecated_class()`. Will be `TypeError` in `v1.0`."
+                    " See docs/guide/migration.md for upgrade steps.",
                     UserWarning,
                     stacklevel=stacklevel,
                 )
@@ -181,7 +186,7 @@ class TargetMode(Enum):
         """Validate a :class:`TargetMode` against the supplied configuration and emit misconfig warnings.
 
         Checks three misconfiguration combinations and emits a :class:`UserWarning` for each one found.
-        These warnings will become :class:`TypeError` in v1.0.
+        These warnings will become :class:`TypeError` in ``v1.0`` (see ``docs/guide/migration.md``).
 
         Misconfiguration warnings are always emitted via :func:`warnings.warn` with ``UserWarning`` — they are
         construction-time guards independent of the runtime ``stream`` callable used for deprecation notices.
@@ -213,19 +218,22 @@ class TargetMode(Enum):
             messages.append(
                 f"`@deprecated(target=TargetMode.ARGS_REMAP)` on `{source_name}` requires "
                 "`args_mapping` to specify which arguments are being renamed. Without it the "
-                "decorator has zero effect. This will be TypeError in v1.0."
+                "decorator has zero effect. This will be `TypeError` in `v1.0`."
+                " See docs/guide/migration.md for upgrade steps."
             )
         if mode is cls.NOTIFY and args_mapping:
             messages.append(
                 f"`@deprecated(target=TargetMode.NOTIFY)` on `{source_name}` ignores "
                 "`args_mapping`. Use `TargetMode.ARGS_REMAP` to rename arguments, or pass a "
-                "callable target to forward the call. This will be TypeError in v1.0."
+                "callable target to forward the call. This will be `TypeError` in `v1.0`."
+                " See docs/guide/migration.md for upgrade steps."
             )
         if mode is cls.NOTIFY and args_extra:
             messages.append(
                 f"`@deprecated(target=TargetMode.NOTIFY)` on `{source_name}` ignores "
                 "`args_extra`. Use a callable target to forward with extra arguments. "
-                "This will be TypeError in v1.0."
+                "This will be `TypeError` in `v1.0`."
+                " See docs/guide/migration.md for upgrade steps."
             )
         if stacklevel is not None:
             for msg in messages:

--- a/src/deprecate/_types.py
+++ b/src/deprecate/_types.py
@@ -19,11 +19,11 @@ class TargetMode(Enum):
     Members:
         NOTIFY: Notify-only deprecation -- warn on every call; original body executes unchanged. Replaces
             ``target=None``. Passing ``args_mapping`` or ``args_extra`` with this mode emits a :class:`UserWarning`
-            today; :class:`TypeError` is planned in ``v1.0`` (see ``docs/guide/migration.md``).
+            today; :class:`TypeError` is planned in ``v1.0`` (see ``https://borda.github.io/pyDeprecate/guide/migration/``).
         ARGS_REMAP: Deprecate argument names only -- warn only when deprecated argument names are passed; remaps
             kwargs via ``args_mapping`` before calling the original body. Replaces ``target=True``. This mode is
             strongly recommended with ``args_mapping``; omitting it emits a :class:`UserWarning` today, and
-            :class:`TypeError` is planned in ``v1.0`` (see ``docs/guide/migration.md``).
+            :class:`TypeError` is planned in ``v1.0`` (see ``https://borda.github.io/pyDeprecate/guide/migration/``).
 
     Examples:
         >>> from deprecate import TargetMode
@@ -52,7 +52,7 @@ class TargetMode(Enum):
         Args:
             target: Legacy sentinel — ``None`` → :attr:`TargetMode.NOTIFY`, ``True`` → :attr:`TargetMode.ARGS_REMAP`,
                 ``False`` → :attr:`TargetMode.NOTIFY` (not a valid mode; :class:`TypeError` in v1.0 —
-                see ``docs/guide/migration.md``).
+                see ``https://borda.github.io/pyDeprecate/guide/migration/``).
             stacklevel: Stack level forwarded to :func:`warnings.warn`.  Pass ``None`` to suppress all warnings
                 entirely.  Defaults to ``3``.
 
@@ -75,7 +75,8 @@ class TargetMode(Enum):
             if stacklevel is not None:
                 warnings.warn(
                     "target=None is deprecated since `v0.8`; use `TargetMode.NOTIFY` instead."
-                    " Will be removed in `v1.0`. See docs/guide/migration.md for upgrade steps.",
+                    " Will be removed in `v1.0`."
+                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -84,7 +85,8 @@ class TargetMode(Enum):
             if stacklevel is not None:
                 warnings.warn(
                     "target=True is deprecated since `v0.8`; use `TargetMode.ARGS_REMAP` instead."
-                    " Will be removed in `v1.0`. See docs/guide/migration.md for upgrade steps.",
+                    " Will be removed in `v1.0`."
+                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -93,7 +95,8 @@ class TargetMode(Enum):
             if stacklevel is not None:
                 warnings.warn(
                     "`target=False` is not a valid deprecation mode and will be treated as `TargetMode.NOTIFY`."
-                    " This will be `TypeError` in `v1.0`. See docs/guide/migration.md for upgrade steps.",
+                    " This will be `TypeError` in `v1.0`."
+                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
                     UserWarning,
                     stacklevel=stacklevel,
                 )
@@ -148,7 +151,8 @@ class TargetMode(Enum):
                 if stacklevel is not None:
                     warnings.warn(
                         "`target=True` with `args_mapping` will resolve to `TargetMode.ARGS_REMAP`."
-                        " Will be `TypeError` in `v1.0`. See docs/guide/migration.md for upgrade steps.",
+                        " Will be `TypeError` in `v1.0`."
+                        " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
                         FutureWarning,
                         stacklevel=stacklevel,
                     )
@@ -157,7 +161,7 @@ class TargetMode(Enum):
                 warnings.warn(
                     "`target=True` without `args_mapping` resolves to `TargetMode.NOTIFY`"
                     " (warns on every access). Will be `TypeError` in `v1.0`."
-                    " See docs/guide/migration.md for upgrade steps.",
+                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -166,7 +170,7 @@ class TargetMode(Enum):
             if stacklevel is not None:
                 warnings.warn(
                     "`target=False` is not valid for `deprecated_class()`. Will be `TypeError` in `v1.0`."
-                    " See docs/guide/migration.md for upgrade steps.",
+                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
                     UserWarning,
                     stacklevel=stacklevel,
                 )
@@ -186,7 +190,7 @@ class TargetMode(Enum):
         """Validate a :class:`TargetMode` against the supplied configuration and emit misconfig warnings.
 
         Checks three misconfiguration combinations and emits a :class:`UserWarning` for each one found.
-        These warnings will become :class:`TypeError` in ``v1.0`` (see ``docs/guide/migration.md``).
+        These warnings will become :class:`TypeError` in ``v1.0`` (see ``https://borda.github.io/pyDeprecate/guide/migration/``).
 
         Misconfiguration warnings are always emitted via :func:`warnings.warn` with ``UserWarning`` — they are
         construction-time guards independent of the runtime ``stream`` callable used for deprecation notices.
@@ -219,21 +223,21 @@ class TargetMode(Enum):
                 f"`@deprecated(target=TargetMode.ARGS_REMAP)` on `{source_name}` requires "
                 "`args_mapping` to specify which arguments are being renamed. Without it the "
                 "decorator has zero effect. This will be `TypeError` in `v1.0`."
-                " See docs/guide/migration.md for upgrade steps."
+                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps."
             )
         if mode is cls.NOTIFY and args_mapping:
             messages.append(
                 f"`@deprecated(target=TargetMode.NOTIFY)` on `{source_name}` ignores "
                 "`args_mapping`. Use `TargetMode.ARGS_REMAP` to rename arguments, or pass a "
                 "callable target to forward the call. This will be `TypeError` in `v1.0`."
-                " See docs/guide/migration.md for upgrade steps."
+                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps."
             )
         if mode is cls.NOTIFY and args_extra:
             messages.append(
                 f"`@deprecated(target=TargetMode.NOTIFY)` on `{source_name}` ignores "
                 "`args_extra`. Use a callable target to forward with extra arguments. "
                 "This will be `TypeError` in `v1.0`."
-                " See docs/guide/migration.md for upgrade steps."
+                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps."
             )
         if stacklevel is not None:
             for msg in messages:

--- a/src/deprecate/_types.py
+++ b/src/deprecate/_types.py
@@ -19,11 +19,11 @@ class TargetMode(Enum):
     Members:
         NOTIFY: Notify-only deprecation -- warn on every call; original body executes unchanged. Replaces
             ``target=None``. Passing ``args_mapping`` or ``args_extra`` with this mode emits a :class:`UserWarning`
-            today; :class:`TypeError` is planned in ``v1.0`` (see ``https://borda.github.io/pyDeprecate/guide/migration/``).
+            today; :class:`TypeError` is planned in ``v1.0``.
         ARGS_REMAP: Deprecate argument names only -- warn only when deprecated argument names are passed; remaps
             kwargs via ``args_mapping`` before calling the original body. Replaces ``target=True``. This mode is
             strongly recommended with ``args_mapping``; omitting it emits a :class:`UserWarning` today, and
-            :class:`TypeError` is planned in ``v1.0`` (see ``https://borda.github.io/pyDeprecate/guide/migration/``).
+            :class:`TypeError` is planned in ``v1.0``.
 
     Examples:
         >>> from deprecate import TargetMode
@@ -51,8 +51,7 @@ class TargetMode(Enum):
 
         Args:
             target: Legacy sentinel — ``None`` → :attr:`TargetMode.NOTIFY`, ``True`` → :attr:`TargetMode.ARGS_REMAP`,
-                ``False`` → :attr:`TargetMode.NOTIFY` (not a valid mode; :class:`TypeError` in v1.0 —
-                see ``https://borda.github.io/pyDeprecate/guide/migration/``).
+                ``False`` → :attr:`TargetMode.NOTIFY` (not a valid mode; :class:`TypeError` in v1.0).
             stacklevel: Stack level forwarded to :func:`warnings.warn`.  Pass ``None`` to suppress all warnings
                 entirely.  Defaults to ``3``.
 
@@ -75,8 +74,7 @@ class TargetMode(Enum):
             if stacklevel is not None:
                 warnings.warn(
                     "target=None is deprecated since `v0.8`; use `TargetMode.NOTIFY` instead."
-                    " Will be removed in `v1.0`."
-                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
+                    " Will be removed in `v1.0`.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -85,8 +83,7 @@ class TargetMode(Enum):
             if stacklevel is not None:
                 warnings.warn(
                     "target=True is deprecated since `v0.8`; use `TargetMode.ARGS_REMAP` instead."
-                    " Will be removed in `v1.0`."
-                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
+                    " Will be removed in `v1.0`.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -95,8 +92,7 @@ class TargetMode(Enum):
             if stacklevel is not None:
                 warnings.warn(
                     "`target=False` is not a valid deprecation mode and will be treated as `TargetMode.NOTIFY`."
-                    " This will be `TypeError` in `v1.0`."
-                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
+                    " This will be `TypeError` in `v1.0`.",
                     UserWarning,
                     stacklevel=stacklevel,
                 )
@@ -151,8 +147,7 @@ class TargetMode(Enum):
                 if stacklevel is not None:
                     warnings.warn(
                         "`target=True` with `args_mapping` will resolve to `TargetMode.ARGS_REMAP`."
-                        " Will be `TypeError` in `v1.0`."
-                        " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
+                        " Will be `TypeError` in `v1.0`.",
                         FutureWarning,
                         stacklevel=stacklevel,
                     )
@@ -160,8 +155,7 @@ class TargetMode(Enum):
             if stacklevel is not None:
                 warnings.warn(
                     "`target=True` without `args_mapping` resolves to `TargetMode.NOTIFY`"
-                    " (warns on every access). Will be `TypeError` in `v1.0`."
-                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
+                    " (warns on every access). Will be `TypeError` in `v1.0`.",
                     FutureWarning,
                     stacklevel=stacklevel,
                 )
@@ -169,8 +163,7 @@ class TargetMode(Enum):
         if target is False:
             if stacklevel is not None:
                 warnings.warn(
-                    "`target=False` is not valid for `deprecated_class()`. Will be `TypeError` in `v1.0`."
-                    " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
+                    "`target=False` is not valid for `deprecated_class()`. Will be `TypeError` in `v1.0`.",
                     UserWarning,
                     stacklevel=stacklevel,
                 )
@@ -190,7 +183,7 @@ class TargetMode(Enum):
         """Validate a :class:`TargetMode` against the supplied configuration and emit misconfig warnings.
 
         Checks three misconfiguration combinations and emits a :class:`UserWarning` for each one found.
-        These warnings will become :class:`TypeError` in ``v1.0`` (see ``https://borda.github.io/pyDeprecate/guide/migration/``).
+        These warnings will become :class:`TypeError` in ``v1.0``.
 
         Misconfiguration warnings are always emitted via :func:`warnings.warn` with ``UserWarning`` — they are
         construction-time guards independent of the runtime ``stream`` callable used for deprecation notices.
@@ -223,21 +216,18 @@ class TargetMode(Enum):
                 f"`@deprecated(target=TargetMode.ARGS_REMAP)` on `{source_name}` requires "
                 "`args_mapping` to specify which arguments are being renamed. Without it the "
                 "decorator has zero effect. This will be `TypeError` in `v1.0`."
-                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps."
             )
         if mode is cls.NOTIFY and args_mapping:
             messages.append(
                 f"`@deprecated(target=TargetMode.NOTIFY)` on `{source_name}` ignores "
                 "`args_mapping`. Use `TargetMode.ARGS_REMAP` to rename arguments, or pass a "
                 "callable target to forward the call. This will be `TypeError` in `v1.0`."
-                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps."
             )
         if mode is cls.NOTIFY and args_extra:
             messages.append(
                 f"`@deprecated(target=TargetMode.NOTIFY)` on `{source_name}` ignores "
                 "`args_extra`. Use a callable target to forward with extra arguments. "
                 "This will be `TypeError` in `v1.0`."
-                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps."
             )
         if stacklevel is not None:
             for msg in messages:

--- a/tests/integration/test_target_mode.py
+++ b/tests/integration/test_target_mode.py
@@ -340,7 +340,7 @@ class TestLegacySentinels:
 
     def test_false_emits_user_warning(self) -> None:
         """target=False is not valid — should warn at decoration time."""
-        with pytest.warns(UserWarning, match="target=False' is not a valid deprecation mode"):
+        with pytest.warns(UserWarning, match=r"target=False.*is not a valid deprecation mode"):
 
             @deprecated(target=False, deprecated_in="0.1", remove_in="0.5")
             def _fn(x: int) -> int:

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -515,14 +515,12 @@ class TestDecoratorFactory:
                 True,
                 FutureWarning,
                 "`target=True` without `args_mapping` resolves to `TargetMode.NOTIFY`"
-                " (warns on every access). Will be `TypeError` in `v1.0`."
-                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
+                " (warns on every access). Will be `TypeError` in `v1.0`.",
             ),
             (
                 False,
                 UserWarning,
-                "`target=False` is not valid for `deprecated_class()`. Will be `TypeError` in `v1.0`."
-                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
+                "`target=False` is not valid for `deprecated_class()`. Will be `TypeError` in `v1.0`.",
             ),
         ],
     )

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -514,13 +514,15 @@ class TestDecoratorFactory:
             (
                 True,
                 FutureWarning,
-                "target=True without args_mapping resolves to TargetMode.NOTIFY"
-                " (warns on every access). Will be TypeError in v1.0.",
+                "`target=True` without `args_mapping` resolves to `TargetMode.NOTIFY`"
+                " (warns on every access). Will be `TypeError` in `v1.0`."
+                " See docs/guide/migration.md for upgrade steps.",
             ),
             (
                 False,
                 UserWarning,
-                "target=False is not valid for deprecated_class(). Will be TypeError in v1.0.",
+                "`target=False` is not valid for `deprecated_class()`. Will be `TypeError` in `v1.0`."
+                " See docs/guide/migration.md for upgrade steps.",
             ),
         ],
     )

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -516,13 +516,13 @@ class TestDecoratorFactory:
                 FutureWarning,
                 "`target=True` without `args_mapping` resolves to `TargetMode.NOTIFY`"
                 " (warns on every access). Will be `TypeError` in `v1.0`."
-                " See docs/guide/migration.md for upgrade steps.",
+                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
             ),
             (
                 False,
                 UserWarning,
                 "`target=False` is not valid for `deprecated_class()`. Will be `TypeError` in `v1.0`."
-                " See docs/guide/migration.md for upgrade steps.",
+                " See https://borda.github.io/pyDeprecate/guide/migration/ for upgrade steps.",
             ),
         ],
     )


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- docs/guide/migration.md: new migration guide; v1.0 breaking changes + v0.8 upgrade section
- README: TIP block showing 3 stdlib-can't-do scenarios before comparison matrix (F3)
- README: core-vs-advanced hint + separator row in API-at-a-Glance params table (F6)
- README + troubleshooting.md + llms.txt: single install/import name callout (F10)
- _types.py: backtick-format warning messages; add docs/guide/migration.md refs
- tests: update exact-string assertions to match reformatted warning messages

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
