### PR TITLE
fix: PEP 702 crash, decoration-time guards, and docs for v0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ While `pyDeprecate` focuses on comprehensive forwarding and argument mapping, ot
 > [!NOTE]
 > This comparison is compiled to the best of our knowledge and we're happy to make any justified corrections. If you spot an inaccuracy, please [open an issue](https://github.com/Borda/pyDeprecate/issues) or submit a PR.
 
-> **Note:** Every deprecation variant writes the same `DeprecationConfig` — `@deprecated`, `deprecated_class`, `deprecated_instance`, and the audit tools all read from a single source of truth. This means your CI pipeline (`pydeprecate check src/`) catches misconfigured wrappers across all three variants with one scan.
+> [!NOTE]
+> Every deprecation variant writes the same `DeprecationConfig` — `@deprecated`, `deprecated_class`, `deprecated_instance`, and the audit tools all read from a single source of truth. This means your CI pipeline (`pydeprecate check src/`) catches misconfigured wrappers across all three variants with one scan.
 
 ## 💾 Installation
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Not sure which API to reach for? Start here.
 
 > [!TIP]
 > `@deprecated_class()` shares `target`, `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_mapping`, `args_extra`, and `template_mgs`.
-> `deprecated_instance()` shares `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_extra`, and `template_mgs`; it requires `obj` and adds `name` (display name) and `read_only`.
+> `deprecated_instance()` shares `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_extra`, and `template_mgs`; it requires `obj` and adds `name` (display name) and `read_only` (blocks standard collection mutators: `append`, `pop`, `update`, etc.; custom mutator names bypass this guard).
 
 </details>
 
@@ -708,7 +708,9 @@ TRAINING_CONFIG = {"lr": 0.001, "batch_size": 32, "epochs": 10}
 # DEFAULTS = {"lr": 0.001, "batch_size": 32, "epochs": 10}
 
 # DEPRECATED API — `DEFAULTS` was the original name; read-only so
-# callers cannot mutate shared state through the deprecated alias
+# callers cannot mutate shared state through the deprecated alias.
+# Note: read_only=True blocks only standard collection mutators (append, pop,
+# update, etc.); custom method names on the wrapped object bypass this guard.
 DEFAULTS = deprecated_instance(
     TRAINING_CONFIG,
     deprecated_in="1.2",

--- a/README.md
+++ b/README.md
@@ -108,33 +108,35 @@ While `pyDeprecate` focuses on comprehensive forwarding and argument mapping, ot
 
 </details>
 
+> **When to prefer `warnings.deprecated` (PEP 702):** If your project targets Python 3.13+ and you only need simple call-site warnings visible to static type-checkers (mypy, pyright, IDEs), the stdlib decorator is the right choice — zero extra dependency. `warnings.warn` tells users what is deprecated; pyDeprecate tells users what to use instead and does the forwarding for them. Choose `pyDeprecate` when you need call-forwarding, argument remapping, proxy wrapping of module-level constants, or CI audit tools — none of those exist in PEP 702. On Python < 3.13, `typing_extensions.deprecated` requires `typing_extensions` (marked ✍️ for that reason).
+
 <br>
 
-| _Feature_                | `pyDeprecate` | `warnings.warn` (stdlib) | `deprecation` (Lib) | `Deprecated` (wrapt) | `warnings.deprecated` (3.13+) / `typing_extensions.deprecated` |
+| _Feature_ | `pyDeprecate` | `warnings.warn` (stdlib) | `deprecation` (Lib) | `Deprecated` (wrapt) | `warnings.deprecated` (3.13+) / `typing_extensions.deprecated` |
 | ------------------------ | :-----------: | :----------------------: | :-----------------: | :------------------: | :------------------------------------------------------------: |
-| **Simple Warnings**      |      ✅       |            ✅            |         ✅          |          ✅          |                               ✅                               |
-| **Auto-Forward Calls**   |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Argument Mapping**     |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Argument Deprecation** |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
-| **Class/Instance Proxy** |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Docstring Updates**    |      ✅       |            ❌            |         ✅          |          ✅          |                               ❌                               |
-| **Version Tracking**     |      ✅       |            ✍️            |         ✅          |          ✅          |                               ❌                               |
-| **Prevent Log Spam**     |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
-| **Zero Extra Depend.**   |      ✅       |            ✅            |         ❌          |          ❌          |                               ✍️                               |
-| **Custom Streams**       |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
-| **Testing Helpers**      |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **CI/Audit Tools**       |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Decorator Stacking**   |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Sphinx Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **MkDocs Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| **Simple Warnings** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Auto-Forward Calls** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Argument Mapping** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Argument Deprecation** | ✅ | ✍️ | ❌ | ❌ | ❌ |
+| **Class/Instance Proxy** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Docstring Updates** | ✅ | ❌ | ✅ | ✅ | ❌ |
+| **Version Tracking** | ✅ | ✍️ | ✅ | ✅ | ❌ |
+| **Prevent Log Spam** | ✅ | ✍️ | ❌ | ❌ | ❌ |
+| **Zero Extra Depend.** | ✅ | ✅ | ❌ | ❌ | ✍️ |
+| **Custom Streams** | ✅ | ✍️ | ❌ | ❌ | ❌ |
+| **Testing Helpers** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **CI/Audit Tools** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Decorator Stacking** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Sphinx Plugin** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **MkDocs Plugin** | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 ✍️ = possible but requires manual implementation
 ✍️ (_Zero Extra Depend._ row) = stdlib on Python 3.13+; requires `typing_extensions` backport on Python < 3.13
 
 > [!NOTE]
 > This comparison is compiled to the best of our knowledge and we're happy to make any justified corrections. If you spot an inaccuracy, please [open an issue](https://github.com/Borda/pyDeprecate/issues) or submit a PR.
->
-> **When to prefer `warnings.deprecated` (PEP 702):** If your project targets Python 3.13+ and you only need simple call-site warnings visible to static type-checkers (mypy, pyright, IDEs), the stdlib decorator is the right choice — zero extra dependency. Choose `pyDeprecate` when you need call-forwarding, argument remapping, proxy wrapping of module-level constants, or CI audit tools — none of those exist in PEP 702. On Python < 3.13, `typing_extensions.deprecated` requires `typing_extensions` (marked ✍️ for that reason).
+
+> **Note:** Every deprecation variant writes the same `DeprecationConfig` — `@deprecated`, `deprecated_class`, `deprecated_instance`, and the audit tools all read from a single source of truth. This means your CI pipeline (`pydeprecate check src/`) catches misconfigured wrappers across all three variants with one scan.
 
 ## 💾 Installation
 
@@ -195,36 +197,36 @@ Not sure which API to reach for? Start here.
 
 **Pick the right decorator:**
 
-| Scenario                                      | API to use                                                               |
+| Scenario | API to use |
 | --------------------------------------------- | ------------------------------------------------------------------------ |
-| Renaming a function or method                 | `@deprecated(target=new_func)`                                           |
+| Renaming a function or method | `@deprecated(target=new_func)` |
 | Renaming an argument within the same function | `@deprecated(target=TargetMode.ARGS_REMAP, args_mapping={"old": "new"})` |
-| Warn only — original body still runs          | `@deprecated(deprecated_in="1.0", remove_in="2.0")`                      |
-| Deprecating a class, Enum, or dataclass name  | `@deprecated_class(target=NewClass)`                                     |
-| Deprecating a module-level constant or object | `deprecated_instance(obj, ...)`                                          |
+| Warn only — original body still runs | `@deprecated(deprecated_in="1.0", remove_in="2.0")` |
+| Deprecating a class, Enum, or dataclass name | `@deprecated_class(target=NewClass)` |
+| Deprecating a module-level constant or object | `deprecated_instance(obj, ...)` |
 
 > **Note:** Legacy `target=None` and `target=True` emit `FutureWarning` at decoration time in v0.8 and become `TypeError` in v1.0. Use `TargetMode.NOTIFY` and `TargetMode.ARGS_REMAP` respectively.
 
 <details>
   <summary><strong>All `@deprecated` parameters at a glance:</strong></summary>
 
-| Param              | Default                     | Purpose                                                                                                    |
+| Param | Default | Purpose |
 | ------------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `target`           | `TargetMode.NOTIFY`         | `Callable` to forward to · `TargetMode.ARGS_REMAP` to remap args · `TargetMode.NOTIFY` (default) warn-only |
-| `deprecated_in`    | `""`                        | Version when deprecated (e.g. `"1.0"`)                                                                     |
-| `remove_in`        | `""`                        | Version when removed (e.g. `"2.0"`)                                                                        |
-|                    | **Advanced: ~10% of cases** |                                                                                                            |
-| `stream`           | `deprecation_warning`       | Warning sink callable (set `None` to silence warnings)                                                     |
-| `num_warns`        | `1`                         | `1` once · `-1` always · `N` exactly N times                                                               |
-| `args_mapping`     | `None`                      | `{"old": "new"}` rename · `{"old": None}` drop                                                             |
-| `template_mgs`     | `None`                      | Custom warning message template (`%`-style placeholders)                                                   |
-| `args_extra`       | `None`                      | Fixed kwargs injected into the target call                                                                 |
-| `skip_if`          | `False`                     | `bool` or `Callable → bool`; skip deprecation when true                                                    |
-| `update_docstring` | `False`                     | Append Sphinx `.. deprecated::` notice to docstring                                                        |
+| `target` | `TargetMode.NOTIFY` | `Callable` to forward to · `TargetMode.ARGS_REMAP` to remap args · `TargetMode.NOTIFY` (default) warn-only |
+| `deprecated_in` | `""` | Version when deprecated (e.g. `"1.0"`) |
+| `remove_in` | `""` | Version when removed (e.g. `"2.0"`) |
+| | **Advanced: ~10% of cases** | |
+| `stream` | `deprecation_warning` | Warning sink callable (set `None` to silence warnings) |
+| `num_warns` | `1` | `1` once · `-1` always · `N` exactly N times |
+| `args_mapping` | `None` | `{"old": "new"}` rename · `{"old": None}` drop |
+| `template_mgs` | `None` | Custom warning message template (`%`-style placeholders) |
+| `args_extra` | `None` | Fixed kwargs injected into the target call |
+| `skip_if` | `False` | `bool` or `Callable → bool`; skip deprecation when true |
+| `update_docstring` | `False` | Append Sphinx `.. deprecated::` notice to docstring |
 
 > [!TIP]
 > `@deprecated_class()` shares `target`, `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_mapping`, `args_extra`, and `template_mgs`.
-> `deprecated_instance()` shares `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_extra`, and `template_mgs`; it requires `obj` and adds `name` (display name) and `read_only` (blocks standard collection mutators: `append`, `pop`, `update`, etc.; custom mutator names bypass this guard).
+> `deprecated_instance()` shares `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_extra`, and `template_mgs`; it requires `obj` and adds `name` (display name) and `read_only`.
 
 </details>
 
@@ -242,11 +244,11 @@ The functionality is kept simple and all defaults should be reasonable, but you 
 
 In particular the target values (cases):
 
-| `target` value          | Use case                                      | `args_mapping`                     | Warning trigger                    |
+| `target` value | Use case | `args_mapping` | Warning trigger |
 | ----------------------- | --------------------------------------------- | ---------------------------------- | ---------------------------------- |
-| `TargetMode.NOTIFY`     | Whole callable going away; no replacement yet | Ignored (warns; TypeError in v1.0) | Every call                         |
-| `TargetMode.ARGS_REMAP` | Callable stays; argument names are renamed    | Required                           | Only when old arg names are passed |
-| `<callable>`            | Callable replaced by another; calls forwarded | Optional                           | Every call                         |
+| `TargetMode.NOTIFY` | Whole callable going away; no replacement yet | Ignored (warns; TypeError in v1.0) | Every call |
+| `TargetMode.ARGS_REMAP` | Callable stays; argument names are renamed | Required | Only when old arg names are passed |
+| `<callable>` | Callable replaced by another; calls forwarded | Optional | Every call |
 
 > [!TIP]
 > `TargetMode.NOTIFY` replaces the old `target=None` sentinel and `TargetMode.ARGS_REMAP` replaces the old `target=True` sentinel. The old forms still work but emit a `FutureWarning` at decoration time.
@@ -698,6 +700,8 @@ strings, prefer wrapping them in a container (such as a dict or configuration ob
 directly, since arithmetic and other primitive protocol operations are not intercepted by the wrapper. The
 `name` parameter is optional; when omitted it defaults to the type name of the wrapped object.
 
+The proxy passes `isinstance(obj, OriginalClass)` and `issubclass(SubClass, OriginalClass)` checks transparently — zero changes needed in type-guard code.
+
 ```python
 from deprecate import deprecated_instance
 
@@ -708,9 +712,7 @@ TRAINING_CONFIG = {"lr": 0.001, "batch_size": 32, "epochs": 10}
 # DEFAULTS = {"lr": 0.001, "batch_size": 32, "epochs": 10}
 
 # DEPRECATED API — `DEFAULTS` was the original name; read-only so
-# callers cannot mutate shared state through the deprecated alias.
-# Note: read_only=True blocks only standard collection mutators (append, pop,
-# update, etc.); custom method names on the wrapped object bypass this guard.
+# callers cannot mutate shared state through the deprecated alias
 DEFAULTS = deprecated_instance(
     TRAINING_CONFIG,
     deprecated_in="1.2",
@@ -1182,6 +1184,24 @@ pydeprecate all path/to/your/package --version 2.0.0
 
 **Common flags** (all subcommands): `--norecursive` scans the top-level module only; `--skip_errors` always exits `0` even when issues are found.
 `expiry` and `all` also accept `--version VERSION` to set the current version explicitly.
+
+**Example: catching a deprecated-to-deprecated chain**
+
+```
+$ pydeprecate chains src/mypackage
+⚠  Deprecated chain detected: old_fn → legacy_fn → new_fn
+   old_fn is deprecated and forwards to legacy_fn, which is also deprecated.
+   Update old_fn to forward directly to new_fn.
+```
+
+**Example: combined one-liner scan across all checks**
+
+```
+$ pydeprecate all src/mypackage
+✓ check:  12 wrappers validated, 0 misconfigured
+⚠ expiry: 2 wrappers past remove_in deadline
+✓ chains: no deprecated→deprecated chains detected
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -112,23 +112,23 @@ While `pyDeprecate` focuses on comprehensive forwarding and argument mapping, ot
 
 <br>
 
-| _Feature_ | `pyDeprecate` | `warnings.warn` (stdlib) | `deprecation` (Lib) | `Deprecated` (wrapt) | `warnings.deprecated` (3.13+) / `typing_extensions.deprecated` |
+| _Feature_                | `pyDeprecate` | `warnings.warn` (stdlib) | `deprecation` (Lib) | `Deprecated` (wrapt) | `warnings.deprecated` (3.13+) / `typing_extensions.deprecated` |
 | ------------------------ | :-----------: | :----------------------: | :-----------------: | :------------------: | :------------------------------------------------------------: |
-| **Simple Warnings** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Auto-Forward Calls** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Argument Mapping** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Argument Deprecation** | ✅ | ✍️ | ❌ | ❌ | ❌ |
-| **Class/Instance Proxy** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Docstring Updates** | ✅ | ❌ | ✅ | ✅ | ❌ |
-| **Version Tracking** | ✅ | ✍️ | ✅ | ✅ | ❌ |
-| **Prevent Log Spam** | ✅ | ✍️ | ❌ | ❌ | ❌ |
-| **Zero Extra Depend.** | ✅ | ✅ | ❌ | ❌ | ✍️ |
-| **Custom Streams** | ✅ | ✍️ | ❌ | ❌ | ❌ |
-| **Testing Helpers** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **CI/Audit Tools** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Decorator Stacking** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Sphinx Plugin** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **MkDocs Plugin** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Simple Warnings**      |      ✅       |            ✅            |         ✅          |          ✅          |                               ✅                               |
+| **Auto-Forward Calls**   |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| **Argument Mapping**     |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| **Argument Deprecation** |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
+| **Class/Instance Proxy** |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| **Docstring Updates**    |      ✅       |            ❌            |         ✅          |          ✅          |                               ❌                               |
+| **Version Tracking**     |      ✅       |            ✍️            |         ✅          |          ✅          |                               ❌                               |
+| **Prevent Log Spam**     |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
+| **Zero Extra Depend.**   |      ✅       |            ✅            |         ❌          |          ❌          |                               ✍️                               |
+| **Custom Streams**       |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
+| **Testing Helpers**      |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| **CI/Audit Tools**       |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| **Decorator Stacking**   |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| **Sphinx Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| **MkDocs Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
 
 ✍️ = possible but requires manual implementation
 ✍️ (_Zero Extra Depend._ row) = stdlib on Python 3.13+; requires `typing_extensions` backport on Python < 3.13
@@ -197,32 +197,32 @@ Not sure which API to reach for? Start here.
 
 **Pick the right decorator:**
 
-| Scenario | API to use |
+| Scenario                                      | API to use                                                               |
 | --------------------------------------------- | ------------------------------------------------------------------------ |
-| Renaming a function or method | `@deprecated(target=new_func)` |
+| Renaming a function or method                 | `@deprecated(target=new_func)`                                           |
 | Renaming an argument within the same function | `@deprecated(target=TargetMode.ARGS_REMAP, args_mapping={"old": "new"})` |
-| Warn only — original body still runs | `@deprecated(deprecated_in="1.0", remove_in="2.0")` |
-| Deprecating a class, Enum, or dataclass name | `@deprecated_class(target=NewClass)` |
-| Deprecating a module-level constant or object | `deprecated_instance(obj, ...)` |
+| Warn only — original body still runs          | `@deprecated(deprecated_in="1.0", remove_in="2.0")`                      |
+| Deprecating a class, Enum, or dataclass name  | `@deprecated_class(target=NewClass)`                                     |
+| Deprecating a module-level constant or object | `deprecated_instance(obj, ...)`                                          |
 
 > **Note:** Legacy `target=None` and `target=True` emit `FutureWarning` at decoration time in v0.8 and become `TypeError` in v1.0. Use `TargetMode.NOTIFY` and `TargetMode.ARGS_REMAP` respectively.
 
 <details>
   <summary><strong>All `@deprecated` parameters at a glance:</strong></summary>
 
-| Param | Default | Purpose |
+| Param              | Default                     | Purpose                                                                                                    |
 | ------------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `target` | `TargetMode.NOTIFY` | `Callable` to forward to · `TargetMode.ARGS_REMAP` to remap args · `TargetMode.NOTIFY` (default) warn-only |
-| `deprecated_in` | `""` | Version when deprecated (e.g. `"1.0"`) |
-| `remove_in` | `""` | Version when removed (e.g. `"2.0"`) |
-| | **Advanced: ~10% of cases** | |
-| `stream` | `deprecation_warning` | Warning sink callable (set `None` to silence warnings) |
-| `num_warns` | `1` | `1` once · `-1` always · `N` exactly N times |
-| `args_mapping` | `None` | `{"old": "new"}` rename · `{"old": None}` drop |
-| `template_mgs` | `None` | Custom warning message template (`%`-style placeholders) |
-| `args_extra` | `None` | Fixed kwargs injected into the target call |
-| `skip_if` | `False` | `bool` or `Callable → bool`; skip deprecation when true |
-| `update_docstring` | `False` | Append Sphinx `.. deprecated::` notice to docstring |
+| `target`           | `TargetMode.NOTIFY`         | `Callable` to forward to · `TargetMode.ARGS_REMAP` to remap args · `TargetMode.NOTIFY` (default) warn-only |
+| `deprecated_in`    | `""`                        | Version when deprecated (e.g. `"1.0"`)                                                                     |
+| `remove_in`        | `""`                        | Version when removed (e.g. `"2.0"`)                                                                        |
+|                    | **Advanced: ~10% of cases** |                                                                                                            |
+| `stream`           | `deprecation_warning`       | Warning sink callable (set `None` to silence warnings)                                                     |
+| `num_warns`        | `1`                         | `1` once · `-1` always · `N` exactly N times                                                               |
+| `args_mapping`     | `None`                      | `{"old": "new"}` rename · `{"old": None}` drop                                                             |
+| `template_mgs`     | `None`                      | Custom warning message template (`%`-style placeholders)                                                   |
+| `args_extra`       | `None`                      | Fixed kwargs injected into the target call                                                                 |
+| `skip_if`          | `False`                     | `bool` or `Callable → bool`; skip deprecation when true                                                    |
+| `update_docstring` | `False`                     | Append Sphinx `.. deprecated::` notice to docstring                                                        |
 
 > [!TIP]
 > `@deprecated_class()` shares `target`, `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_mapping`, `args_extra`, and `template_mgs`.
@@ -244,11 +244,11 @@ The functionality is kept simple and all defaults should be reasonable, but you 
 
 In particular the target values (cases):
 
-| `target` value | Use case | `args_mapping` | Warning trigger |
+| `target` value          | Use case                                      | `args_mapping`                     | Warning trigger                    |
 | ----------------------- | --------------------------------------------- | ---------------------------------- | ---------------------------------- |
-| `TargetMode.NOTIFY` | Whole callable going away; no replacement yet | Ignored (warns; TypeError in v1.0) | Every call |
-| `TargetMode.ARGS_REMAP` | Callable stays; argument names are renamed | Required | Only when old arg names are passed |
-| `<callable>` | Callable replaced by another; calls forwarded | Optional | Every call |
+| `TargetMode.NOTIFY`     | Whole callable going away; no replacement yet | Ignored (warns; TypeError in v1.0) | Every call                         |
+| `TargetMode.ARGS_REMAP` | Callable stays; argument names are renamed    | Required                           | Only when old arg names are passed |
+| `<callable>`            | Callable replaced by another; calls forwarded | Optional                           | Every call                         |
 
 > [!TIP]
 > `TargetMode.NOTIFY` replaces the old `target=None` sentinel and `TargetMode.ARGS_REMAP` replaces the old `target=True` sentinel. The old forms still work but emit a `FutureWarning` at decoration time.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -184,6 +184,14 @@
             "@type": "Answer",
             "text": "read_only=True intercepts only the following standard collection mutator names: append, clear, discard, extend, insert, pop, remove, setdefault, update, add. These cover the mutating methods on Python's built-in list, dict, and set types. Custom method names such as register(), reload(), or set_value() are not in this list and pass through to the underlying object unchanged. Workaround: subclass the wrapped type and override the custom mutator method to raise AttributeError explicitly, then wrap an instance of that subclass."
           }
+        },
+        {
+          "@type": "Question",
+          "name": "Why did I get TypeError at decoration time about a cross-class method target?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The cross-class guard raises TypeError at decoration time when @deprecated on a method in class Foo targets a method defined on a different class Bar. Forwarding to a cross-class method silently passes self of the wrong type. Fix: target a method on the same class or a standalone function. False positives from decorators that rewrite __qualname__ and from metaclass-generated classes were fixed in v0.8."
+          }
         }
       ]
     }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -176,6 +176,14 @@
             "@type": "Answer",
             "text": "This is intended behaviour. When args_mapping is provided without an explicit callable target, the proxy auto-resolves to TargetMode.ARGS_REMAP and warns only when an old argument name is actually present in the call. Callers already using the new argument name see no warning, matching the per-argument behaviour of @deprecated(target=TargetMode.ARGS_REMAP, args_mapping=...). To warn on every call regardless of argument names, set target=TargetMode.NOTIFY explicitly."
           }
+        },
+        {
+          "@type": "Question",
+          "name": "Why did my object mutate despite setting read_only=True on deprecated_instance?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "read_only=True intercepts only the following standard collection mutator names: append, clear, discard, extend, insert, pop, remove, setdefault, update, add. These cover the mutating methods on Python's built-in list, dict, and set types. Custom method names such as register(), reload(), or set_value() are not in this list and pass through to the underlying object unchanged. Workaround: subclass the wrapped type and override the custom mutator method to raise AttributeError explicitly, then wrap an instance of that subclass."
+          }
         }
       ]
     }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -559,7 +559,13 @@ ______________________________________________________________________
 
 ## TypeError at decoration time: cross-class method target
 
-**Q:** I got `TypeError: @deprecated on method 'old_method' (owner class 'Foo') targets method 'new_method' on a different class 'Bar'. Cross-class method forwarding silently passes the wrong self type ...`. What does this mean and how do I fix it?
+**Q:** I got the following error at decoration time — what does it mean and how do I fix it?
+
+```
+TypeError: Cannot use @deprecated on 'Foo.old_method' with target 'Bar.new_method':
+cross-class method forwarding is not supported because `self` would carry the wrong type.
+The target must be a method on the same class ('Foo') or a full class (use target=Bar for class migration).
+```
 
 **A:** The cross-class guard in pyDeprecate raises `TypeError` at **decoration time** (when the class body is executed), not at call time. It fires when `@deprecated` on a method in class `Foo` points to a method defined on a different class `Bar`. Forwarding to a method on a different class silently passes `self` of the wrong type, causing `AttributeError` or incorrect behaviour at runtime — the guard prevents this misconfiguration from reaching production.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -559,7 +559,13 @@ ______________________________________________________________________
 
 ## TypeError at decoration time: cross-class method target
 
-**Q:** I got `TypeError: @deprecated on method 'old_method' (owner class 'Foo') targets method 'new_method' on a different class 'Bar'. Cross-class method forwarding silently passes the wrong self type ...`. What does this mean and how do I fix it?
+**Q:** I got the following error at decoration time — what does it mean and how do I fix it?
+
+```text
+TypeError: Cannot use @deprecated on 'Foo.old_method' with target 'Bar.new_method':
+cross-class method forwarding is not supported because `self` would carry the wrong type.
+The target must be a method on the same class ('Foo') or a full class (use target=Bar for class migration).
+```
 
 **A:** The cross-class guard in pyDeprecate raises `TypeError` at **decoration time** (when the class body is executed), not at call time. It fires when `@deprecated` on a method in class `Foo` points to a method defined on a different class `Bar`. Forwarding to a method on a different class silently passes `self` of the wrong type, causing `AttributeError` or incorrect behaviour at runtime — the guard prevents this misconfiguration from reaching production.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -537,6 +537,26 @@ def my_func(x: int) -> int:
 
 ______________________________________________________________________
 
+## My object mutated despite `read_only=True`
+
+**Q:** I passed `read_only=True` to `deprecated_instance()` but a method on my object still mutated its state. Why?
+
+**A:** `read_only=True` intercepts only the following standard collection mutator names: `append`, `clear`, `discard`, `extend`, `insert`, `pop`, `remove`, `setdefault`, `update`, `add`. These cover the mutating methods on Python's built-in `list`, `dict`, and `set` types.
+
+Custom method names — for example `register()`, `reload()`, or `set_value()` — are not in this list and call through to the underlying object without any guard.
+
+**Workaround:** Subclass the wrapped object's type and override the custom mutator method to raise explicitly:
+
+```python
+class ReadOnlyRegistry(dict):
+    def register(self, item):
+        raise AttributeError("'LEGACY_REGISTRY' is deprecated and read-only. Migrate away from this object.")
+```
+
+Then wrap an instance of `ReadOnlyRegistry` instead of a plain `dict`. This keeps `read_only=True` in place for standard collection mutators while adding explicit guards for your custom methods.
+
+______________________________________________________________________
+
 ## Still stuck?
 
 !!! question "Open a GitHub issue"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -453,11 +453,11 @@ old_endpoint("/api/users")
 
 **Choosing the log level:**
 
-| Level | When to use |
+| Level             | When to use                                   |
 | ----------------- | --------------------------------------------- |
-| `logging.info` | Early deprecation window; low urgency |
-| `logging.warning` | Standard choice; default log configs show it |
-| `logging.error` | Critical deprecation nearing removal deadline |
+| `logging.info`    | Early deprecation window; low urgency         |
+| `logging.warning` | Standard choice; default log configs show it  |
+| `logging.error`   | Critical deprecation nearing removal deadline |
 
 **Benefits over `warnings.warn`:**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -453,11 +453,11 @@ old_endpoint("/api/users")
 
 **Choosing the log level:**
 
-| Level             | When to use                                   |
+| Level | When to use |
 | ----------------- | --------------------------------------------- |
-| `logging.info`    | Early deprecation window; low urgency         |
-| `logging.warning` | Standard choice; default log configs show it  |
-| `logging.error`   | Critical deprecation nearing removal deadline |
+| `logging.info` | Early deprecation window; low urgency |
+| `logging.warning` | Standard choice; default log configs show it |
+| `logging.error` | Critical deprecation nearing removal deadline |
 
 **Benefits over `warnings.warn`:**
 
@@ -554,6 +554,41 @@ class ReadOnlyRegistry(dict):
 ```
 
 Then wrap an instance of `ReadOnlyRegistry` instead of a plain `dict`. This keeps `read_only=True` in place for standard collection mutators while adding explicit guards for your custom methods.
+
+______________________________________________________________________
+
+## TypeError at decoration time: cross-class method target
+
+**Q:** I got `TypeError: @deprecated on method 'old_method' (owner class 'Foo') targets method 'new_method' on a different class 'Bar'. Cross-class method forwarding silently passes the wrong self type ...`. What does this mean and how do I fix it?
+
+**A:** The cross-class guard in pyDeprecate raises `TypeError` at **decoration time** (when the class body is executed), not at call time. It fires when `@deprecated` on a method in class `Foo` points to a method defined on a different class `Bar`. Forwarding to a method on a different class silently passes `self` of the wrong type, causing `AttributeError` or incorrect behaviour at runtime — the guard prevents this misconfiguration from reaching production.
+
+**Common fix — forward to the correct target within the same class or to a standalone function:**
+
+```python
+from deprecate import deprecated
+
+
+class MyService:
+    def execute(self, x: int) -> int:
+        return x * 2
+
+    # Correct: target is on the same class
+    @deprecated(target=execute, deprecated_in="1.0", remove_in="2.0")
+    def run(self, x: int) -> int:
+        pass
+```
+
+If you are intentionally delegating to another class, convert the target to a standalone function or use `@deprecated_class` to deprecate the whole class instead.
+
+**False-positive triggers fixed in v0.8:**
+
+Before v0.8, two patterns produced spurious `TypeError` raises from the guard:
+
+- **Decorators that rewrite `__qualname__`** — a decorator applied before `@deprecated` that sets `fn.__qualname__ = "OtherClass.method"` caused the guard to see the wrong owner class. Fixed in v0.8 by reading `__qualname__` from the enclosing class-body frame, which Python sets before any decorator runs.
+- **Metaclass-generated classes** — `type("Name", bases, ns)` and similar patterns produce qualnames like `"FakeOwner.method"` for methods that are not actually on `FakeOwner`. Fixed in v0.8 by verifying that the class name in the qualname prefix actually exists in the module globals; when it does not, the guard skips the check.
+
+If you are on v0.8+ and still seeing an unexpected `TypeError` from the cross-class guard, open an issue with a minimal reproducer.
 
 ______________________________________________________________________
 

--- a/src/deprecate/_types.py
+++ b/src/deprecate/_types.py
@@ -283,6 +283,7 @@ class _HasDeprecationMeta(Protocol):
     """
 
     __deprecated__: DeprecationConfig
+    __name__: str
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         """Call the deprecated object."""

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -20,7 +20,7 @@ from inspect import Parameter
 from typing import Any, Callable, Literal, Optional, Union, cast
 from warnings import warn
 
-from deprecate._types import DeprecationConfig, TargetMode, _DeprecatedCallable, _WrapperState
+from deprecate._types import DeprecationConfig, TargetMode, _DeprecatedCallable, _WrapperState, _has_deprecation_meta
 from deprecate.docstring.inject import _update_docstring_with_deprecation, normalize_docstring_style
 from deprecate.utils import _get_signature, get_func_arguments_types_defaults
 
@@ -696,6 +696,19 @@ def deprecated(
         if callable(target) and not inspect.isclass(target):
             _check_cross_class_method_target(source, target)
         _target = _normalize_target(source, target)
+
+        # Stacked callable-target guard: detect ``@deprecated(target=fn_a)`` applied over an
+        # already-wrapped callable that itself has a callable target. Only ARGS_REMAP stacking
+        # is supported; callable-over-callable stacking silently raises ``TypeError`` at the
+        # first call because the inner wrapper's signature does not match the outer target's
+        # remapped kwargs. Surface this at decoration time instead.
+        if callable(_target) and _has_deprecation_meta(source) and callable(source.__deprecated__.target):
+            warnings.warn(
+                f"'{source.__name__}' has a callable target stacked over another callable-target @deprecated."
+                " Only ARGS_REMAP stacking is supported. This will raise TypeError at call time.",
+                UserWarning,
+                stacklevel=3,
+            )
 
         # Skip for legacy sentinels: _normalize_target already fired a FutureWarning;
         # re-running the guard here would report the wrong migration path.

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -20,7 +20,7 @@ from inspect import Parameter
 from typing import Any, Callable, Literal, Optional, Union, cast
 from warnings import warn
 
-from deprecate._types import DeprecationConfig, TargetMode, _DeprecatedCallable, _WrapperState, _has_deprecation_meta
+from deprecate._types import DeprecationConfig, TargetMode, _DeprecatedCallable, _has_deprecation_meta, _WrapperState
 from deprecate.docstring.inject import _update_docstring_with_deprecation, normalize_docstring_style
 from deprecate.utils import _get_signature, get_func_arguments_types_defaults
 

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -571,7 +571,7 @@ def deprecated(
         num_warns: Number of times to show warning per function or per deprecated argument:
             - ``1`` (default): Show warning once per function/argument
             - ``-1``: Show warning on every call
-            - ``0``: suppresses all warnings (equivalent to ``stream=None``)
+            - ``0``: Suppress deprecation warnings emitted for the decorated function/argument
             - ``N > 1``: Show warning N times total
         template_mgs: Custom warning message template with format specifiers:
             - ``source_name``: Function name (e.g., "my_func")

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -47,7 +47,7 @@ deprecation_warning = partial(warn, category=FutureWarning)
 ArgsMapping = dict[str, Optional[str]]
 
 #: All ``%``-style placeholders accepted by the built-in warning templates.  Probing a user-supplied
-#: ``template_mgs`` against this mapping at decoration time surfaces typos (``%(unknwn)s``) and
+#: ``template_mgs`` against this mapping at decoration time surfaces typos (``%(wrong_name_or_typo)s``) and
 #: malformed conversion specifiers (``%(source_name)d``) before any call site ever triggers them.
 _TEMPLATE_MGS_PROBE_ARGS: dict[str, str] = {
     "source_name": "x",

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -46,6 +46,40 @@ deprecation_warning = partial(warn, category=FutureWarning)
 
 ArgsMapping = dict[str, Optional[str]]
 
+#: All ``%``-style placeholders accepted by the built-in warning templates.  Probing a user-supplied
+#: ``template_mgs`` against this mapping at decoration time surfaces typos (``%(unknwn)s``) and
+#: malformed conversion specifiers (``%(source_name)d``) before any call site ever triggers them.
+_TEMPLATE_MGS_PROBE_ARGS: dict[str, str] = {
+    "source_name": "x",
+    "source_path": "x.y",
+    "deprecated_in": "0.0",
+    "remove_in": "1.0",
+    "target_name": "x",
+    "target_path": "x.y",
+    "argument_map": "x -> y",
+}
+
+
+def _validate_template_mgs(template_mgs: Optional[str]) -> None:
+    """Probe ``template_mgs`` with every documented placeholder, raising at decoration time on failure.
+
+    Args:
+        template_mgs: User-supplied warning message template, or ``None``.  ``None`` and empty strings are
+            no-ops because the call sites already fall back to the built-in templates.
+
+    Raises:
+        ValueError: When ``template_mgs`` references an unknown ``%(...)s`` key, uses a malformed conversion
+            specifier, or otherwise fails ``%``-formatting against the full placeholder set.
+    """
+    if not template_mgs:
+        return
+    try:
+        template_mgs % _TEMPLATE_MGS_PROBE_ARGS
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid template_mgs: {exc!r}. Available placeholders: {list(_TEMPLATE_MGS_PROBE_ARGS)}"
+        ) from exc
+
 
 def _get_positional_params(params: list[inspect.Parameter]) -> list[inspect.Parameter]:
     """Filter positional-only and positional-or-keyword parameters."""
@@ -619,6 +653,9 @@ def deprecated(
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
     def packing(source: Callable) -> Callable:
+        # Probe ``template_mgs`` against every documented placeholder so typos and malformed
+        # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
+        _validate_template_mgs(template_mgs)
         # Note: template_mgs intentionally bypasses this guard — callers with custom templates
         # control their own messaging and may not rely on deprecated_in being present.
         if not deprecated_in and stream is not None and not template_mgs and not inspect.isclass(source):

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -571,6 +571,7 @@ def deprecated(
         num_warns: Number of times to show warning per function or per deprecated argument:
             - ``1`` (default): Show warning once per function/argument
             - ``-1``: Show warning on every call
+            - ``0``: suppresses all warnings (equivalent to ``stream=None``)
             - ``N > 1``: Show warning N times total
         template_mgs: Custom warning message template with format specifiers:
             - ``source_name``: Function name (e.g., "my_func")

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -719,7 +719,12 @@ def deprecated(
 
             state = cast(_DeprecatedCallable, wrapped_fn)._state
             state.called += 1
-            dep_cfg = cast(_DeprecatedCallable, wrapped_fn).__deprecated__
+            # Read DeprecationConfig from the closure rather than re-reading
+            # ``wrapped_fn.__deprecated__``: a PEP 702 ``typing_extensions.deprecated``
+            # decorator stacked outside this one overwrites that attribute with a plain
+            # string, which then crashes on ``.misconfigured`` access. ``_state`` must
+            # still be read via attribute because it is mutable and updated between calls.
+            dep_cfg = _dep_cfg
             if dep_cfg.misconfigured and stream and not state.warned_misconfigured:
                 warnings.warn(
                     f"'{source.__name__}' has an invalid deprecation configuration;"
@@ -819,6 +824,12 @@ def deprecated(
             misconfigured=misconfigured,
             docstring_style=normalized_docstring_style,
         )
+        # Bind ``DeprecationConfig`` into the wrapper closure so call-time reads
+        # survive PEP 702 ``typing_extensions.deprecated`` stacked outside this
+        # decorator overwriting ``wrapped_fn.__deprecated__`` with a string.
+        # ``wrapped_fn`` already captured this name from the enclosing scope via
+        # the late-binding closure rule; the assignment here is what populates it.
+        _dep_cfg = dep_meta
         wrapped_fn_typed = cast(_DeprecatedCallable, wrapped_fn)
         wrapped_fn_typed.__deprecated__ = dep_meta
         wrapped_fn_typed._state = _WrapperState()

--- a/src/deprecate/proxy.py
+++ b/src/deprecate/proxy.py
@@ -35,6 +35,7 @@ from deprecate.deprecation import (
     TEMPLATE_WARNING_ARGUMENTS,
     TEMPLATE_WARNING_CALLABLE,
     TEMPLATE_WARNING_NO_TARGET,
+    _validate_template_mgs,
     deprecation_warning,
 )
 from deprecate.docstring.inject import _update_docstring_with_deprecation, normalize_docstring_style
@@ -102,6 +103,9 @@ class _DeprecatedProxy:
         ``target=False`` plus NOTIFY+args_mapping / NOTIFY+args_extra detected upstream) before the proxy
         rewrites them away, so the final frozen :class:`DeprecationConfig` records every signal in one place.
         """
+        # Probe ``template_mgs`` against every documented placeholder so typos and malformed
+        # conversion specifiers fail at decoration time instead of on the first proxy access.
+        _validate_template_mgs(template_mgs)
         # Track whether the raw ``target=False`` sentinel was passed so audit can flag it. The override
         # path lets upstream callers fold their own pre-validated misconfig signals into the same flag.
         misconfigured = target is False or _misconfigured_override

--- a/src/deprecate/proxy.py
+++ b/src/deprecate/proxy.py
@@ -65,6 +65,9 @@ class _DeprecatedProxy:
             (default), the built-in template for the active scenario is used (callable-target, no-target, or
             per-argument).  See :func:`~deprecate.proxy.deprecated_class` for the available ``%``-style placeholders.
         read_only: If ``True``, raise :class:`AttributeError` on any write attempt through the proxy.
+            Only the following standard collection mutator names are intercepted: ``append``, ``clear``,
+            ``discard``, ``extend``, ``insert``, ``pop``, ``remove``, ``setdefault``, ``update``, ``add``.
+            Custom method names (e.g. ``register()``, ``reload()``, ``set_value()``) are not blocked.
         target: Optional replacement object.  When set, all attribute, item, and call access is forwarded to *target*
             instead of *obj*.
         args_mapping: Optional dict remapping keyword argument names when the proxy is called.  Keys are old argument
@@ -659,6 +662,9 @@ def deprecated_instance(
             (default), the built-in template for the active scenario is used.  See
             :func:`~deprecate.proxy.deprecated_class` for the available ``%``-style placeholders.
         read_only: If ``True``, raise :class:`AttributeError` on any write attempt through the proxy.
+            Only the following standard collection mutator names are intercepted: ``append``, ``clear``,
+            ``discard``, ``extend``, ``insert``, ``pop``, ``remove``, ``setdefault``, ``update``, ``add``.
+            Custom method names (e.g. ``register()``, ``reload()``, ``set_value()``) are not blocked.
         args_extra: Optional dict of extra keyword arguments merged into the forwarded call when the proxy is invoked.
             Caller-supplied values override entries with the same key.
 

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -58,6 +58,7 @@ from tests.collection_targets import (
     TargetColorEnum,
     TargetWithInjected,
     TimerDecorator,
+    _Pep702ProxyTarget,  # private alias — see B1b regression fixture below
     add_values,
     base_pow_args,
     base_sum_kwargs,
@@ -1304,3 +1305,33 @@ def pep702_stacked(x: int) -> int:
     Forwards the call (and all warnings) to the stacked wrapper.
     """
     return _pep702_stacked(x)
+
+
+# ========== PEP 702 stacking regression fixture (B1b — deprecated_class proxy) ==========
+# ``typing_extensions.deprecated`` stacked OUTSIDE pyDeprecate's ``deprecated_class``
+# proxy wrapper.  The inner ``deprecated_class(...)`` returns a ``_DeprecatedProxy``
+# instance whose ``__deprecated__`` slot lives in the proxy instance ``__dict__``
+# (set via ``object.__setattr__``) and is read back via ``object.__getattribute__``.
+#
+# PEP 702's outer wrapper assigns ``arg.__deprecated__ = msg`` on the proxy.  That
+# attribute set routes through the proxy's forwarding ``__setattr__``, which calls
+# ``setattr(self._get_active(), "__deprecated__", msg)`` — landing on the wrapped
+# class, not on the proxy's own instance ``__dict__``.  As a result, the proxy's
+# ``object.__getattribute__(self, "__deprecated__")`` reads in ``_dep`` and ``__call__``
+# still resolve to the original ``DeprecationConfig`` and instantiation survives.
+#
+# This fixture is the B1b regression guard against re-introducing a clobber path.
+# Both intermediate bindings are underscore-prefixed so audit walkers do not probe
+# the PEP 702-wrapped plain function as a pyDeprecate target.
+_pep702_proxy_inner = deprecated_class(deprecated_in="0.8", remove_in="1.0")(_Pep702ProxyTarget)
+_pep702_proxy_stacked = typing_extensions.deprecated("use `Pep702ProxyTarget`")(_pep702_proxy_inner)
+
+
+def pep702_proxy_stacked() -> _Pep702ProxyTarget:
+    """Tiny re-export thunk for the PEP 702 + ``deprecated_class`` stacked proxy (B1b).
+
+    Returns a fresh instance produced by invoking the stacked wrapper.  Defined as
+    a function (not a module-level binding) so audit walkers skip the PEP 702
+    wrapper whose ``__deprecated__`` is a plain string.
+    """
+    return _pep702_proxy_stacked()

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -44,6 +44,7 @@ from functools import partial
 from typing import Any, Callable
 from warnings import warn
 
+import typing_extensions
 from sklearn.metrics import accuracy_score
 
 from deprecate import TargetMode, deprecated, deprecated_class, deprecated_instance, void
@@ -67,6 +68,7 @@ from tests.collection_targets import (
     fn_with_default,
     identity_value,
     increment_value,
+    pep702_target,
     power_with_new_coef,
     return_b,
     return_z,
@@ -1274,3 +1276,31 @@ def make_explicit_notify_no_versions_warns() -> Callable[[int], int]:
         return identity_value(x)
 
     return fn
+
+
+# ========== PEP 702 stacking regression fixture (B1a) ==========
+# ``typing_extensions.deprecated`` stacked OUTSIDE pyDeprecate's ``@deprecated``
+# overwrites the inner wrapper's ``__deprecated__`` attribute with a plain string.
+# Pre-fix, ``wrapped_fn`` re-read ``__deprecated__`` from itself at call time and
+# crashed with ``AttributeError: 'str' object has no attribute 'misconfigured'``.
+# Capturing ``DeprecationConfig`` in a closure variable inside ``packing()`` keeps
+# the metadata reachable even after PEP 702 overwrites the attribute.
+#
+# Both intermediate bindings are underscore-prefixed so ``find_deprecation_wrappers``
+# skips them: the inner pyDeprecate wrapper is exposed through PEP 702, which sets a
+# plain string ``__deprecated__`` and would otherwise crash ``validate_deprecation_wrapper``.
+# The public ``pep702_stacked`` re-export is a thunk function with no ``__deprecated__``
+# attribute, so the audit walker steps over it without probing.
+_pep702_inner = deprecated(target=pep702_target, deprecated_in="0.8", remove_in="1.0")(lambda x: x)
+_pep702_stacked = typing_extensions.deprecated("use `pep702_target`")(_pep702_inner)
+
+
+def pep702_stacked(x: int) -> int:
+    """Tiny re-export thunk for the PEP 702 + pyDeprecate stacked wrapper.
+
+    Defined as a function (not a direct module-level binding to ``_pep702_stacked``) so
+    ``find_deprecation_wrappers`` does not treat the PEP 702 wrapper — whose
+    ``__deprecated__`` is a plain string — as a pyDeprecate audit target.
+    Forwards the call (and all warnings) to the stacked wrapper.
+    """
+    return _pep702_stacked(x)

--- a/tests/collection_targets.py
+++ b/tests/collection_targets.py
@@ -235,6 +235,25 @@ def pep702_target(x: int) -> int:
     return x * 2
 
 
+class _Pep702ProxyTarget:
+    """Target class for PEP 702 stacking on ``deprecated_class`` proxy (B1b).
+
+    Provides a stable ``value()`` method so the stacking test can confirm that
+    instantiation and method dispatch survive after PEP 702
+    ``typing_extensions.deprecated`` was applied on top of the ``deprecated_class``
+    proxy wrapper.
+
+    Underscore-prefixed so :func:`deprecate.find_deprecation_wrappers` skips it: the
+    outer PEP 702 wrapper forwards its ``__deprecated__ = msg`` assignment through the
+    proxy's ``__setattr__`` onto this wrapped class, leaving a plain string on the
+    class attribute that would otherwise crash the audit walker.
+    """
+
+    def value(self) -> int:
+        """Return a stable sentinel value used by the B1b regression test."""
+        return 42
+
+
 def timing_wrapper(func: Callable) -> Callable:
     """Decorator to measure the execution time of a function."""
 

--- a/tests/collection_targets.py
+++ b/tests/collection_targets.py
@@ -269,6 +269,16 @@ def timing_wrapper(func: Callable) -> Callable:
     return wrapper
 
 
+def stacked_inner_target(x: int) -> int:
+    """Inner target for stacked-callable-target guard tests."""
+    return x * 3
+
+
+def stacked_outer_target(x: int) -> int:
+    """Outer target for stacked-callable-target guard tests."""
+    return x * 5
+
+
 class TimerDecorator:
     """A class-based decorator to time functions and methods."""
 

--- a/tests/collection_targets.py
+++ b/tests/collection_targets.py
@@ -225,6 +225,16 @@ def fn_remap_with_extra_body(new_arg: int = 0, injected: int = 0) -> int:
     return new_arg + injected
 
 
+def pep702_target(x: int) -> int:
+    """Target for PEP 702 stacking regression tests.
+
+    Doubles the input value so the wrapping test can confirm the inner pyDeprecate
+    @deprecated forwarded the call after PEP 702 ``typing_extensions.deprecated``
+    overwrote ``__deprecated__`` on the wrapper.
+    """
+    return x * 2
+
+
 def timing_wrapper(func: Callable) -> Callable:
     """Decorator to measure the execution time of a function."""
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,7 @@ pytest-cov >=7.1.0
 scikit-learn >=1.6.1
 phmdoctest >=1.4.0
 dataclasses  # needed for phmdoctest
+typing_extensions  # PEP 702 stacking regression tests
 
 # Docs extensions
 griffe  # for MKDocs

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -944,3 +944,49 @@ class TestPEP702StackingRegression:
         assert future_warnings, "expected at least one FutureWarning from pyDeprecate"
         assert any("pep702_target" in str(w.message) for w in future_warnings)
         assert result == 6
+
+
+class TestTemplateMgsValidation:
+    """A malformed ``template_mgs`` is detected at decoration time, not at first call (B6)."""
+
+    def test_unknown_placeholder_raises_at_decoration(self) -> None:
+        """An unknown ``%(...)s`` key raises ``ValueError`` when ``@deprecated`` is applied — before any call."""
+        from tests.collection_targets import base_sum_kwargs
+
+        with pytest.raises(ValueError, match="Invalid template_mgs"):
+            deprecated(
+                target=base_sum_kwargs,
+                deprecated_in="0.8",
+                remove_in="1.0",
+                template_mgs="bad %(unknown_key)s",
+            )(base_sum_kwargs)
+
+    def test_valid_template_accepted_at_decoration(self) -> None:
+        """A template using only documented placeholders is accepted at decoration time."""
+        from tests.collection_targets import base_sum_kwargs
+
+        # Must not raise — covers happy path of the probe.
+        wrapper = deprecated(
+            target=base_sum_kwargs,
+            deprecated_in="0.8",
+            remove_in="1.0",
+            template_mgs="`%(source_name)s` -> `%(target_name)s` since v%(deprecated_in)s",
+        )(base_sum_kwargs)
+        assert callable(wrapper)
+
+
+class TestStackedCallableTargetGuard:
+    """Stacking ``@deprecated(target=fn_a)`` over ``@deprecated(target=fn_b)`` warns at decoration time (B4).
+
+    Callable-over-callable stacking silently raises ``TypeError`` at the first call because the
+    inner wrapper's signature does not match the outer target's remapped kwargs. The guard surfaces
+    this misconfiguration at decoration time so authors catch it without exercising the call path.
+    """
+
+    def test_stacked_callable_targets_warn_at_decoration(self) -> None:
+        """Decorating a callable-target wrapper with another callable target emits ``UserWarning``."""
+        from tests.collection_targets import stacked_inner_target, stacked_outer_target
+
+        inner = deprecated(target=stacked_inner_target, deprecated_in="0.8", remove_in="1.0")(stacked_outer_target)
+        with pytest.warns(UserWarning, match="callable target stacked"):
+            deprecated(target=stacked_outer_target, deprecated_in="0.8", remove_in="1.0")(inner)

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Union, cast
 from unittest.mock import MagicMock
 
 import pytest
+import typing_extensions
 
 from deprecate import TargetMode, deprecated, void
 from deprecate.deprecation import (
@@ -29,7 +30,12 @@ from deprecate.docstring.inject import (
     normalize_docstring_style,
 )
 from deprecate.proxy import _DeprecatedProxy
-from tests.collection_deprecate import CrossGuardModuleLevel, CrossGuardOldClass, CrossGuardSameClass
+from tests.collection_deprecate import (
+    CrossGuardModuleLevel,
+    CrossGuardOldClass,
+    CrossGuardSameClass,
+    pep702_stacked,
+)
 from tests.collection_targets import KeywordCallTarget, call_signature_source
 
 
@@ -893,3 +899,48 @@ class TestEmptyVersionGuardSymmetry:
                 return b
 
         assert not [w for w in caught if issubclass(w.category, UserWarning)]
+
+
+class TestPEP702StackingRegression:
+    """Stacking ``typing_extensions.deprecated`` outside ``@deprecated`` no longer crashes (B1a).
+
+    PEP 702 ``typing_extensions.deprecated`` overwrites the inner wrapper's
+    ``__deprecated__`` attribute with the message string. Before the fix, ``wrapped_fn``
+    re-read that attribute at call time and crashed with
+    ``AttributeError: 'str' object has no attribute 'misconfigured'``. The fix captures
+    the ``DeprecationConfig`` instance in a closure variable so the call path survives
+    arbitrary outer decorators rewriting ``__deprecated__``.
+    """
+
+    def test_pep702_stacked_call_does_not_crash(self) -> None:
+        """Stacked PEP 702 + pyDeprecate wrapper forwards the call and returns the target's result."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = pep702_stacked(1)
+        assert result == 2
+
+    def test_pep702_stacked_emits_pep702_deprecation_warning(self) -> None:
+        """Outer ``typing_extensions.deprecated`` emits its DeprecationWarning at call time."""
+        with pytest.warns(DeprecationWarning, match="use `pep702_target`"):
+            pep702_stacked(2)
+
+    def test_pep702_stacked_emits_pydeprecate_warning_on_first_call(self) -> None:
+        """Inner ``@deprecated`` still emits its FutureWarning naming the target.
+
+        Uses a freshly-built wrapper so the pyDeprecate ``_state.warned_calls`` counter
+        is zero — the module-level ``pep702_stacked`` fixture may already have warned
+        in earlier tests under ``num_warns=1``.
+        """
+        from tests.collection_targets import pep702_target
+
+        inner = deprecated(target=pep702_target, deprecated_in="0.8", remove_in="1.0")(lambda x: x)
+        stacked = typing_extensions.deprecated("use `pep702_target`")(inner)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = stacked(3)
+
+        future_warnings = [w for w in caught if issubclass(w.category, FutureWarning)]
+        assert future_warnings, "expected at least one FutureWarning from pyDeprecate"
+        assert any("pep702_target" in str(w.message) for w in future_warnings)
+        assert result == 6

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -20,8 +20,9 @@ from tests.collection_deprecate import (
     ProxyCallableWithArgsMapping,
     ProxyClassWithArgsExtra,
     WarnOnlyColorEnum,
+    pep702_proxy_stacked,
 )
-from tests.collection_targets import NewDataClass, TargetColorEnum, TargetWithInjected
+from tests.collection_targets import NewDataClass, TargetColorEnum, TargetWithInjected, _Pep702ProxyTarget
 
 
 class TestProxyInit:
@@ -1064,3 +1065,35 @@ class TestProxyArgsMappingBehavior:
             warnings.simplefilter("always")
             proxy(old_key=2)
         assert not caught
+
+
+class TestPEP702ProxyStackingRegression:
+    """Stacking ``typing_extensions.deprecated`` outside ``deprecated_class`` does not break the proxy (B1b).
+
+    PEP 702's ``typing_extensions.deprecated`` assigns ``arg.__deprecated__ = msg`` on the
+    object it decorates.  For a ``_DeprecatedProxy`` instance, that assignment routes
+    through the proxy's forwarding ``__setattr__`` and lands on the wrapped class — it
+    does **not** clobber the proxy's own instance ``__dict__`` slot (which was set via
+    ``object.__setattr__`` at construction time and is read back via
+    ``object.__getattribute__`` in ``_dep`` and ``__call__``).  These tests guard against
+    a future refactor re-introducing a clobber path on the proxy.
+    """
+
+    def test_pep702_proxy_stacked_instantiation_does_not_crash(self) -> None:
+        """Stacked PEP 702 + ``deprecated_class`` proxy instantiates and dispatches methods."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            instance = pep702_proxy_stacked()
+            assert instance.value() == 42
+
+    def test_pep702_proxy_stacked_returns_target_instance(self) -> None:
+        """The stacked wrapper produces an instance of the wrapped target class."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            instance = pep702_proxy_stacked()
+        assert isinstance(instance, _Pep702ProxyTarget)
+
+    def test_pep702_proxy_stacked_emits_pep702_deprecation_warning(self) -> None:
+        """Outer ``typing_extensions.deprecated`` emits its DeprecationWarning on call."""
+        with pytest.warns(DeprecationWarning, match="use `Pep702ProxyTarget`"):
+            pep702_proxy_stacked()

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -308,6 +308,22 @@ class TestProxyReadOnly:
         assert "k" not in inner
         assert "m" in inner
 
+    def test_custom_mutator_bypasses_read_only_guard(self) -> None:
+        """Custom method names not in the blocked set pass through read_only=True (known limitation)."""
+
+        class RegistryWithCustomMutator:
+            def __init__(self) -> None:
+                self.items: list[str] = []
+
+            def register(self, item: str) -> None:
+                self.items.append(item)
+
+        obj = RegistryWithCustomMutator()
+        proxy = deprecated_instance(obj, deprecated_in="1.0", remove_in="2.0", read_only=True, stream=None)
+        # `register` is not in the blocked set — it must NOT raise
+        proxy.register("x")
+        assert obj.items == ["x"]
+
 
 class TestProxyGetActive:
     """Active object selection: source vs. target."""


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

This pull request introduces several improvements and clarifications to the deprecation library, focusing on error surfacing, proxy behavior, and documentation. The most significant changes include early validation of custom warning templates, enhanced documentation and user guidance around proxy mutability and cross-class method deprecation, and improved robustness when stacking deprecation decorators. These updates aim to make deprecation handling safer, more transparent, and easier to debug for users.

**Validation and Error Surfacing:**

* Added `_validate_template_mgs` to validate custom `template_mgs` warning templates at decoration time, catching typos and malformed placeholders before runtime. This is now called in both `@deprecated` and proxy initialization. [[1]](diffhunk://#diff-10f6a668c55149debe15400e9033be8448ab5b75c6246161f3a980677bed054aR49-R82) [[2]](diffhunk://#diff-10f6a668c55149debe15400e9033be8448ab5b75c6246161f3a980677bed054aR657-R659) [[3]](diffhunk://#diff-709b52b75d240a612cd107902512b26ddfba04f3e57fd16dc9d455be031ed35aR38) [[4]](diffhunk://#diff-709b52b75d240a612cd107902512b26ddfba04f3e57fd16dc9d455be031ed35aR109-R111)

**Proxy and Read-Only Behavior:**

* Clarified in documentation and docstrings that `read_only=True` for `deprecated_instance` and proxies only intercepts standard collection mutators (e.g., `append`, `pop`, `update`), not custom methods. Provided workarounds and detailed lists of intercepted methods. [[1]](diffhunk://#diff-709b52b75d240a612cd107902512b26ddfba04f3e57fd16dc9d455be031ed35aR68-R70) [[2]](diffhunk://#diff-709b52b75d240a612cd107902512b26ddfba04f3e57fd16dc9d455be031ed35aR665-R667) [[3]](diffhunk://#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82dR540-R594) [[4]](diffhunk://#diff-9c2d836b64a8163ccdd77c4928201aae0d01b69b97990008539f6ccadf885b95R179-R194) F698R700)

**Decorator Robustness and Stacking:**

* Improved robustness when stacking `@deprecated` with other deprecation decorators (e.g., PEP 702/`typing_extensions.deprecated`), ensuring correct reading of deprecation metadata and preventing crashes if attributes are overwritten. [[1]](diffhunk://#diff-10f6a668c55149debe15400e9033be8448ab5b75c6246161f3a980677bed054aL722-R778) [[2]](diffhunk://#diff-10f6a668c55149debe15400e9033be8448ab5b75c6246161f3a980677bed054aR878-R883)
* Added a guard and warning for unsupported stacking of callable-targeted `@deprecated` decorators, surfacing potential `TypeError` at decoration time instead of runtime.

**Cross-Class Method Targeting:**

* Improved error messages and documentation for the cross-class method target guard, clarifying when and why `TypeError` is raised and listing fixes and false positive resolutions. [[1]](diffhunk://#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82dR540-R594) [[2]](diffhunk://#diff-9c2d836b64a8163ccdd77c4928201aae0d01b69b97990008539f6ccadf885b95R179-R194)

**Documentation and Audit Tools:**

* Expanded documentation with examples of audit tool output, deprecated-to-deprecated chain detection, and clarified when to prefer standard library deprecation tools versus `pyDeprecate`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R111-R112) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L136-R139) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1188-R1205)

These changes collectively improve developer experience, error detection, and the clarity of the deprecation workflow.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
