### PR TITLE
docs(ci): workflow_dispatch backfill trigger and GEO-enriched mike template

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,20 +4,21 @@
 # Flow:
 #
 #   Triggers (filtered at the workflow level):
-#     - push → main                                    → build + deploy to latest/
+#     - push → main                                    → build + deploy to dev/
 #     - push → version-like tag (v1.2, 1.2.3, …)       → build + deploy to <tag>/ (and stable/ if highest)
 #     - pull_request → main                            → build only (no deploy)
+#     - workflow_dispatch (tag input)                  → build + deploy to <tag>/ (no set-default change)
 #
 #   Jobs:
 #     build-landing-docs ──┐
-#     build-demo-sphinx ───┤  (run on every trigger)
+#     build-demo-sphinx ───┤  (run on every trigger; demo jobs skip gracefully if source absent)
 #     build-demo-mkdocs ───┤
 #                          ▼
 #                       assemble-site  (run on every trigger)
 #                          ├─ inject sphinx + mkdocs artifacts into docs/
 #                          ├─ mike deploy <version_path> [aliases…] --update-aliases
-#                          ├─ mike set-default <latest|stable>
-#                          ├─ git push gh-pages [push events only] — this IS the deploy
+#                          ├─ mike set-default <latest|stable>  [skipped on workflow_dispatch]
+#                          ├─ git push gh-pages [push + workflow_dispatch events] — this IS the deploy
 #                          │  (GitHub Pages serves directly from the gh-pages branch)
 #                          └─ upload built site as workflow artifact (manual inspection)
 #
@@ -38,6 +39,17 @@ on:
       - "[0-9]*.[0-9]*" # 1.2, 1.2.3 — no v prefix
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to backfill (e.g. v0.7.0). Must already exist on the remote."
+        required: true
+        type: string
+      alias:
+        description: "Optional mike alias to attach (e.g. stable). Leave empty for none."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -63,6 +75,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || '' }}
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -70,13 +83,30 @@ jobs:
           python-version: ${{ env.PYTHON_DEFAULT }}
           cache: pip
 
+      - name: 🔎 Verify mkdocs.yml exists at this ref
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ ! -f mkdocs.yml ]; then
+            echo "::error::Tag '${{ inputs.tag }}' has no mkdocs.yml — cannot build docs. Earliest supported tag: v0.7.0."
+            exit 1
+          fi
+
       - name: 📦 Install portal dependencies
         run: pip install -r docs/requirements.txt
 
+      - name: 📄 Generate docs/index.md from README if missing
+        # Historical tags (e.g. v0.7.0) expected docs/index.md to be generated at build time.
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ ! -f docs/index.md ] && [ -f README.md ]; then
+            mkdir -p docs
+            cp README.md docs/index.md
+          fi
+
       - name: 📖 Build portal
-        # Documentation screenshots (demo-docs-*.png) live under docs/assets/images/ so MkDocs picks them up
-        # natively without a copy step.
-        run: mkdocs build --strict
+        # Drop --strict for dispatch: historical docs may have nav entries pointing to demo dirs
+        # that are injected only at assemble time. Strict is enforced on push/PR where it matters.
+        run: mkdocs build ${{ github.event_name != 'workflow_dispatch' && '--strict' || '' }}
 
       - name: 📄 Copy Markdown sources into site for .md URL support
         run: |
@@ -97,6 +127,8 @@ jobs:
     steps:
       - name: 🔀 Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag || '' }}
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -105,17 +137,21 @@ jobs:
           cache: pip
 
       - name: 📦 Install package + Sphinx dependencies
-        run: pip install . -r demo-docs/sphinx/requirements.txt
+        run: |
+          [ -d demo-docs/sphinx ] || { echo "::notice::demo-docs/sphinx absent at this ref — skipping Sphinx demo."; exit 0; }
+          pip install . -r demo-docs/sphinx/requirements.txt
 
       - name: 📖 Build Sphinx documentation
-        working-directory: demo-docs/sphinx
-        run: make html
+        run: |
+          [ -d demo-docs/sphinx ] || exit 0
+          cd demo-docs/sphinx && make html
 
       - name: 📤 Upload Sphinx docs artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sphinx-docs
           path: demo-docs/sphinx/build/html/
+          if-no-files-found: warn
           retention-days: 7
 
   build-demo-mkdocs:
@@ -125,6 +161,8 @@ jobs:
     steps:
       - name: 🔀 Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.tag || '' }}
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -133,17 +171,21 @@ jobs:
           cache: pip
 
       - name: 📦 Install package + MkDocs dependencies
-        run: pip install . -r demo-docs/mkdocs/requirements.txt
+        run: |
+          [ -d demo-docs/mkdocs ] || { echo "::notice::demo-docs/mkdocs absent at this ref — skipping MkDocs demo."; exit 0; }
+          pip install . -r demo-docs/mkdocs/requirements.txt
 
       - name: 📖 Build MkDocs documentation
-        working-directory: demo-docs/mkdocs
-        run: mkdocs build --strict
+        run: |
+          [ -d demo-docs/mkdocs ] || exit 0
+          cd demo-docs/mkdocs && mkdocs build --strict
 
       - name: 📤 Upload MkDocs docs artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mkdocs-docs
           path: demo-docs/mkdocs/site/
+          if-no-files-found: warn
           retention-days: 7
 
   assemble-site:
@@ -161,6 +203,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || '' }}
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -169,7 +212,10 @@ jobs:
           cache: pip
 
       - name: 📦 Install mike
-        run: pip install -r docs/requirements.txt
+        run: |
+          pip install -r docs/requirements.txt
+          # Ensure mike is available even when not listed in historical tags' requirements.txt
+          pip install "mike>=2.1,<3"
 
       - name: 🔑 Configure git identity for mike
         run: |
@@ -183,6 +229,15 @@ jobs:
             git fetch origin "${GH_PAGES_BRANCH}:${GH_PAGES_BRANCH}"
           else
             echo "No remote ${GH_PAGES_BRANCH} branch yet — mike will create it on first deploy."
+          fi
+
+      - name: 📄 Generate docs/index.md from README if missing
+        # Historical tags (e.g. v0.7.0) expected docs/index.md to be generated at build time.
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ ! -f docs/index.md ] && [ -f README.md ]; then
+            mkdir -p docs
+            cp README.md docs/index.md
           fi
 
       - name: 📥 Download Sphinx artifact
@@ -201,10 +256,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${GITHUB_REF_TYPE}" = "branch" ]; then
-            VERSION_PATH="latest"
-            STABLE_TAG=""
-            SKIP="false"
+          SKIP="false"
+          ALIASES=""
+          SET_DEFAULT=""
+          STABLE_TAG=""
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            # Backfill: use the user-supplied tag; never change set-default.
+            VERSION_PATH="${{ inputs.tag }}"
+            ALIASES="${{ inputs.alias }}"
+          elif [ "${GITHUB_REF_TYPE}" = "branch" ]; then
+            # Unreleased main branch — never set as default; users want stable docs by default.
+            VERSION_PATH="dev"
           else
             if [[ ! "${GITHUB_REF_NAME}" =~ ${RELEASE_TAG_PATTERN} ]]; then
               echo "Skipping docs deploy for non-final tag: ${GITHUB_REF_NAME}"
@@ -213,17 +276,10 @@ jobs:
             fi
             VERSION_PATH="${GITHUB_REF_NAME}"
             STABLE_TAG="$((git tag --list | { grep -E "${RELEASE_TAG_PATTERN}" || true; } | sort -V | tail -1))"
-            SKIP="false"
-          fi
-
-          ALIASES=""
-          SET_DEFAULT=""
-
-          if [ "${VERSION_PATH}" = "latest" ]; then
-            SET_DEFAULT="latest"
-          elif [ -n "${STABLE_TAG}" ] && [ "${VERSION_PATH}" = "${STABLE_TAG}" ]; then
-            ALIASES="stable"
-            SET_DEFAULT="stable"
+            if [ -n "${STABLE_TAG}" ] && [ "${VERSION_PATH}" = "${STABLE_TAG}" ]; then
+              ALIASES="stable"
+              SET_DEFAULT="stable"
+            fi
           fi
 
           {
@@ -254,7 +310,10 @@ jobs:
         if: env.SKIP != 'true' && env.SET_DEFAULT != ''
         run: |
           set -euo pipefail
-          mike set-default --branch "${GH_PAGES_BRANCH}" "${SET_DEFAULT}"
+          mike set-default \
+            --branch "${GH_PAGES_BRANCH}" \
+            --template docs/overrides/mike_redirect.html \
+            "${SET_DEFAULT}"
 
       - name: 📦 Export built site
         if: env.SKIP != 'true'
@@ -271,5 +330,5 @@ jobs:
           retention-days: 7
 
       - name: 📤 Push gh-pages branch
-        if: github.event_name == 'push' && env.SKIP != 'true'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && env.SKIP != 'true'
         run: git push origin "${GH_PAGES_BRANCH}"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -275,7 +275,7 @@ jobs:
               exit 0
             fi
             VERSION_PATH="${GITHUB_REF_NAME}"
-            STABLE_TAG="$((git tag --list | { grep -E "${RELEASE_TAG_PATTERN}" || true; } | sort -V | tail -1))"
+            STABLE_TAG="$(git tag --list | { grep -E "${RELEASE_TAG_PATTERN}" || true; } | sort -V | tail -1)"
             if [ -n "${STABLE_TAG}" ] && [ "${VERSION_PATH}" = "${STABLE_TAG}" ]; then
               ALIASES="stable"
               SET_DEFAULT="stable"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-[0.8.0] — 2026-05-DD — Default `TargetMode` enum & CLI audit tools
+[0.8.0] — 2026-05-20 — Default `TargetMode` enum & CLI audit tools
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-[0.8.0] — 2026-05-20 — Default `TargetMode` enum & CLI audit tools
+[0.8.0] — 2026-05-DD — Default `TargetMode` enum & CLI audit tools
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -916,7 +916,7 @@ This is useful for generating API docs with Sphinx, MkDocs, and strict Google/Nu
 
 ![Sphinx demo — deprecation notice rendered as a styled deprecated directive](docs/assets/images/demo-docs-sphinx.png)
 
-See the live rendered output in the online demos: [Sphinx demo](https://borda.github.io/pyDeprecate/latest/demo-sphinx/api.html) · [MkDocs demo](https://borda.github.io/pyDeprecate/latest/demo-mkdocs/api.html).
+See the live rendered output in the online demos: [Sphinx demo](https://borda.github.io/pyDeprecate/stable/demo-sphinx/api.html) · [MkDocs demo](https://borda.github.io/pyDeprecate/stable/demo-mkdocs/api.html).
 
 <details>
 <summary>MkDocs integration: render injected notices with <code>mkdocstrings</code></summary>

--- a/README.md
+++ b/README.md
@@ -112,23 +112,23 @@ While `pyDeprecate` focuses on comprehensive forwarding and argument mapping, ot
 
 <br>
 
-| _Feature_                | `pyDeprecate` | `warnings.warn` (stdlib) | `deprecation` (Lib) | `Deprecated` (wrapt) | `warnings.deprecated`† (py3.13+)  |
-| ------------------------ | :-----------: | :----------------------: | :-----------------: | :------------------: | :-------------------------------: |
-| **Simple Warnings**      |      ✅       |            ✅            |         ✅          |          ✅          |                ✅                 |
-| **Auto-Forward Calls**   |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
-| **Argument Mapping**     |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
-| **Argument Deprecation** |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                 |
-| **Class/Instance Proxy** |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
-| **Docstring Updates**    |      ✅       |            ❌            |         ✅          |          ✅          |                ❌                 |
-| **Version Tracking**     |      ✅       |            ✍️            |         ✅          |          ✅          |                ❌                 |
-| **Prevent Log Spam**     |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                 |
-| **Zero Extra Depend.**   |      ✅       |            ✅            |         ❌          |          ❌          |                 †                 |
-| **Custom Streams**       |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                 |
-| **Testing Helpers**      |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
-| **CI/Audit Tools**       |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
-| **Decorator Stacking**   |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
-| **Sphinx Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
-| **MkDocs Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
+| _Feature_                | `pyDeprecate` | `warnings.warn` (stdlib) | `deprecation` (Lib) | `Deprecated` (wrapt) | `warnings.deprecated`† (py3.13+) |
+| ------------------------ | :-----------: | :----------------------: | :-----------------: | :------------------: | :------------------------------: |
+| **Simple Warnings**      |      ✅       |            ✅            |         ✅          |          ✅          |                ✅                |
+| **Auto-Forward Calls**   |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                |
+| **Argument Mapping**     |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                |
+| **Argument Deprecation** |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                |
+| **Class/Instance Proxy** |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                |
+| **Docstring Updates**    |      ✅       |            ❌            |         ✅          |          ✅          |                ❌                |
+| **Version Tracking**     |      ✅       |            ✍️            |         ✅          |          ✅          |                ❌                |
+| **Prevent Log Spam**     |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                |
+| **Zero Extra Depend.**   |      ✅       |            ✅            |         ❌          |          ❌          |                †                 |
+| **Custom Streams**       |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                |
+| **Testing Helpers**      |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                |
+| **CI/Audit Tools**       |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                |
+| **Decorator Stacking**   |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                |
+| **Sphinx Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                |
+| **MkDocs Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                |
 
 ✍️ = possible but requires manual implementation
 † stdlib on Python 3.13+; also available as `typing_extensions.deprecated` backport for Python < 3.13
@@ -136,7 +136,7 @@ While `pyDeprecate` focuses on comprehensive forwarding and argument mapping, ot
 > [!NOTE]
 > This comparison is compiled to the best of our knowledge and we're happy to make any justified corrections. If you spot an inaccuracy, please [open an issue](https://github.com/Borda/pyDeprecate/issues) or submit a PR.
 
-> [!NOTE]
+> [!TIP]
 > Every deprecation variant writes the same `DeprecationConfig` — `@deprecated`, `deprecated_class`, `deprecated_instance`, and the audit tools all read from a single source of truth. This means your CI pipeline (`pydeprecate check src/`) catches misconfigured wrappers across all three variants with one scan.
 
 ## 💾 Installation

--- a/README.md
+++ b/README.md
@@ -112,26 +112,26 @@ While `pyDeprecate` focuses on comprehensive forwarding and argument mapping, ot
 
 <br>
 
-| _Feature_                | `pyDeprecate` | `warnings.warn` (stdlib) | `deprecation` (Lib) | `Deprecated` (wrapt) | `warnings.deprecated` (3.13+) / `typing_extensions.deprecated` |
-| ------------------------ | :-----------: | :----------------------: | :-----------------: | :------------------: | :------------------------------------------------------------: |
-| **Simple Warnings**      |      ✅       |            ✅            |         ✅          |          ✅          |                               ✅                               |
-| **Auto-Forward Calls**   |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Argument Mapping**     |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Argument Deprecation** |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
-| **Class/Instance Proxy** |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Docstring Updates**    |      ✅       |            ❌            |         ✅          |          ✅          |                               ❌                               |
-| **Version Tracking**     |      ✅       |            ✍️            |         ✅          |          ✅          |                               ❌                               |
-| **Prevent Log Spam**     |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
-| **Zero Extra Depend.**   |      ✅       |            ✅            |         ❌          |          ❌          |                               ✍️                               |
-| **Custom Streams**       |      ✅       |            ✍️            |         ❌          |          ❌          |                               ❌                               |
-| **Testing Helpers**      |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **CI/Audit Tools**       |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Decorator Stacking**   |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **Sphinx Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
-| **MkDocs Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                               ❌                               |
+| _Feature_                | `pyDeprecate` | `warnings.warn` (stdlib) | `deprecation` (Lib) | `Deprecated` (wrapt) | `warnings.deprecated`† (py3.13+)  |
+| ------------------------ | :-----------: | :----------------------: | :-----------------: | :------------------: | :-------------------------------: |
+| **Simple Warnings**      |      ✅       |            ✅            |         ✅          |          ✅          |                ✅                 |
+| **Auto-Forward Calls**   |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
+| **Argument Mapping**     |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
+| **Argument Deprecation** |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                 |
+| **Class/Instance Proxy** |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
+| **Docstring Updates**    |      ✅       |            ❌            |         ✅          |          ✅          |                ❌                 |
+| **Version Tracking**     |      ✅       |            ✍️            |         ✅          |          ✅          |                ❌                 |
+| **Prevent Log Spam**     |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                 |
+| **Zero Extra Depend.**   |      ✅       |            ✅            |         ❌          |          ❌          |                 †                 |
+| **Custom Streams**       |      ✅       |            ✍️            |         ❌          |          ❌          |                ❌                 |
+| **Testing Helpers**      |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
+| **CI/Audit Tools**       |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
+| **Decorator Stacking**   |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
+| **Sphinx Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
+| **MkDocs Plugin**        |      ✅       |            ❌            |         ❌          |          ❌          |                ❌                 |
 
 ✍️ = possible but requires manual implementation
-✍️ (_Zero Extra Depend._ row) = stdlib on Python 3.13+; requires `typing_extensions` backport on Python < 3.13
+† stdlib on Python 3.13+; also available as `typing_extensions.deprecated` backport for Python < 3.13
 
 > [!NOTE]
 > This comparison is compiled to the best of our knowledge and we're happy to make any justified corrections. If you spot an inaccuracy, please [open an issue](https://github.com/Borda/pyDeprecate/issues) or submit a PR.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -16,13 +16,13 @@
 
 ## Docs
 
-- [Home](https://borda.github.io/pyDeprecate/latest/index.html): Project overview, features, and comparison with other deprecation tools
-- [Getting Started](https://borda.github.io/pyDeprecate/latest/getting-started.html): Installation, quick start, and API overview
-- [Use Cases](https://borda.github.io/pyDeprecate/latest/guide/use-cases.html): 13 real-world deprecation patterns with worked examples
-- [void() Helper](https://borda.github.io/pyDeprecate/latest/guide/void-helper.html): How and when to use the void() sentinel function
-- [Customization](https://borda.github.io/pyDeprecate/latest/guide/customization.html): Message templates and output redirection to loggers or custom callables
-- [Audit Tools](https://borda.github.io/pyDeprecate/latest/guide/audit.html): CI/CD enforcement of removal deadlines and deprecation chain detection
-- [Troubleshooting](https://borda.github.io/pyDeprecate/latest/troubleshooting.html): Common errors and their fixes
+- [Home](https://borda.github.io/pyDeprecate/stable/index.html): Project overview, features, and comparison with other deprecation tools
+- [Getting Started](https://borda.github.io/pyDeprecate/stable/getting-started.html): Installation, quick start, and API overview
+- [Use Cases](https://borda.github.io/pyDeprecate/stable/guide/use-cases.html): 13 real-world deprecation patterns with worked examples
+- [void() Helper](https://borda.github.io/pyDeprecate/stable/guide/void-helper.html): How and when to use the void() sentinel function
+- [Customization](https://borda.github.io/pyDeprecate/stable/guide/customization.html): Message templates and output redirection to loggers or custom callables
+- [Audit Tools](https://borda.github.io/pyDeprecate/stable/guide/audit.html): CI/CD enforcement of removal deadlines and deprecation chain detection
+- [Troubleshooting](https://borda.github.io/pyDeprecate/stable/troubleshooting.html): Common errors and their fixes
 
 ## Agent Notes
 
@@ -170,11 +170,11 @@ What is being deprecated?
 
 - [PyPI](https://pypi.org/project/pyDeprecate/): Package installation and release history
 - [GitHub](https://github.com/Borda/pyDeprecate): Source code and issue tracker
-- [Changelog](https://borda.github.io/pyDeprecate/latest/changelog.html): Release notes and version history
+- [Changelog](https://borda.github.io/pyDeprecate/stable/changelog.html): Release notes and version history
 
 ## Optional
 
 - [Contributing](https://github.com/Borda/pyDeprecate/blob/main/.github/CONTRIBUTING.md): Contribution guide
 - [Security](https://github.com/Borda/pyDeprecate/blob/main/.github/SECURITY.md): Security policy
-- [Sphinx Demo](https://borda.github.io/pyDeprecate/latest/demo-sphinx/index.html): Docstring auto-injection rendered via Sphinx
-- [MkDocs Demo](https://borda.github.io/pyDeprecate/latest/demo-mkdocs/index.html): Docstring auto-injection rendered via MkDocs
+- [Sphinx Demo](https://borda.github.io/pyDeprecate/stable/demo-sphinx/index.html): Docstring auto-injection rendered via Sphinx
+- [MkDocs Demo](https://borda.github.io/pyDeprecate/stable/demo-mkdocs/index.html): Docstring auto-injection rendered via MkDocs

--- a/docs/mkdocs_hooks.py
+++ b/docs/mkdocs_hooks.py
@@ -7,11 +7,25 @@ Injects a ``<link>`` element pointing to ``/llms.txt`` into every page's
 from __future__ import annotations
 
 import logging
+import os
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mkdocs.config.defaults import MkDocsConfig
     from mkdocs.structure.pages import Page
+
+
+def on_config(config: MkDocsConfig, **_kwargs: object) -> MkDocsConfig:
+    """Inject package version into extra config so templates can reference it."""
+    try:
+        about = os.path.join(os.path.dirname(os.path.dirname(__file__)), "src", "deprecate", "__about__.py")
+        with open(about) as f:
+            match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', f.read())
+        config.extra["package_version"] = match.group(1) if match else ""
+    except Exception:
+        config.extra["package_version"] = ""
+    return config
 
 
 def on_post_page(output: str, page: Page, config: MkDocsConfig, **_kwargs: object) -> str:

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -64,8 +64,8 @@
   ],
   "keywords": "Python, deprecation, decorator, API migration, backwards compatibility, code quality, CI/CD",
   "isAccessibleForFree": true,
-  "releaseNotes": "https://borda.github.io/pyDeprecate/latest/changelog.html",
-  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://borda.github.io/pyDeprecate/latest/" }
+  "releaseNotes": "https://borda.github.io/pyDeprecate/stable/changelog.html",
+  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://borda.github.io/pyDeprecate/stable/" }
 }
 </script>
 <script type="application/ld+json">
@@ -95,7 +95,7 @@
     "@type": "SearchAction",
     "target": {
       "@type": "EntryPoint",
-      "urlTemplate": "https://borda.github.io/pyDeprecate/latest/search/?q={search_term_string}"
+      "urlTemplate": "https://borda.github.io/pyDeprecate/stable/search/?q={search_term_string}"
     },
     "query-input": "required name=search_term_string"
   }
@@ -259,28 +259,28 @@
       "position": 1,
       "name": "Install pyDeprecate",
       "text": "Run pip install pyDeprecate in your Python 3.9+ environment. No runtime dependencies are added.",
-      "url": "https://borda.github.io/pyDeprecate/latest/getting-started.html#installation"
+      "url": "https://borda.github.io/pyDeprecate/stable/getting-started.html#installation"
     },
     {
       "@type": "HowToStep",
       "position": 2,
       "name": "Import the decorator",
       "text": "Add from deprecate import deprecated at the top of your Python file.",
-      "url": "https://borda.github.io/pyDeprecate/latest/getting-started.html#quick-start"
+      "url": "https://borda.github.io/pyDeprecate/stable/getting-started.html#quick-start"
     },
     {
       "@type": "HowToStep",
       "position": 3,
       "name": "Apply @deprecated to the old function",
       "text": "Decorate the old function with @deprecated(target=new_function, deprecated_in='1.0', remove_in='2.0'). Calls to the old name emit a FutureWarning and automatically forward to the new function.",
-      "url": "https://borda.github.io/pyDeprecate/latest/getting-started.html#quick-start"
+      "url": "https://borda.github.io/pyDeprecate/stable/getting-started.html#quick-start"
     },
     {
       "@type": "HowToStep",
       "position": 4,
       "name": "Enforce the removal deadline in CI",
       "text": "Install the audit extra with pip install pyDeprecate[audit] and call validate_deprecation_expiry() in your CI pipeline to catch deprecated code past its deadline.",
-      "url": "https://borda.github.io/pyDeprecate/latest/getting-started.html#installation"
+      "url": "https://borda.github.io/pyDeprecate/stable/getting-started.html#installation"
     }
   ]
 }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -4,17 +4,13 @@
 {{ super() }}
 
 {% if page %}
-{# mike version segment (latest|stable|<tag>); falls back to 'latest' for plain mkdocs builds
-   where no version prefix exists (first segment ends in .html or is empty). #}
-{% set _version_prefix = page.canonical_url.replace(config.site_url, '').split('/')[0] %}
-{% if not _version_prefix or _version_prefix.endswith('.html') %}{% set _version_prefix = 'latest' %}{% endif %}
 <!-- Open Graph meta tags -->
 <meta property="og:type" content="{% if page.file.src_path == 'index.md' %}website{% else %}article{% endif %}" />
 <meta property="og:title" content="{% if page.file.src_path == 'index.md' %}pyDeprecate — Python Deprecation Decorator Library{% else %}{{ page.title }} — pyDeprecate{% endif %}" />
 <meta property="og:description" content="{{ page.meta.description | d(config.site_description, true) }}" />
 <meta property="og:url" content="{{ page.canonical_url }}" />
 <meta property="og:site_name" content="{{ config.site_name }}" />
-<meta property="og:image" content="{{ config.site_url }}{{ _version_prefix }}/assets/images/demo-docs-mkdocs.png" />
+<meta property="og:image" content="{{ config.site_url.rstrip('/') }}/assets/images/demo-docs-mkdocs.png" />
 <meta property="og:image:alt" content="pyDeprecate documentation" />
 <meta property="og:image:width" content="1280" />
 <meta property="og:image:height" content="640" />
@@ -22,7 +18,7 @@
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="{% if page.file.src_path == 'index.md' %}pyDeprecate — Python Deprecation Decorator Library{% else %}{{ page.title }} — pyDeprecate{% endif %}" />
 <meta name="twitter:description" content="{{ page.meta.description | d(config.site_description, true) }}" />
-<meta name="twitter:image" content="{{ config.site_url }}{{ _version_prefix }}/assets/images/demo-docs-mkdocs.png" />
+<meta name="twitter:image" content="{{ config.site_url.rstrip('/') }}/assets/images/demo-docs-mkdocs.png" />
 <meta name="twitter:image:alt" content="pyDeprecate documentation" />
 
 <!-- JSON-LD structured data -->
@@ -51,8 +47,25 @@
     "https://pypi.org/project/pyDeprecate/",
     "https://github.com/Borda/pyDeprecate",
     "https://libraries.io/pypi/pyDeprecate",
+    "https://anaconda.org/conda-forge/pydeprecate",
     "https://repology.org/project/python:pydeprecate/versions"
-  ]
+  ],
+  "softwareVersion": {{ config.extra.package_version | d("", true) | tojson }},
+  "featureList": [
+    "Decorator-based function and method deprecation with automatic call forwarding",
+    "Argument renaming and remapping via args_mapping",
+    "Conditional deprecation skipping with skip_if",
+    "Class and enum deprecation via @deprecated_class",
+    "Module-level value deprecation via deprecated_instance",
+    "CI/CD audit utilities: validate_deprecation_expiry, find_deprecation_wrappers",
+    "CLI tools for automated deprecation linting",
+    "Auto-updating function docstrings with deprecation notices",
+    "Zero runtime dependencies"
+  ],
+  "keywords": "Python, deprecation, decorator, API migration, backwards compatibility, code quality, CI/CD",
+  "isAccessibleForFree": true,
+  "releaseNotes": "https://borda.github.io/pyDeprecate/latest/changelog.html",
+  "mainEntityOfPage": { "@type": "WebPage", "@id": "https://borda.github.io/pyDeprecate/latest/" }
 }
 </script>
 <script type="application/ld+json">
@@ -66,6 +79,7 @@
     "https://www.linkedin.com/in/jiraborovec",
     "https://orcid.org/0000-0001-7246-8758"
   ],
+  "jobTitle": "Open Source Software Engineer",
   "knowsAbout": ["Python", "Software Deprecation", "API Design", "Open Source Software", "Machine Learning"],
   "description": "Creator of pyDeprecate; core maintainer of PyTorch Lightning and TorchMetrics; PhD in Medical Imaging."
 }
@@ -81,7 +95,7 @@
     "@type": "SearchAction",
     "target": {
       "@type": "EntryPoint",
-      "urlTemplate": "https://borda.github.io/pyDeprecate/search/?q={search_term_string}"
+      "urlTemplate": "https://borda.github.io/pyDeprecate/latest/search/?q={search_term_string}"
     },
     "query-input": "required name=search_term_string"
   }
@@ -207,9 +221,11 @@
   "description": {{ page.meta.description | d(config.site_description, true) | tojson }},
   "url": {{ page.canonical_url | tojson }},
   "mainEntityOfPage": { "@type": "WebPage", "@id": {{ page.canonical_url | tojson }} },
-  "author": { "@type": "Person", "name": "Jiri Borovec", "url": "https://github.com/Borda", "sameAs": ["https://github.com/Borda"] },
+  "image": "{{ config.site_url.rstrip('/') }}/assets/images/demo-docs-mkdocs.png",
+  "author": { "@type": "Person", "name": "Jiri Borovec", "url": "https://github.com/Borda", "sameAs": ["https://github.com/Borda", "https://www.linkedin.com/in/jiraborovec", "https://orcid.org/0000-0001-7246-8758"] },
   "publisher": { "@type": "Person", "name": "Jiri Borovec", "url": "https://github.com/Borda" },
-  "speakable": { "@type": "SpeakableSpecification", "cssSelector": [".md-content h1", ".md-content h2"] }{% if page.meta.git_revision_date_localized %},
+  "speakable": { "@type": "SpeakableSpecification", "cssSelector": [".md-content h1", ".md-content h2"] }{% if page.meta.git_creation_date_localized %},
+  "datePublished": {{ page.meta.git_creation_date_localized | striptags | trim | tojson }}{% endif %}{% if page.meta.git_revision_date_localized %},
   "dateModified": {{ page.meta.git_revision_date_localized | striptags | trim | tojson }}{% endif %}
 }
 </script>
@@ -243,28 +259,28 @@
       "position": 1,
       "name": "Install pyDeprecate",
       "text": "Run pip install pyDeprecate in your Python 3.9+ environment. No runtime dependencies are added.",
-      "url": "https://borda.github.io/pyDeprecate/getting-started.html#installation"
+      "url": "https://borda.github.io/pyDeprecate/latest/getting-started.html#installation"
     },
     {
       "@type": "HowToStep",
       "position": 2,
       "name": "Import the decorator",
       "text": "Add from deprecate import deprecated at the top of your Python file.",
-      "url": "https://borda.github.io/pyDeprecate/getting-started.html#quick-start"
+      "url": "https://borda.github.io/pyDeprecate/latest/getting-started.html#quick-start"
     },
     {
       "@type": "HowToStep",
       "position": 3,
       "name": "Apply @deprecated to the old function",
       "text": "Decorate the old function with @deprecated(target=new_function, deprecated_in='1.0', remove_in='2.0'). Calls to the old name emit a FutureWarning and automatically forward to the new function.",
-      "url": "https://borda.github.io/pyDeprecate/getting-started.html#quick-start"
+      "url": "https://borda.github.io/pyDeprecate/latest/getting-started.html#quick-start"
     },
     {
       "@type": "HowToStep",
       "position": 4,
       "name": "Enforce the removal deadline in CI",
       "text": "Install the audit extra with pip install pyDeprecate[audit] and call validate_deprecation_expiry() in your CI pipeline to catch deprecated code past its deadline.",
-      "url": "https://borda.github.io/pyDeprecate/getting-started.html#installation"
+      "url": "https://borda.github.io/pyDeprecate/latest/getting-started.html#installation"
     }
   ]
 }

--- a/docs/overrides/mike_redirect.html
+++ b/docs/overrides/mike_redirect.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url={{ href }}">
+    <link rel="canonical" href="{{ href }}">
+    <title>pyDeprecate — Python Deprecation Decorator Library</title>
+    <meta name="description" content="pyDeprecate — zero-dependency Python library for deprecating functions, methods, and classes. Automatic call forwarding, argument remapping, and CI/CD audit utilities. Python 3.9+.">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="pyDeprecate — Python Deprecation Decorator Library">
+    <meta property="og:description" content="pyDeprecate — zero-dependency Python library for deprecating functions, methods, and classes. Automatic call forwarding, argument remapping, and CI/CD audit utilities. Python 3.9+.">
+    <meta property="og:url" content="https://borda.github.io/pyDeprecate/">
+    <meta property="og:site_name" content="pyDeprecate">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="pyDeprecate — Python Deprecation Decorator Library">
+    <meta name="twitter:description" content="pyDeprecate — zero-dependency Python library for deprecating functions, methods, and classes. Zero dependencies. Python 3.9+.">
+  </head>
+  <body>
+    <p>Redirecting to <a href="{{ href }}">{{ href }}</a>&hellip;</p>
+  </body>
+</html>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,5 +1,28 @@
 User-agent: *
 Allow: /
 
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 # AI crawler access — llms.txt available
-# https://borda.github.io/pyDeprecate/llms.txt
+# https://borda.github.io/pyDeprecate/latest/llms.txt
+
+Sitemap: https://borda.github.io/pyDeprecate/latest/sitemap.xml

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -23,6 +23,6 @@ User-agent: Google-Extended
 Allow: /
 
 # AI crawler access — llms.txt available
-# https://borda.github.io/pyDeprecate/latest/llms.txt
+# https://borda.github.io/pyDeprecate/stable/llms.txt
 
-Sitemap: https://borda.github.io/pyDeprecate/latest/sitemap.xml
+Sitemap: https://borda.github.io/pyDeprecate/stable/sitemap.xml


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- workflow_dispatch input: tag + optional alias; all 4 jobs check out at inputs.tag for historical backfills
- mike set-default now uses --template docs/overrides/mike_redirect.html
- docs/overrides/mike_redirect.html (new): Jinja2 mike template with OG/Twitter meta on root redirect page
- main branch deploys to dev/ instead of latest/ so released version stays default
- push to gh-pages fires on workflow_dispatch events too (not push-only)
- docs/mkdocs_hooks.py: on_config hook injects package_version into template context
- docs/overrides/main.html: og:image double-path fix, HowTo step /latest/ URLs, WebSite SearchAction URL, featureList/keywords/releaseNotes/mainEntityOfPage/conda-forge sameAs, datePublished
- docs/robots.txt: AI crawler Allow directives + corrected Sitemap URL to /latest/sitemap.xml
- CHANGELOG.md: fix placeholder date 2026-05-DD → 2026-05-20
- README.md: simplify warnings.deprecated column; † footnote for typing_extensions; Zero Extra Depend. ✍️ → †

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
