### PR TITLE
feat: support `ARGS_REMAP+NOTIFY` stacking, guard unsupported combos

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ______________________________________________________________________
   - [Advanced target argument mapping](#advanced-target-argument-mapping)
   - [Deprecation warning only](#deprecation-warning-only)
   - [Self argument mapping](#self-argument-mapping)
-  - [Multiple deprecation levels](#multiple-deprecation-levels)
+  - [Stacked deprecation decorators](#stacked-deprecation-decorators)
   - [Conditional skip](#conditional-skip)
   - [Class deprecation](#class-deprecation)
   - [Deprecating constants and instances](#deprecating-constants-and-instances)
@@ -104,7 +104,7 @@ While `pyDeprecate` focuses on comprehensive forwarding and argument mapping, ot
 - **Testing Helpers**: Built-in tools like `assert_no_warnings()` ensure your deprecations are testable and deterministic.
 - **Class/Instance Proxy**: Deprecate entire classes, Enums, dataclasses, and module-level objects with transparent proxy wrappers (`deprecated_class`, `deprecated_instance`).
 - **CI/Audit Tools**: Validate wrapper configuration, and—when installed with the `pyDeprecate[audit]` extra—enforce removal deadlines (PEP 440) and detect deprecated-to-deprecated chains — designed for CI pipelines and test suites.
-- **Decorator Stacking**: Stack multiple `@deprecated` decorators on one function for multi-level argument migration, with each layer tracking its own version range and warning count independently.
+- **Decorator Stacking**: Stack `@deprecated` decorators for multi-version migrations — rename arguments across releases (`ARGS_REMAP + ARGS_REMAP`), then deprecate the whole function when a complete replacement arrives (`ARGS_REMAP + NOTIFY`). Unsupported combinations warn at decoration time.
 - **Sphinx Plugin**: Ships a Sphinx autodoc extension (`deprecate.docstring.sphinx_ext`) so `_DeprecatedProxy` objects are documented with their injected deprecation notice instead of rendering as opaque aliases.
 - **MkDocs Plugin**: Ships a Griffe extension (`deprecate.docstring.griffe_ext`) for mkdocstrings so runtime-injected `!!! warning` admonitions are visible in MkDocs-generated API docs.
 
@@ -488,12 +488,12 @@ my_func(value=42, legacy_param="old")
 > [!WARNING]
 > `TargetMode.ARGS_REMAP` without `args_mapping` is a misconfiguration; using it emits a construction-time `UserWarning`. This will become a `TypeError` in v1.0. If you only want to warn callers with no forwarding or remapping, use `TargetMode.NOTIFY` instead.
 
-### 🔗 Multiple deprecation levels
+### 🔗 Stacked deprecation decorators
 
-Eventually you can set multiple deprecation levels via chaining deprecation arguments as each could be deprecated in another version:
+Stack `@deprecated` decorators to handle multi-version deprecation migrations. Each layer tracks its own version range and warning count independently.
 
 <details>
-  <summary>Example: chaining two argument deprecations across different versions</summary>
+  <summary>Pattern 1: multi-step argument renames (ARGS_REMAP + ARGS_REMAP)</summary>
 
 ```python
 from deprecate import TargetMode, deprecated
@@ -530,6 +530,33 @@ code output:
 ```
 
 </details>
+
+<details>
+  <summary>Pattern 2: lifecycle migration (ARGS_REMAP + NOTIFY)</summary>
+
+Rename an argument in v1.0, then deprecate the whole function in v2.0 when a complete replacement exists. `ARGS_REMAP` must be the outermost (top) decorator; `NOTIFY` goes below it.
+
+```python
+from deprecate import TargetMode, deprecated
+
+
+@deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"factor": "scale"})
+@deprecated(TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")
+def compute_power(base: float, factor: float = 1, scale: float = 1) -> float:
+    return base**scale
+
+
+compute_power(2, factor=3)  # → 2 warnings (arg rename + function deprecated), returns 8.0
+compute_power(2, scale=3)   # → 1 warning  (function deprecated only),          returns 8.0
+```
+
+</details>
+
+| Outer (top) | Inner (bottom) | Status |
+|---|---|---|
+| `ARGS_REMAP` | `ARGS_REMAP` | ✓ Supported |
+| `ARGS_REMAP` | `NOTIFY` | ✓ Supported |
+| `callable` / `NOTIFY` | anything else | ✗ `UserWarning` at decoration time |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -552,16 +552,17 @@ compute_power(2, scale=3)  # → 1 warning  (function deprecated only),         
 
 </details>
 
-| Outer (top)  | Inner (bottom) | Status                             |
-| ------------ | -------------- | ---------------------------------- |
-| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        |
-| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        |
-| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time |
-| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time |
-| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time |
-| `NOTIFY`     | `callable`     | ✓ Supported                        |
-| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time |
-| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time |
+| Outer (top)  | Inner (bottom) | Status                             | Notes                                                             |
+| ------------ | -------------- | ---------------------------------- | ----------------------------------------------------------------- |
+| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        | Multi-step argument renames across versions                       |
+| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        | Lifecycle: rename args first, then deprecate the whole function   |
+| `NOTIFY`     | `callable`     | ✓ Supported                        | Outer NOTIFY warns callers; inner callable handles forwarding     |
+| `callable`   | `callable`     | ✗ `UserWarning` at decoration time | Use a single `@deprecated(target=<callable>)` instead             |
+| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})`          |
+| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)`             |
+| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include `target=` and `args_mapping=` |
+| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one |
+| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below           |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -552,17 +552,17 @@ compute_power(2, scale=3)  # → 1 warning  (function deprecated only),         
 
 </details>
 
-| Outer (top)  | Inner (bottom) | Status                             | Notes                                                             |
-| ------------ | -------------- | ---------------------------------- | ----------------------------------------------------------------- |
-| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        | Multi-step argument renames across versions                       |
-| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        | Lifecycle: rename args first, then deprecate the whole function   |
-| `NOTIFY`     | `callable`     | ✓ Supported                        | Outer NOTIFY warns callers; inner callable handles forwarding     |
-| `callable`   | `callable`     | ✗ `UserWarning` at decoration time | Use a single `@deprecated(target=<callable>)` instead             |
-| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})`          |
-| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)`             |
-| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include `target=` and `args_mapping=` |
+| Outer (top)  | Inner (bottom) | Status                             | Notes                                                                   |
+| ------------ | -------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        | Multi-step argument renames across versions                             |
+| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        | Lifecycle: rename args first, then deprecate the whole function         |
+| `NOTIFY`     | `callable`     | ✓ Supported                        | Outer NOTIFY warns callers; inner callable handles forwarding           |
+| `callable`   | `callable`     | ✗ `UserWarning` at decoration time | Use a single `@deprecated(target=<callable>)` instead                   |
+| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})`                |
+| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)`                   |
+| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include `target=` and `args_mapping=`     |
 | `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one |
-| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below           |
+| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below                 |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,9 @@ compute_power(2, scale=3)  # → 1 warning  (function deprecated only),         
 | `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        |
 | `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        |
 | `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time |
+| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time |
 | `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time |
+| `NOTIFY`     | `callable`     | ✓ Supported                        |
 | `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time |
 | `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time |
 

--- a/README.md
+++ b/README.md
@@ -557,9 +557,9 @@ compute_power(2, scale=3)  # → 1 warning  (function deprecated only),         
 | `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        |
 | `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        |
 | `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time |
-| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time |
+| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time |
+| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time |
 | `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time |
-| `NOTIFY`     | `callable`     | ✗ `UserWarning` at decoration time |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -552,11 +552,14 @@ compute_power(2, scale=3)  # → 1 warning  (function deprecated only),         
 
 </details>
 
-| Outer (top)           | Inner (bottom) | Status                             |
-| --------------------- | -------------- | ---------------------------------- |
-| `ARGS_REMAP`          | `ARGS_REMAP`   | ✓ Supported                        |
-| `ARGS_REMAP`          | `NOTIFY`       | ✓ Supported                        |
-| `callable` / `NOTIFY` | anything else  | ✗ `UserWarning` at decoration time |
+| Outer (top)  | Inner (bottom) | Status                             |
+| ------------ | -------------- | ---------------------------------- |
+| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        |
+| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        |
+| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time |
+| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time |
+| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time |
+| `NOTIFY`     | `callable`     | ✗ `UserWarning` at decoration time |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -547,16 +547,16 @@ def compute_power(base: float, factor: float = 1, scale: float = 1) -> float:
 
 
 compute_power(2, factor=3)  # → 2 warnings (arg rename + function deprecated), returns 8.0
-compute_power(2, scale=3)   # → 1 warning  (function deprecated only),          returns 8.0
+compute_power(2, scale=3)  # → 1 warning  (function deprecated only),          returns 8.0
 ```
 
 </details>
 
-| Outer (top) | Inner (bottom) | Status |
-|---|---|---|
-| `ARGS_REMAP` | `ARGS_REMAP` | ✓ Supported |
-| `ARGS_REMAP` | `NOTIFY` | ✓ Supported |
-| `callable` / `NOTIFY` | anything else | ✗ `UserWarning` at decoration time |
+| Outer (top)           | Inner (bottom) | Status                             |
+| --------------------- | -------------- | ---------------------------------- |
+| `ARGS_REMAP`          | `ARGS_REMAP`   | ✓ Supported                        |
+| `ARGS_REMAP`          | `NOTIFY`       | ✓ Supported                        |
+| `callable` / `NOTIFY` | anything else  | ✗ `UserWarning` at decoration time |
 
 <br>
 

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -377,6 +377,28 @@ compute_power(2)  # → 1 warning  (function deprecated only),          returns 
 | `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one             |
 | `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below                             |
 
+### N-level stacking
+
+Any sequence of supported adjacent pairs stacks transitively. The guard inspects only one hop at a time — as long as each adjacent pair is a supported combination, the full stack is accepted silently.
+
+**Example — three-level lifecycle migration:**
+
+```python
+from deprecate import TargetMode, deprecated
+
+
+@deprecated(TargetMode.ARGS_REMAP, deprecated_in="0.3", remove_in="0.6", args_mapping={"c1": "nc1"})
+@deprecated(TargetMode.ARGS_REMAP, deprecated_in="0.4", remove_in="0.7", args_mapping={"nc1": "nc2"})
+@deprecated(TargetMode.NOTIFY, deprecated_in="0.7", remove_in="1.0")
+def any_pow(base, c1: float = 0, nc1: float = 0, nc2: float = 2) -> float:
+    return base**nc2
+```
+
+Each adjacent pair is `ARGS_REMAP + ARGS_REMAP` (supported) and `ARGS_REMAP + NOTIFY` (supported), so no decoration-time warning fires. The three layers execute in turn at call time.
+
+!!! note "Unsupported pair breaks the whole chain"
+    A single unsupported adjacent pair anywhere in the stack emits `UserWarning` at decoration time for that pair. Chains with `NOTIFY + ARGS_REMAP` adjacent remain unsupported — the wrong-order warning still fires.
+
 Use [`validate_deprecation_chains()`](audit.md#detecting-deprecation-chains) in CI to catch accidental deprecated-to-deprecated chains automatically.
 
 ## Conditional skip

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -289,13 +289,17 @@ with warnings.catch_warnings(record=True) as w:
 
     As of v0.8, `target=True` is a deprecated sentinel for `TargetMode.ARGS_REMAP`. Using either without `args_mapping` emits construction-time warnings: a `FutureWarning` for the legacy sentinel, and a `UserWarning` because `ARGS_REMAP` requires `args_mapping` to have any effect. This will become a `TypeError` in v1.0. If your intent is to warn callers with no forwarding or remapping, use `TargetMode.NOTIFY` instead.
 
-## Chained deprecation levels
+## Stacked deprecation decorators
 
-!!! warning "Stacked decorators can create unintended deprecation chains"
+Stack multiple `@deprecated` decorators on a single function to handle migrations that span several releases. Each layer tracks its own version range and warning count independently.
 
-    Each stacked `@deprecated(TargetMode.ARGS_REMAP, ...)` decorator emits its own notice. If you accidentally point a decorator's `target` at another deprecated function instead of the final implementation, callers receive redundant warnings. Use [`validate_deprecation_chains()`](audit.md#detecting-deprecation-chains) in CI to catch these mistakes automatically.
+!!! warning "Not all stacking combinations are supported"
 
-When arguments are deprecated across multiple releases, stack one `@deprecated(TargetMode.ARGS_REMAP, ...)` per rename. Each decorator operates on its own version range and emits a separate notice, giving callers version-specific migration guidance.
+    Only two combinations work correctly. Everything else emits `UserWarning` at **decoration time** (not at call time) so you catch the misconfiguration immediately. See the [supported combinations table](#supported-stacking-combinations) below.
+
+### Pattern 1 — multi-step argument renames (ARGS_REMAP + ARGS_REMAP)
+
+When an argument is renamed more than once across releases, stack one `@deprecated(TargetMode.ARGS_REMAP, ...)` per rename. Each decorator operates on its own version range and emits a separate notice, giving callers version-specific migration guidance.
 
 ```python
 from deprecate import TargetMode, deprecated
@@ -326,13 +330,51 @@ print(any_pow(2, 3))
 ```
 
 <details>
-  <summary>Output: <code>print(any_pow(2, 3)</code></summary>
+  <summary>Output: <code>print(any_pow(2, 3))</code></summary>
 
 ```
 8
 ```
 
 </details>
+
+### Pattern 2 — lifecycle migration (ARGS_REMAP + NOTIFY)
+
+The most common real-world lifecycle: an argument is renamed in an early release (`ARGS_REMAP`), then the entire function is deprecated in a later release once a complete replacement exists (`NOTIFY`). Put `ARGS_REMAP` outermost (top decorator) and `NOTIFY` below it.
+
+Callers still using the old argument name receive **both** warnings — the arg-rename notice and the function-deprecated notice. Callers already using the new name receive only the function-deprecated notice.
+
+```python
+from deprecate import TargetMode, deprecated
+
+
+@deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"factor": "scale"})
+@deprecated(TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")
+def compute_power(base: float, factor: float = 1, scale: float = 1) -> float:
+    return base**scale
+
+
+compute_power(2, factor=3)  # → 2 warnings (arg rename + function deprecated), returns 8.0
+compute_power(2, scale=3)   # → 1 warning  (function deprecated only),          returns 8.0
+compute_power(2)             # → 1 warning  (function deprecated only),          returns 2.0
+```
+
+!!! danger "Wrong order raises `UserWarning` at decoration time"
+
+    `@deprecated(NOTIFY)` on top of `@deprecated(ARGS_REMAP)` is the wrong order — pyDeprecate detects it and warns immediately at decoration time with the message *"Reverse the decorator order: put @deprecated(ARGS_REMAP, ...) outermost"*.
+
+### Supported stacking combinations
+
+| Outer (top) | Inner (bottom) | Status | Notes |
+|---|---|---|---|
+| `ARGS_REMAP` | `ARGS_REMAP` | ✓ Supported | Multi-step argument renames across versions |
+| `ARGS_REMAP` | `NOTIFY` | ✓ Supported | Lifecycle: rename args first, then deprecate the whole function |
+| `callable` | `ARGS_REMAP` | ✗ `UserWarning` at decoration | Collapse to `@deprecated(target=fn, args_mapping={...})` |
+| `ARGS_REMAP` | `callable` | ✗ `UserWarning` at decoration | Update the inner decorator to include both `target=` and `args_mapping=` |
+| `NOTIFY` | `NOTIFY` | ✗ `UserWarning` at decoration | Update the existing decorator's versions instead of adding a second one |
+| `NOTIFY` | `ARGS_REMAP` | ✗ `UserWarning` at decoration | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below |
+
+Use [`validate_deprecation_chains()`](audit.md#detecting-deprecation-chains) in CI to catch accidental deprecated-to-deprecated chains automatically.
 
 ## Conditional skip
 

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -369,10 +369,12 @@ compute_power(2)  # → 1 warning  (function deprecated only),          returns 
 | ------------ | -------------- | ----------------------------- | ------------------------------------------------------------------------ |
 | `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                   | Multi-step argument renames across versions                              |
 | `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                   | Lifecycle: rename args first, then deprecate the whole function          |
-| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration | Collapse to `@deprecated(target=fn, args_mapping={...})`                 |
-| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration | Update the inner decorator to include both `target=` and `args_mapping=` |
-| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration | Update the existing decorator's versions instead of adding a second one  |
-| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below                  |
+| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})` |
+| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)` |
+| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include both `target=` and `args_mapping=` |
+| `NOTIFY`     | `callable`     | ✓ Supported                          | Outer NOTIFY fires, then inner callable target executes; both layers work correctly |
+| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one |
+| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below |
 
 Use [`validate_deprecation_chains()`](audit.md#detecting-deprecation-chains) in CI to catch accidental deprecated-to-deprecated chains automatically.
 

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -355,8 +355,8 @@ def compute_power(base: float, factor: float = 1, scale: float = 1) -> float:
 
 
 compute_power(2, factor=3)  # → 2 warnings (arg rename + function deprecated), returns 8.0
-compute_power(2, scale=3)   # → 1 warning  (function deprecated only),          returns 8.0
-compute_power(2)             # → 1 warning  (function deprecated only),          returns 2.0
+compute_power(2, scale=3)  # → 1 warning  (function deprecated only),          returns 8.0
+compute_power(2)  # → 1 warning  (function deprecated only),          returns 2.0
 ```
 
 !!! danger "Wrong order raises `UserWarning` at decoration time"
@@ -365,14 +365,14 @@ compute_power(2)             # → 1 warning  (function deprecated only),       
 
 ### Supported stacking combinations
 
-| Outer (top) | Inner (bottom) | Status | Notes |
-|---|---|---|---|
-| `ARGS_REMAP` | `ARGS_REMAP` | ✓ Supported | Multi-step argument renames across versions |
-| `ARGS_REMAP` | `NOTIFY` | ✓ Supported | Lifecycle: rename args first, then deprecate the whole function |
-| `callable` | `ARGS_REMAP` | ✗ `UserWarning` at decoration | Collapse to `@deprecated(target=fn, args_mapping={...})` |
-| `ARGS_REMAP` | `callable` | ✗ `UserWarning` at decoration | Update the inner decorator to include both `target=` and `args_mapping=` |
-| `NOTIFY` | `NOTIFY` | ✗ `UserWarning` at decoration | Update the existing decorator's versions instead of adding a second one |
-| `NOTIFY` | `ARGS_REMAP` | ✗ `UserWarning` at decoration | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below |
+| Outer (top)  | Inner (bottom) | Status                        | Notes                                                                    |
+| ------------ | -------------- | ----------------------------- | ------------------------------------------------------------------------ |
+| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                   | Multi-step argument renames across versions                              |
+| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                   | Lifecycle: rename args first, then deprecate the whole function          |
+| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration | Collapse to `@deprecated(target=fn, args_mapping={...})`                 |
+| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration | Update the inner decorator to include both `target=` and `args_mapping=` |
+| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration | Update the existing decorator's versions instead of adding a second one  |
+| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below                  |
 
 Use [`validate_deprecation_chains()`](audit.md#detecting-deprecation-chains) in CI to catch accidental deprecated-to-deprecated chains automatically.
 

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -365,17 +365,17 @@ compute_power(2)  # → 1 warning  (function deprecated only),          returns 
 
 ### Supported stacking combinations
 
-| Outer (top)  | Inner (bottom) | Status                             | Notes                                                                               |
-| ------------ | -------------- | ---------------------------------- | ----------------------------------------------------------------------------------- |
-| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        | Multi-step argument renames across versions                                         |
-| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        | Lifecycle: rename args first, then deprecate the whole function                     |
+| Outer (top)  | Inner (bottom) | Status                             | Notes                                                                                                                                                              |
+| ------------ | -------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        | Multi-step argument renames across versions                                                                                                                        |
+| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        | Lifecycle: rename args first, then deprecate the whole function                                                                                                    |
 | `NOTIFY`     | `callable`     | ✓ Supported                        | Outer NOTIFY warns callers the function is going away; inner callable handles forwarding. Prefer `@deprecated(target=<callable>)` directly — same effect, simpler. |
-| `callable`   | `callable`     | ✗ `UserWarning` at decoration time | Use a single `@deprecated(target=<callable>)` instead                               |
-| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})`                            |
-| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)`                               |
-| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include both `target=` and `args_mapping=`            |
-| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one             |
-| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below                             |
+| `callable`   | `callable`     | ✗ `UserWarning` at decoration time | Use a single `@deprecated(target=<callable>)` instead                                                                                                              |
+| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})`                                                                                                           |
+| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)`                                                                                                              |
+| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include both `target=` and `args_mapping=`                                                                                           |
+| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one                                                                                            |
+| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below                                                                                                            |
 
 ### N-level stacking
 
@@ -397,6 +397,7 @@ def any_pow(base, c1: float = 0, nc1: float = 0, nc2: float = 2) -> float:
 Each adjacent pair is `ARGS_REMAP + ARGS_REMAP` (supported) and `ARGS_REMAP + NOTIFY` (supported), so no decoration-time warning fires. The three layers execute in turn at call time.
 
 !!! note "Unsupported pair breaks the whole chain"
+
     A single unsupported adjacent pair anywhere in the stack emits `UserWarning` at decoration time for that pair. Chains with `NOTIFY + ARGS_REMAP` adjacent remain unsupported — the wrong-order warning still fires.
 
 Use [`validate_deprecation_chains()`](audit.md#detecting-deprecation-chains) in CI to catch accidental deprecated-to-deprecated chains automatically.

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -295,7 +295,7 @@ Stack multiple `@deprecated` decorators on a single function to handle migration
 
 !!! warning "Not all stacking combinations are supported"
 
-    Only two combinations work correctly. Everything else emits `UserWarning` at **decoration time** (not at call time) so you catch the misconfiguration immediately. See the [supported combinations table](#supported-stacking-combinations) below.
+    Only three combinations work correctly. Everything else emits `UserWarning` at **decoration time** (not at call time) so you catch the misconfiguration immediately. See the [supported combinations table](#supported-stacking-combinations) below.
 
 ### Pattern 1 — multi-step argument renames (ARGS_REMAP + ARGS_REMAP)
 
@@ -369,10 +369,11 @@ compute_power(2)  # → 1 warning  (function deprecated only),          returns 
 | ------------ | -------------- | ---------------------------------- | ----------------------------------------------------------------------------------- |
 | `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        | Multi-step argument renames across versions                                         |
 | `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        | Lifecycle: rename args first, then deprecate the whole function                     |
+| `NOTIFY`     | `callable`     | ✓ Supported                        | Outer NOTIFY warns callers the function is going away; inner callable handles forwarding. Prefer `@deprecated(target=<callable>)` directly — same effect, simpler. |
+| `callable`   | `callable`     | ✗ `UserWarning` at decoration time | Use a single `@deprecated(target=<callable>)` instead                               |
 | `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})`                            |
 | `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)`                               |
 | `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include both `target=` and `args_mapping=`            |
-| `NOTIFY`     | `callable`     | ✓ Supported                        | Outer NOTIFY fires, then inner callable target executes; both layers work correctly |
 | `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one             |
 | `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below                             |
 

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -365,16 +365,16 @@ compute_power(2)  # → 1 warning  (function deprecated only),          returns 
 
 ### Supported stacking combinations
 
-| Outer (top)  | Inner (bottom) | Status                        | Notes                                                                    |
-| ------------ | -------------- | ----------------------------- | ------------------------------------------------------------------------ |
-| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                   | Multi-step argument renames across versions                              |
-| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                   | Lifecycle: rename args first, then deprecate the whole function          |
-| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})` |
-| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)` |
-| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include both `target=` and `args_mapping=` |
-| `NOTIFY`     | `callable`     | ✓ Supported                          | Outer NOTIFY fires, then inner callable target executes; both layers work correctly |
-| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one |
-| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below |
+| Outer (top)  | Inner (bottom) | Status                             | Notes                                                                               |
+| ------------ | -------------- | ---------------------------------- | ----------------------------------------------------------------------------------- |
+| `ARGS_REMAP` | `ARGS_REMAP`   | ✓ Supported                        | Multi-step argument renames across versions                                         |
+| `ARGS_REMAP` | `NOTIFY`       | ✓ Supported                        | Lifecycle: rename args first, then deprecate the whole function                     |
+| `callable`   | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Collapse to `@deprecated(target=fn, args_mapping={...})`                            |
+| `callable`   | `NOTIFY`       | ✗ `UserWarning` at decoration time | Collapse to a single `@deprecated(target=<callable>)`                               |
+| `ARGS_REMAP` | `callable`     | ✗ `UserWarning` at decoration time | Update the inner decorator to include both `target=` and `args_mapping=`            |
+| `NOTIFY`     | `callable`     | ✓ Supported                        | Outer NOTIFY fires, then inner callable target executes; both layers work correctly |
+| `NOTIFY`     | `NOTIFY`       | ✗ `UserWarning` at decoration time | Update the existing decorator's versions instead of adding a second one             |
+| `NOTIFY`     | `ARGS_REMAP`   | ✗ `UserWarning` at decoration time | Wrong order — swap: `ARGS_REMAP` on top, `NOTIFY` below                             |
 
 Use [`validate_deprecation_chains()`](audit.md#detecting-deprecation-chains) in CI to catch accidental deprecated-to-deprecated chains automatically.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Calling `addition(1, 2)` now emits a `FutureWarning` and transparently forwards 
 - **Docstring injection** — `update_docstring=True` appends a Sphinx `.. deprecated::` or MkDocs admonition notice automatically, keeping rendered API docs accurate.
 - **Sphinx Plugin** — ships `deprecate.docstring.sphinx_ext` so `_DeprecatedProxy` objects render with their injected deprecation notice in Sphinx autodoc.
 - **MkDocs Plugin** — ships `deprecate.docstring.griffe_ext` for mkdocstrings so runtime-injected `!!! warning` admonitions are visible in MkDocs-generated API docs.
-- **Decorator stacking** — stack multiple `@deprecated` decorators on one function for multi-level argument migration; each layer tracks its own version range and warning count independently.
+- **Decorator stacking** — stack `@deprecated` decorators for multi-version migrations: rename arguments across releases (`ARGS_REMAP + ARGS_REMAP`), then deprecate the whole function when a complete replacement arrives (`ARGS_REMAP + NOTIFY`). Unsupported combinations warn at decoration time, not at call time.
 - **Custom streams** — route warnings to `logging`, standard `warnings`, or any callable via the `stream` parameter; `stream=None` silences output while forwarding still occurs.
 - **Custom message templates** — `template_mgs` overrides the default message with `%`-style placeholders (`source_name`, `target_path`, `deprecated_in`, `remove_in`, `argument_map`).
 - **Conditional skip** — `skip_if=callable` suppresses the deprecation notice when a runtime condition is met (e.g. caller has migrated to a newer dependency).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -136,7 +136,7 @@ dataclasses.replace(info, empty_args_mapping=True)
 
 **Wrong stacking order** — `@deprecated(NOTIFY)` on top of `@deprecated(ARGS_REMAP)`:
 ```python
-# WRONG — NOTIFY outer silently skips the ARGS_REMAP inner for callers not using the old arg name
+# WRONG — emits UserWarning at decoration time; ARGS_REMAP must be outer (on top), NOTIFY inner
 @deprecated(deprecated_in="2.0", remove_in="3.0")           # outer NOTIFY
 @deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"old": "new"})
 def my_func(old: int = 0, new: int = 0) -> int:
@@ -178,7 +178,7 @@ What is being deprecated?
          │           → also add args_mapping={"old_name": "new_name"}
          ├─ Only renaming an argument within the same function?
          │    → target=TargetMode.ARGS_REMAP with args_mapping; keep working body
-         └─ No replacement, warn-only?
+         ├─ No replacement, warn-only?
               → omit target (defaults to TargetMode.NOTIFY); keep working body
          └─ Already deprecated (args renamed earlier) and now the whole function is going away?
               → keep ARGS_REMAP decorator on top; add @deprecated(NOTIFY) below it

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -134,6 +134,22 @@ dataclasses.replace(info, empty_args_mapping=True)
 
 **Install vs import name confusion** — import as `deprecate`, not `pydeprecate` (install: `pip install pyDeprecate`; import: `from deprecate import deprecated`).
 
+**Wrong stacking order** — `@deprecated(NOTIFY)` on top of `@deprecated(ARGS_REMAP)`:
+```python
+# WRONG — NOTIFY outer silently skips the ARGS_REMAP inner for callers not using the old arg name
+@deprecated(deprecated_in="2.0", remove_in="3.0")           # outer NOTIFY
+@deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"old": "new"})
+def my_func(old: int = 0, new: int = 0) -> int:
+    return new
+
+# CORRECT — ARGS_REMAP on top, NOTIFY below; pyDeprecate warns at decoration if order is wrong
+@deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"old": "new"})
+@deprecated(deprecated_in="2.0", remove_in="3.0")           # inner NOTIFY
+def my_func(old: int = 0, new: int = 0) -> int:
+    return new
+```
+
+
 ### Decision Flowchart
 
 ```
@@ -164,6 +180,9 @@ What is being deprecated?
          │    → target=TargetMode.ARGS_REMAP with args_mapping; keep working body
          └─ No replacement, warn-only?
               → omit target (defaults to TargetMode.NOTIFY); keep working body
+         └─ Already deprecated (args renamed earlier) and now the whole function is going away?
+              → keep ARGS_REMAP decorator on top; add @deprecated(NOTIFY) below it
+                (ARGS_REMAP outer + NOTIFY inner — both layers fire independently)
 ```
 
 ## Resources

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -149,6 +149,8 @@ def my_func(old: int = 0, new: int = 0) -> int:
     return new
 ```
 
+**N-level stacking:** any sequence of supported adjacent pairs stacks transitively (e.g., ARGS_REMAP + ARGS_REMAP + NOTIFY — three decorators). The guard inspects one hop at a time; each adjacent pair must itself be supported.
+
 
 ### Decision Flowchart
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -208,6 +208,14 @@
         },
         {
           "@type": "Question",
+          "name": "Why did I get UserWarning about an unsupported stacking combination?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "pyDeprecate validates @deprecated stacking combinations at decoration time and emits UserWarning for unsupported cases. Only two combinations are supported: ARGS_REMAP (outer) + ARGS_REMAP (inner) for multi-step argument renames, and ARGS_REMAP (outer) + NOTIFY (inner) for the lifecycle pattern of renaming args first then deprecating the whole function. The most common mistake is putting NOTIFY on top of ARGS_REMAP — reverse the order: ARGS_REMAP must be outermost (on top) and NOTIFY must be innermost (below). The warning message includes a corrective hint."
+          }
+        },
+        {
+          "@type": "Question",
           "name": "Why did I get TypeError at decoration time about a cross-class method target?",
           "acceptedAnswer": {
             "@type": "Answer",

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -211,7 +211,7 @@
           "name": "Why did I get UserWarning about an unsupported stacking combination?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "pyDeprecate validates @deprecated stacking combinations at decoration time and emits UserWarning for unsupported cases. Only two combinations are supported: ARGS_REMAP (outer) + ARGS_REMAP (inner) for multi-step argument renames, and ARGS_REMAP (outer) + NOTIFY (inner) for the lifecycle pattern of renaming args first then deprecating the whole function. The most common mistake is putting NOTIFY on top of ARGS_REMAP — reverse the order: ARGS_REMAP must be outermost (on top) and NOTIFY must be innermost (below). The warning message includes a corrective hint."
+            "text": "pyDeprecate validates @deprecated stacking combinations at decoration time and emits UserWarning for unsupported cases. Three combinations are supported: ARGS_REMAP (outer) + ARGS_REMAP (inner) for multi-step argument renames, ARGS_REMAP (outer) + NOTIFY (inner) for the lifecycle pattern of renaming args first then deprecating the whole function, and NOTIFY (outer) + callable target (inner) when the inner decorator forwards to a concrete replacement callable. The most common mistake is putting NOTIFY on top of ARGS_REMAP — reverse the order: ARGS_REMAP must be outermost (on top) and NOTIFY must be innermost (below). The warning message includes a corrective hint."
           }
         },
         {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -610,10 +610,11 @@ Reverse the decorator order: put @deprecated(ARGS_REMAP, ...) outermost (on top)
 and @deprecated(NOTIFY, ...) below it. Will be `TypeError` in `v1.0`.
 ```
 
-**A:** pyDeprecate validates stacking combinations at decoration time and emits `UserWarning` for every unsupported case. Only two combinations work correctly:
+**A:** pyDeprecate validates stacking combinations at decoration time and emits `UserWarning` for every unsupported case. Common supported combinations include:
 
 - `ARGS_REMAP` (outer, on top) + `ARGS_REMAP` (inner): multi-step argument renames across versions.
 - `ARGS_REMAP` (outer, on top) + `NOTIFY` (inner): lifecycle pattern — rename args first, then deprecate the whole function.
+- `NOTIFY` (outer, on top) + `callable` (inner): deprecate a callable target directly without an inner `@deprecated` wrapper.
 
 See [Supported stacking combinations](guide/use-cases.md#supported-stacking-combinations) for the full table. The warning message identifies which combination fired and includes a corrective hint.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -622,15 +622,17 @@ See [Supported stacking combinations](guide/use-cases.md#supported-stacking-comb
 ```python
 from deprecate import TargetMode, deprecated
 
+
 # Wrong — NOTIFY outer emits UserWarning at decoration time
-@deprecated(deprecated_in="2.0", remove_in="3.0")           # outer NOTIFY
+@deprecated(deprecated_in="2.0", remove_in="3.0")  # outer NOTIFY
 @deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"old": "new"})
 def my_func(old: int = 0, new: int = 0) -> int:
     return new
 
+
 # Correct — ARGS_REMAP on top, NOTIFY below
 @deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"old": "new"})
-@deprecated(deprecated_in="2.0", remove_in="3.0")           # inner NOTIFY
+@deprecated(deprecated_in="2.0", remove_in="3.0")  # inner NOTIFY
 def my_func(old: int = 0, new: int = 0) -> int:
     return new
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -598,6 +598,45 @@ If you are on v0.8+ and still seeing an unexpected `TypeError` from the cross-cl
 
 ______________________________________________________________________
 
+## UserWarning at decoration time: unsupported stacking combination
+
+**Q:** I got a `UserWarning` when applying multiple `@deprecated` decorators to the same function. What does it mean and how do I fix it?
+
+The message looks like one of:
+
+```text
+UserWarning: 'my_func' has @deprecated(NOTIFY) stacked over @deprecated(ARGS_REMAP).
+Reverse the decorator order: put @deprecated(ARGS_REMAP, ...) outermost (on top)
+and @deprecated(NOTIFY, ...) below it. Will be `TypeError` in `v1.0`.
+```
+
+**A:** pyDeprecate validates stacking combinations at decoration time and emits `UserWarning` for every unsupported case. Only two combinations work correctly:
+
+- `ARGS_REMAP` (outer, on top) + `ARGS_REMAP` (inner): multi-step argument renames across versions.
+- `ARGS_REMAP` (outer, on top) + `NOTIFY` (inner): lifecycle pattern — rename args first, then deprecate the whole function.
+
+See [Supported stacking combinations](guide/use-cases.md#supported-stacking-combinations) for the full table. The warning message identifies which combination fired and includes a corrective hint.
+
+**Most common case — wrong order (NOTIFY over ARGS_REMAP):**
+
+```python
+from deprecate import TargetMode, deprecated
+
+# Wrong — NOTIFY outer emits UserWarning at decoration time
+@deprecated(deprecated_in="2.0", remove_in="3.0")           # outer NOTIFY
+@deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"old": "new"})
+def my_func(old: int = 0, new: int = 0) -> int:
+    return new
+
+# Correct — ARGS_REMAP on top, NOTIFY below
+@deprecated(TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"old": "new"})
+@deprecated(deprecated_in="2.0", remove_in="3.0")           # inner NOTIFY
+def my_func(old: int = 0, new: int = 0) -> int:
+    return new
+```
+
+______________________________________________________________________
+
 ## Still stuck?
 
 !!! question "Open a GitHub issue"

--- a/src/deprecate/audit.py
+++ b/src/deprecate/audit.py
@@ -363,19 +363,18 @@ def validate_deprecation_wrapper(func: Callable) -> DeprecationWrapperInfo:
     # - ChainType.TARGET: target is a deprecated callable that itself forwards to another function
     #   (i.e. target.__deprecated__.target is not a supported stacking mode). Fix: point directly
     #   to the final target.
-    # - ChainType.STACKED: supported decorator stacking. Three sub-cases:
+    # - ChainType.STACKED: supported decorator stacking. Two sub-cases:
     #   (a) target is a deprecated callable whose own target=ARGS_REMAP (self-deprecation with renaming).
-    #   (b) target is a deprecated callable whose own target=NOTIFY (lifecycle migration).
-    #   (c) target=True but __wrapped__ also has target=True (stacked @deprecated(True) decorators).
+    #   (b) target=True but __wrapped__ also has target=True (stacked @deprecated(True) decorators).
     _is_args_remap = target is TargetMode.ARGS_REMAP
     _is_notify = target is TargetMode.NOTIFY
 
     chain_type: Optional[ChainType] = None
     if callable(target) and _has_deprecation_meta(target):
         wrp_depr_tgt = target.__deprecated__.target
-        # STACKED: inner is ARGS_REMAP (mappings compose) OR inner is NOTIFY (supported lifecycle pattern)
-        # TARGET: inner is another callable (actual forwarding chain — should point to final target directly)
-        is_stacked = wrp_depr_tgt is TargetMode.ARGS_REMAP or wrp_depr_tgt is TargetMode.NOTIFY
+        # STACKED: inner is ARGS_REMAP (mappings compose)
+        # TARGET: inner is NOTIFY or another callable (actual forwarding chain — should point to final target directly)
+        is_stacked = wrp_depr_tgt is TargetMode.ARGS_REMAP
         chain_type = ChainType.STACKED if is_stacked else ChainType.TARGET
     elif _is_args_remap:
         wrapped = getattr(func, "__wrapped__", None)

--- a/src/deprecate/audit.py
+++ b/src/deprecate/audit.py
@@ -361,18 +361,21 @@ def validate_deprecation_wrapper(func: Callable) -> DeprecationWrapperInfo:
     self_reference = target is func if target is not None else False
     # chain_type distinguishes two chain problems:
     # - ChainType.TARGET: target is a deprecated callable that itself forwards to another function
-    #   (i.e. target.__deprecated__.target is not True). Fix: point directly to the final target.
-    # - ChainType.STACKED: arg mappings chain/compose and need collapsing. Two sub-cases:
-    #   (a) target is a deprecated callable whose own target=True (self-deprecation with renaming).
-    #   (b) target=True but __wrapped__ also has target=True (stacked @deprecated(True) decorators).
+    #   (i.e. target.__deprecated__.target is not a supported stacking mode). Fix: point directly
+    #   to the final target.
+    # - ChainType.STACKED: supported decorator stacking. Three sub-cases:
+    #   (a) target is a deprecated callable whose own target=ARGS_REMAP (self-deprecation with renaming).
+    #   (b) target is a deprecated callable whose own target=NOTIFY (lifecycle migration).
+    #   (c) target=True but __wrapped__ also has target=True (stacked @deprecated(True) decorators).
     _is_args_remap = target is TargetMode.ARGS_REMAP
     _is_notify = target is TargetMode.NOTIFY
 
     chain_type: Optional[ChainType] = None
     if callable(target) and _has_deprecation_meta(target):
         wrp_depr_tgt = target.__deprecated__.target
-        is_stacked = wrp_depr_tgt is TargetMode.ARGS_REMAP
-        # target is self-deprecation (mappings compose) or forwarding
+        # STACKED: inner is ARGS_REMAP (mappings compose) OR inner is NOTIFY (supported lifecycle pattern)
+        # TARGET: inner is another callable (actual forwarding chain — should point to final target directly)
+        is_stacked = wrp_depr_tgt is TargetMode.ARGS_REMAP or wrp_depr_tgt is TargetMode.NOTIFY
         chain_type = ChainType.STACKED if is_stacked else ChainType.TARGET
     elif _is_args_remap:
         wrapped = getattr(func, "__wrapped__", None)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -194,10 +194,13 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
     - ``ARGS_REMAP`` (outer) + ``ARGS_REMAP`` (inner): multi-step arg renames across versions.
     - ``ARGS_REMAP`` (outer) + ``NOTIFY`` (inner): lifecycle pattern — rename args first, deprecate
       the whole function later.
+    - ``NOTIFY`` (outer) + ``callable`` (inner): outer NOTIFY warns callers the function is going
+      away; inner callable handles forwarding.
 
-    Unsupported combinations (five cases) produce ``UserWarning`` at decoration time; all others
-    are silently accepted.  The two supported combinations are: ``ARGS_REMAP`` (outer) +
-    ``ARGS_REMAP`` (inner) and ``ARGS_REMAP`` (outer) + ``NOTIFY`` (inner).
+    Unsupported combinations (six cases) produce ``UserWarning`` at decoration time; all others
+    are silently accepted.  The three supported combinations are: ``ARGS_REMAP`` (outer) +
+    ``ARGS_REMAP`` (inner), ``ARGS_REMAP`` (outer) + ``NOTIFY`` (inner), and ``NOTIFY`` (outer) +
+    ``callable`` (inner).
     """
     inner_target = source.__deprecated__.target
     name = source.__name__
@@ -251,6 +254,12 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
             " Reverse the decorator order: put @deprecated(ARGS_REMAP, ...) outermost (on top)"
             " and @deprecated(NOTIFY, ...) below it."
             " Will be `TypeError` in `v1.0`.",
+            UserWarning,
+            stacklevel=3,
+        )
+    else:
+        warnings.warn(
+            f"'{name}' has an unsupported @deprecated stacking combination. Will be `TypeError` in `v1.0`.",
             UserWarning,
             stacklevel=3,
         )

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -222,8 +222,9 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
     elif callable(outer_target) and inner_target is TargetMode.NOTIFY:
         warnings.warn(
             f"'{name}' has a callable target stacked over @deprecated(NOTIFY)."
-            " The function-deprecated warning fires but the callable target is bypassed."
-            " Collapse to a single @deprecated(target=<callable>) and remove the outer @deprecated(NOTIFY)."
+            " The inner function-deprecated warning will not fire at call time; the inner layer is bypassed"
+            " while the callable target is still invoked."
+            " Collapse to a single @deprecated(target=<callable>) and remove the inner @deprecated(NOTIFY)."
             " Will be `TypeError` in `v1.0`.",
             UserWarning,
             stacklevel=3,

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -20,7 +20,14 @@ from inspect import Parameter
 from typing import Any, Callable, Literal, Optional, Union, cast
 from warnings import warn
 
-from deprecate._types import DeprecationConfig, TargetMode, _DeprecatedCallable, _has_deprecation_meta, _WrapperState
+from deprecate._types import (
+    DeprecationConfig,
+    TargetMode,
+    _DeprecatedCallable,
+    _has_deprecation_meta,
+    _HasDeprecationMeta,
+    _WrapperState,
+)
 from deprecate.docstring.inject import _update_docstring_with_deprecation, normalize_docstring_style
 from deprecate.utils import _get_signature, get_func_arguments_types_defaults
 
@@ -176,6 +183,66 @@ def _check_cross_class_method_target(source: Callable, target: Callable) -> None
         f"The target must be a method on the same class ('{src_class_name}') "
         f"or a full class (use target={tgt_class_name} for class migration).",
     )
+
+
+def _warn_stacking_misconfiguration(source: "_HasDeprecationMeta", outer_target: Union[TargetMode, Callable]) -> None:
+    """Emit ``UserWarning`` at decoration time for unsupported stacking combinations.
+
+    Only called when ``source`` already carries ``__deprecated__`` metadata (i.e. is itself a
+    ``@deprecated`` wrapper).  Supported combinations are silently accepted:
+
+    - ``ARGS_REMAP`` (outer) + ``ARGS_REMAP`` (inner): multi-step arg renames across versions.
+    - ``ARGS_REMAP`` (outer) + ``NOTIFY`` (inner): lifecycle pattern — rename args first, deprecate
+      the whole function later.
+
+    All other combinations produce wrong results or ``TypeError`` at the first call; this guard
+    surfaces them at decoration time so authors catch the misconfiguration immediately.
+    """
+    inner_target = source.__deprecated__.target
+    name = source.__name__
+
+    if callable(outer_target) and callable(inner_target):
+        warnings.warn(
+            f"'{name}' has a callable target stacked over another callable-target @deprecated."
+            " Only ARGS_REMAP stacking is supported. This will raise TypeError at call time."
+            " Will be TypeError in v1.0.",
+            UserWarning,
+            stacklevel=4,
+        )
+    elif callable(outer_target) and inner_target is TargetMode.ARGS_REMAP:
+        warnings.warn(
+            f"'{name}' has a callable target stacked over @deprecated(ARGS_REMAP)."
+            " The arg-rename warning will not fire at call time; the inner layer is bypassed."
+            " Collapse to: @deprecated(target=<callable>, args_mapping={...})."
+            " Will be TypeError in v1.0.",
+            UserWarning,
+            stacklevel=4,
+        )
+    elif outer_target is TargetMode.ARGS_REMAP and callable(inner_target):
+        warnings.warn(
+            f"'{name}' has @deprecated(ARGS_REMAP) stacked over a callable-target @deprecated."
+            " Update the inner @deprecated(target=<callable>, args_mapping={...}) instead of stacking."
+            " Will be TypeError in v1.0.",
+            UserWarning,
+            stacklevel=4,
+        )
+    elif outer_target is TargetMode.NOTIFY and inner_target is TargetMode.NOTIFY:
+        warnings.warn(
+            f"'{name}' has duplicate @deprecated(NOTIFY) layers."
+            " Update the existing decorator's `deprecated_in`, `remove_in`, or `template_mgs` instead."
+            " Will be TypeError in v1.0.",
+            UserWarning,
+            stacklevel=4,
+        )
+    elif outer_target is TargetMode.NOTIFY and inner_target is TargetMode.ARGS_REMAP:
+        warnings.warn(
+            f"'{name}' has @deprecated(NOTIFY) stacked over @deprecated(ARGS_REMAP)."
+            " Reverse the decorator order: put @deprecated(ARGS_REMAP, ...) outermost (on top)"
+            " and @deprecated(NOTIFY, ...) below it."
+            " Will be TypeError in v1.0.",
+            UserWarning,
+            stacklevel=4,
+        )
 
 
 def _normalize_target(
@@ -735,18 +802,8 @@ def deprecated(
             _check_cross_class_method_target(source, target)
         _target = _normalize_target(source, target)
 
-        # Stacked callable-target guard: detect ``@deprecated(target=fn_a)`` applied over an
-        # already-wrapped callable that itself has a callable target. Only ARGS_REMAP stacking
-        # is supported; callable-over-callable stacking silently raises ``TypeError`` at the
-        # first call because the inner wrapper's signature does not match the outer target's
-        # remapped kwargs. Surface this at decoration time instead.
-        if callable(_target) and _has_deprecation_meta(source) and callable(source.__deprecated__.target):
-            warnings.warn(
-                f"'{source.__name__}' has a callable target stacked over another callable-target @deprecated."
-                " Only ARGS_REMAP stacking is supported. This will raise TypeError at call time.",
-                UserWarning,
-                stacklevel=3,
-            )
+        if _has_deprecation_meta(source):
+            _warn_stacking_misconfiguration(source, _target)
 
         # Skip for legacy sentinels: _normalize_target already fired a FutureWarning;
         # re-running the guard here would report the wrong migration path.
@@ -794,7 +851,13 @@ def deprecated(
                 reason_argument = {a: b for a, b in args_mapping.items() if a in kwargs}
             # Migrated callers (using the new arg name) produce empty reason_argument;
             # without the args_extra guard they short-circuit before extras are injected.
-            if not (reason_callable or reason_argument) and not (args_extra and _target is TargetMode.ARGS_REMAP):
+            # When source is a stacked @deprecated wrapper (e.g. ARGS_REMAP outer + NOTIFY inner),
+            # do not short-circuit even with no reason — the inner layer may still need to run.
+            if (
+                not (reason_callable or reason_argument)
+                and not (args_extra and _target is TargetMode.ARGS_REMAP)
+                and not _has_deprecation_meta(source)
+            ):
                 return source(**kwargs)
 
             if reason_argument:

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -31,6 +31,8 @@ from deprecate._types import (
 from deprecate.docstring.inject import _update_docstring_with_deprecation, normalize_docstring_style
 from deprecate.utils import _get_signature, get_func_arguments_types_defaults
 
+_V1_BREAK_VERSION = "v1.0"
+
 #: Default template warning message for redirecting callable
 TEMPLATE_WARNING_CALLABLE = (
     "The `%(source_name)s` was deprecated since v%(deprecated_in)s in favor of `%(target_path)s`."
@@ -209,7 +211,7 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
         warnings.warn(
             f"'{name}' has a callable target stacked over another callable-target @deprecated."
             " Only ARGS_REMAP stacking is supported. This will raise `TypeError` at call time."
-            " Will be `TypeError` in `v1.0`.",
+            f" Will be `TypeError` in `{_V1_BREAK_VERSION}`.",
             UserWarning,
             stacklevel=3,
         )
@@ -218,7 +220,7 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
             f"'{name}' has a callable target stacked over @deprecated(ARGS_REMAP)."
             " The arg-rename warning will not fire at call time; the inner layer is bypassed."
             " Collapse to: @deprecated(target=<callable>, args_mapping={...})."
-            " Will be `TypeError` in `v1.0`.",
+            f" Will be `TypeError` in `{_V1_BREAK_VERSION}`.",
             UserWarning,
             stacklevel=3,
         )
@@ -228,7 +230,7 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
             " The inner function-deprecated warning will not fire at call time; the inner layer is bypassed"
             " while the callable target is still invoked."
             " Collapse to a single @deprecated(target=<callable>) and remove the inner @deprecated(NOTIFY)."
-            " Will be `TypeError` in `v1.0`.",
+            f" Will be `TypeError` in `{_V1_BREAK_VERSION}`.",
             UserWarning,
             stacklevel=3,
         )
@@ -236,7 +238,7 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
         warnings.warn(
             f"'{name}' has @deprecated(ARGS_REMAP) stacked over a callable-target @deprecated."
             " Update the inner @deprecated(target=<callable>, args_mapping={...}) instead of stacking."
-            " Will be `TypeError` in `v1.0`.",
+            f" Will be `TypeError` in `{_V1_BREAK_VERSION}`.",
             UserWarning,
             stacklevel=3,
         )
@@ -244,7 +246,7 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
         warnings.warn(
             f"'{name}' has duplicate @deprecated(NOTIFY) layers."
             " Update the existing decorator's `deprecated_in`, `remove_in`, or `template_mgs` instead."
-            " Will be `TypeError` in `v1.0`.",
+            f" Will be `TypeError` in `{_V1_BREAK_VERSION}`.",
             UserWarning,
             stacklevel=3,
         )
@@ -253,13 +255,20 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
             f"'{name}' has @deprecated(NOTIFY) stacked over @deprecated(ARGS_REMAP)."
             " Reverse the decorator order: put @deprecated(ARGS_REMAP, ...) outermost (on top)"
             " and @deprecated(NOTIFY, ...) below it."
-            " Will be `TypeError` in `v1.0`.",
+            f" Will be `TypeError` in `{_V1_BREAK_VERSION}`.",
             UserWarning,
             stacklevel=3,
         )
+    elif (
+        (outer_target is TargetMode.ARGS_REMAP and inner_target is TargetMode.ARGS_REMAP)
+        or (outer_target is TargetMode.ARGS_REMAP and inner_target is TargetMode.NOTIFY)
+        or (outer_target is TargetMode.NOTIFY and callable(inner_target))
+    ):
+        pass  # supported combinations — silently accepted
     else:
         warnings.warn(
-            f"'{name}' has an unsupported @deprecated stacking combination. Will be `TypeError` in `v1.0`.",
+            f"'{name}' has an unsupported @deprecated stacking combination."
+            f" Will be `TypeError` in `{_V1_BREAK_VERSION}`.",
             UserWarning,
             stacklevel=3,
         )
@@ -859,7 +868,7 @@ def deprecated(
             if dep_cfg.misconfigured and stream and not state.warned_misconfigured:
                 warnings.warn(
                     f"'{source.__name__}' has an invalid deprecation configuration;"
-                    " verify your `@deprecated(target=...)` arguments. Will be TypeError in v1.0.",
+                    f" verify your `@deprecated(target=...)` arguments. Will be TypeError in {_V1_BREAK_VERSION}.",
                     UserWarning,
                     stacklevel=2,
                 )

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -185,7 +185,7 @@ def _check_cross_class_method_target(source: Callable, target: Callable) -> None
     )
 
 
-def _warn_stacking_misconfiguration(source: "_HasDeprecationMeta", outer_target: Union[TargetMode, Callable]) -> None:
+def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: Union[TargetMode, Callable]) -> None:
     """Emit ``UserWarning`` at decoration time for unsupported stacking combinations.
 
     Only called when ``source`` already carries ``__deprecated__`` metadata (i.e. is itself a

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -210,7 +210,8 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
     if callable(outer_target) and callable(inner_target):
         warnings.warn(
             f"'{name}' has a callable target stacked over another callable-target @deprecated."
-            " Only ARGS_REMAP stacking is supported. This will raise `TypeError` at call time."
+            " Stacking a callable target over another callable target is not supported."
+            " This will raise `TypeError` at call time."
             f" Will be `TypeError` in `{_V1_BREAK_VERSION}`.",
             UserWarning,
             stacklevel=3,

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -195,8 +195,9 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
     - ``ARGS_REMAP`` (outer) + ``NOTIFY`` (inner): lifecycle pattern — rename args first, deprecate
       the whole function later.
 
-    All other combinations produce wrong results or ``TypeError`` at the first call; this guard
-    surfaces them at decoration time so authors catch the misconfiguration immediately.
+    Unsupported combinations (five cases) produce ``UserWarning`` at decoration time; all others
+    are silently accepted.  The two supported combinations are: ``ARGS_REMAP`` (outer) +
+    ``ARGS_REMAP`` (inner) and ``ARGS_REMAP`` (outer) + ``NOTIFY`` (inner).
     """
     inner_target = source.__deprecated__.target
     name = source.__name__
@@ -204,44 +205,53 @@ def _warn_stacking_misconfiguration(source: _HasDeprecationMeta, outer_target: U
     if callable(outer_target) and callable(inner_target):
         warnings.warn(
             f"'{name}' has a callable target stacked over another callable-target @deprecated."
-            " Only ARGS_REMAP stacking is supported. This will raise TypeError at call time."
-            " Will be TypeError in v1.0.",
+            " Only ARGS_REMAP stacking is supported. This will raise `TypeError` at call time."
+            " Will be `TypeError` in `v1.0`.",
             UserWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
     elif callable(outer_target) and inner_target is TargetMode.ARGS_REMAP:
         warnings.warn(
             f"'{name}' has a callable target stacked over @deprecated(ARGS_REMAP)."
             " The arg-rename warning will not fire at call time; the inner layer is bypassed."
             " Collapse to: @deprecated(target=<callable>, args_mapping={...})."
-            " Will be TypeError in v1.0.",
+            " Will be `TypeError` in `v1.0`.",
             UserWarning,
-            stacklevel=4,
+            stacklevel=3,
+        )
+    elif callable(outer_target) and inner_target is TargetMode.NOTIFY:
+        warnings.warn(
+            f"'{name}' has a callable target stacked over @deprecated(NOTIFY)."
+            " The function-deprecated warning fires but the callable target is bypassed."
+            " Collapse to a single @deprecated(target=<callable>) and remove the outer @deprecated(NOTIFY)."
+            " Will be `TypeError` in `v1.0`.",
+            UserWarning,
+            stacklevel=3,
         )
     elif outer_target is TargetMode.ARGS_REMAP and callable(inner_target):
         warnings.warn(
             f"'{name}' has @deprecated(ARGS_REMAP) stacked over a callable-target @deprecated."
             " Update the inner @deprecated(target=<callable>, args_mapping={...}) instead of stacking."
-            " Will be TypeError in v1.0.",
+            " Will be `TypeError` in `v1.0`.",
             UserWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
     elif outer_target is TargetMode.NOTIFY and inner_target is TargetMode.NOTIFY:
         warnings.warn(
             f"'{name}' has duplicate @deprecated(NOTIFY) layers."
             " Update the existing decorator's `deprecated_in`, `remove_in`, or `template_mgs` instead."
-            " Will be TypeError in v1.0.",
+            " Will be `TypeError` in `v1.0`.",
             UserWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
     elif outer_target is TargetMode.NOTIFY and inner_target is TargetMode.ARGS_REMAP:
         warnings.warn(
             f"'{name}' has @deprecated(NOTIFY) stacked over @deprecated(ARGS_REMAP)."
             " Reverse the decorator order: put @deprecated(ARGS_REMAP, ...) outermost (on top)"
             " and @deprecated(NOTIFY, ...) below it."
-            " Will be TypeError in v1.0.",
+            " Will be `TypeError` in `v1.0`.",
             UserWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
 
 
@@ -803,7 +813,10 @@ def deprecated(
         _target = _normalize_target(source, target)
 
         if _has_deprecation_meta(source):
+            _source_is_stacked = True
             _warn_stacking_misconfiguration(source, _target)
+        else:
+            _source_is_stacked = False
 
         # Skip for legacy sentinels: _normalize_target already fired a FutureWarning;
         # re-running the guard here would report the wrong migration path.
@@ -856,7 +869,7 @@ def deprecated(
             if (
                 not (reason_callable or reason_argument)
                 and not (args_extra and _target is TargetMode.ARGS_REMAP)
-                and not _has_deprecation_meta(source)
+                and not _source_is_stacked
             ):
                 return source(**kwargs)
 

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -63,6 +63,7 @@ from tests.collection_targets import (
     base_pow_args,
     base_sum_kwargs,
     both_old_new_target,
+    compute_power,
     cross_guard_standalone_increment,
     double_value,
     fn_remap_with_extra_body,
@@ -636,28 +637,27 @@ def depr_pow_self_twice(base: float, c1: float = 0, nc1: float = 0, nc2: float =
     return base ** (c1 + nc1 + nc2)
 
 
-@deprecated(TargetMode.ARGS_REMAP, "1.0", "2.0", args_mapping={"factor": "scale"})
-@deprecated(TargetMode.NOTIFY, "2.0", "3.0")
-def depr_compute_power_stacked(base: float, factor: float = 1, scale: float = 1) -> float:
-    """Lifecycle stacking: arg rename (v1.0) + whole-function notice (v2.0).
+def make_depr_compute_power_stacked() -> Callable:
+    """Return a fresh ARGS_REMAP-outer + NOTIFY-inner stacked fixture.
 
-    The outer ARGS_REMAP layer warns when ``factor`` is used (renamed to ``scale`` in
-    v1.0). The inner NOTIFY layer warns on every call that the whole function is
-    deprecated since v2.0. Both layers fire independently, so callers still using the
-    old name receive both warnings.
+    Each call produces a new wrapper pair with an independent ``_WrapperState``,
+    preventing ``num_warns`` counter exhaustion across tests.
 
     Examples:
-        Calling with the old name raises two warnings (arg rename + function deprecated).
+        Calling with the old arg name raises two warnings.
 
         >>> import warnings
+        >>> fn = make_depr_compute_power_stacked()
         >>> with warnings.catch_warnings(record=True) as w:
         ...     warnings.simplefilter("always")
-        ...     result = depr_compute_power_stacked(2, factor=3)
-        ... # doctest: +SKIP
-        >>> result  # doctest: +SKIP
+        ...     result = fn(2.0, factor=3.0)
+        >>> result
         8.0
+        >>> len(w)
+        2
     """
-    return base**scale
+    inner = deprecated(TargetMode.NOTIFY, "2.0", "3.0")(compute_power)
+    return deprecated(TargetMode.ARGS_REMAP, "1.0", "2.0", args_mapping={"factor": "scale"})(inner)
 
 
 @deprecated(TargetMode.ARGS_REMAP, "0.3", "0.4", args_mapping={"c1": "nc1"}, template_mgs=_SHORT_MSG_ARGS, skip_if=True)

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -636,6 +636,30 @@ def depr_pow_self_twice(base: float, c1: float = 0, nc1: float = 0, nc2: float =
     return base ** (c1 + nc1 + nc2)
 
 
+@deprecated(TargetMode.ARGS_REMAP, "1.0", "2.0", args_mapping={"factor": "scale"})
+@deprecated(TargetMode.NOTIFY, "2.0", "3.0")
+def depr_compute_power_stacked(base: float, factor: float = 1, scale: float = 1) -> float:
+    """Lifecycle stacking: arg rename (v1.0) + whole-function notice (v2.0).
+
+    The outer ARGS_REMAP layer warns when ``factor`` is used (renamed to ``scale`` in
+    v1.0). The inner NOTIFY layer warns on every call that the whole function is
+    deprecated since v2.0. Both layers fire independently, so callers still using the
+    old name receive both warnings.
+
+    Examples:
+        Calling with the old name raises two warnings (arg rename + function deprecated).
+
+        >>> import warnings
+        >>> with warnings.catch_warnings(record=True) as w:
+        ...     warnings.simplefilter("always")
+        ...     result = depr_compute_power_stacked(2, factor=3)
+        ... # doctest: +SKIP
+        >>> result  # doctest: +SKIP
+        8.0
+    """
+    return base**scale
+
+
 @deprecated(TargetMode.ARGS_REMAP, "0.3", "0.4", args_mapping={"c1": "nc1"}, template_mgs=_SHORT_MSG_ARGS, skip_if=True)
 @deprecated(
     TargetMode.ARGS_REMAP, "0.1", "0.2", args_mapping={"c1": "nc1"}, template_mgs=_SHORT_MSG_ARGS, skip_if=False

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -660,6 +660,65 @@ def make_depr_compute_power_stacked() -> Callable:
     return deprecated(TargetMode.ARGS_REMAP, "1.0", "2.0", args_mapping={"factor": "scale"})(inner)
 
 
+def make_depr_notify_callable_stacked() -> Callable:
+    """Return a fresh NOTIFY-outer + callable-target-inner stacked fixture.
+
+    Each call produces a new wrapper pair with an independent ``_WrapperState``,
+    preventing ``num_warns`` counter exhaustion across tests.
+
+    The outer ``@deprecated(TargetMode.NOTIFY, ...)`` warns that the whole function is going
+    away; the inner ``@deprecated(target=compute_power, ...)`` warns and forwards to
+    ``compute_power``.  Both ``FutureWarning`` instances fire on every call until counters
+    are exhausted.
+
+    Examples:
+        Calling the stacked wrapper emits two FutureWarnings and returns the computed value.
+
+        >>> import warnings
+        >>> fn = make_depr_notify_callable_stacked()
+        >>> with warnings.catch_warnings(record=True) as w:
+        ...     warnings.simplefilter("always")
+        ...     result = fn(2.0, scale=3.0)
+        >>> result
+        8.0
+        >>> len(w)
+        2
+    """
+    inner = deprecated(target=compute_power, deprecated_in="1.0", remove_in="2.0")(compute_power)
+    return deprecated(TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")(inner)
+
+
+def make_depr_args_remap_notify_with_extra() -> Callable:
+    """Return a fresh ARGS_REMAP-outer + NOTIFY-inner fixture with ``args_extra`` injection.
+
+    The outer ``ARGS_REMAP`` layer maps ``factor`` → ``scale`` and injects ``base=2.0`` via
+    ``args_extra``.  The inner ``NOTIFY`` layer emits its own ``FutureWarning`` and runs the
+    ``compute_power`` body.  Together they verify that ``args_extra`` set on the outer ARGS_REMAP
+    layer flows correctly through the inner NOTIFY layer to the final function call.
+
+    Examples:
+        Calling with the deprecated arg name fires two warnings and returns the injected-base result.
+
+        >>> import warnings
+        >>> fn = make_depr_args_remap_notify_with_extra()
+        >>> with warnings.catch_warnings(record=True) as w:
+        ...     warnings.simplefilter("always")
+        ...     result = fn(factor=3.0)
+        >>> result
+        8.0
+        >>> len(w)
+        2
+    """
+    inner = deprecated(TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")(compute_power)
+    return deprecated(
+        TargetMode.ARGS_REMAP,
+        deprecated_in="1.0",
+        remove_in="2.0",
+        args_mapping={"factor": "scale"},
+        args_extra={"base": 2.0},
+    )(inner)
+
+
 @deprecated(TargetMode.ARGS_REMAP, "0.3", "0.4", args_mapping={"c1": "nc1"}, template_mgs=_SHORT_MSG_ARGS, skip_if=True)
 @deprecated(
     TargetMode.ARGS_REMAP, "0.1", "0.2", args_mapping={"c1": "nc1"}, template_mgs=_SHORT_MSG_ARGS, skip_if=False

--- a/tests/collection_targets.py
+++ b/tests/collection_targets.py
@@ -73,6 +73,16 @@ def stacked_chain_identity(base: int) -> int:
     return base
 
 
+def compute_power(base: float, scale: float = 1) -> float:
+    """Return ``base ** scale``.
+
+    Target for the ARGS_REMAP-outer + NOTIFY-inner lifecycle stacking fixture.
+    The old parameter name ``factor`` was renamed to ``scale`` in v1.0; the whole
+    function is deprecated since v2.0.
+    """
+    return base**scale
+
+
 def return_b(b: int) -> int:
     """Return the mapped positional argument."""
     return b

--- a/tests/collection_targets.py
+++ b/tests/collection_targets.py
@@ -299,3 +299,8 @@ class TimerDecorator:
         self.calls += 1
         print(f"'{self.func.__name__}' executed in {execution_time:.4f}s")
         return result
+
+
+def compute_power(base: float, factor: float = 1, scale: float = 1) -> float:
+    """Compute base raised to scale; factor is the legacy parameter name for scale."""
+    return base**scale

--- a/tests/collection_targets.py
+++ b/tests/collection_targets.py
@@ -73,16 +73,6 @@ def stacked_chain_identity(base: int) -> int:
     return base
 
 
-def compute_power(base: float, scale: float = 1) -> float:
-    """Return ``base ** scale``.
-
-    Target for the ARGS_REMAP-outer + NOTIFY-inner lifecycle stacking fixture.
-    The old parameter name ``factor`` was renamed to ``scale`` in v1.0; the whole
-    function is deprecated since v2.0.
-    """
-    return base**scale
-
-
 def return_b(b: int) -> int:
     """Return the mapped positional argument."""
     return b

--- a/tests/unittests/test_audit.py
+++ b/tests/unittests/test_audit.py
@@ -13,6 +13,7 @@ import pytest
 from deprecate import TargetMode, deprecated
 from deprecate._types import DeprecationConfig, _has_deprecation_meta
 from deprecate.audit import (
+    ChainType,
     DeprecationWrapperInfo,
     _get_package_version,
     _parse_version,
@@ -257,6 +258,20 @@ class TestValidateDeprecationWrapperWithProxy:
         result = validate_deprecation_wrapper(proxy)
         assert result.deprecated_info.args_mapping is None
         assert result.empty_args_mapping is True
+
+    def test_callable_targeting_notify_wrapper_is_target_chain(self) -> None:
+        """A callable target pointing to a NOTIFY wrapper is a forwarding TARGET chain."""
+
+        @deprecated(TargetMode.NOTIFY, deprecated_in="1.0", remove_in="2.0")
+        def notify_layer(value: int) -> int:
+            return value
+
+        @deprecated(target=notify_layer, deprecated_in="1.0", remove_in="2.0")
+        def caller(value: int) -> int:
+            return value
+
+        result = validate_deprecation_wrapper(caller)
+        assert result.chain_type is ChainType.TARGET
 
 
 class TestFindDeprecationWrappersWarningBudget:

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1002,7 +1002,7 @@ class TestStackingGuards:
     remaining combinations.
     """
 
-    def _make_source(self, **kwargs: object) -> Callable[..., int]:
+    def _make_source(self, **kwargs: Any) -> Callable[..., int]:  # noqa: ANN401
         """Return a minimal function decorated with @deprecated using the given kwargs."""
 
         def fn(x: int = 0) -> int:

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1096,7 +1096,7 @@ class TestStackedArgsRemapNotify:
     independently; the inner NOTIFY must run even when no deprecated argument is present.
     """
 
-    def _make_fresh(self) -> object:
+    def _make_fresh(self) -> Callable[..., float]:
         """Return a fresh stacked fixture each time to avoid num_warns counter exhaustion."""
         return make_depr_compute_power_stacked()
 
@@ -1104,7 +1104,7 @@ class TestStackedArgsRemapNotify:
         """Calling with the old arg name raises both the arg-rename and the function-deprecated warning."""
         fn = self._make_fresh()
         with pytest.warns(FutureWarning) as record:
-            result = fn(2, factor=3)  # type: ignore[operator]
+            result = fn(2, factor=3)
         assert result == 8.0
         assert len(record) == 2
 
@@ -1112,7 +1112,7 @@ class TestStackedArgsRemapNotify:
         """Calling with the new arg name raises only the function-deprecated (NOTIFY) warning."""
         fn = self._make_fresh()
         with pytest.warns(FutureWarning) as record:
-            result = fn(2, scale=3)  # type: ignore[operator]
+            result = fn(2, scale=3)
         assert result == 8.0
         assert len(record) == 1
 
@@ -1120,7 +1120,7 @@ class TestStackedArgsRemapNotify:
         """Calling with no arguments at all still fires the NOTIFY warning."""
         fn = self._make_fresh()
         with pytest.warns(FutureWarning) as record:
-            result = fn(2)  # type: ignore[operator]
+            result = fn(2)
         assert result == 2.0
         assert len(record) == 1
 
@@ -1129,7 +1129,7 @@ class TestStackedArgsRemapNotify:
         fn = self._make_fresh()
         # positional: base=2, factor=3 (old positional slot)
         with pytest.warns(FutureWarning) as record:
-            result = fn(2, 3)  # type: ignore[operator]
+            result = fn(2, 3)
         assert result == 8.0
         assert len(record) == 2
 
@@ -1137,10 +1137,10 @@ class TestStackedArgsRemapNotify:
         """Second call after counter exhaustion emits no FutureWarning."""
         fn = self._make_fresh()
         with pytest.warns(FutureWarning):
-            fn(2, factor=3)  # type: ignore[operator]  # exhausts both layer counters
+            fn(2, factor=3)  # exhausts both layer counters
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            fn(2, factor=3)  # type: ignore[operator]
+            fn(2, factor=3)
         assert not [w for w in caught if issubclass(w.category, FutureWarning)]
 
     def test_args_extra_flows_through_notify_layer(self) -> None:
@@ -1166,7 +1166,7 @@ class TestStackedNotifyCallable:
     independently on every call until their counters are exhausted.
     """
 
-    def _make_fresh(self) -> object:
+    def _make_fresh(self) -> Callable[..., float]:
         """Return a fresh stacked fixture each time to avoid num_warns counter exhaustion."""
         return make_depr_notify_callable_stacked()
 
@@ -1174,7 +1174,7 @@ class TestStackedNotifyCallable:
         """Calling the stacked wrapper emits both the NOTIFY and callable-target FutureWarnings."""
         fn = self._make_fresh()
         with pytest.warns(FutureWarning) as record:
-            result = fn(2.0, scale=3.0)  # type: ignore[operator]
+            result = fn(2.0, scale=3.0)
         assert result == 8.0
         assert len(record) == 2
 
@@ -1182,15 +1182,15 @@ class TestStackedNotifyCallable:
         """The callable-target inner layer correctly forwards the call to the final function."""
         fn = self._make_fresh()
         with pytest.warns(FutureWarning):
-            result = fn(3.0, scale=2.0)  # type: ignore[operator]
+            result = fn(3.0, scale=2.0)
         assert result == 9.0
 
     def test_counter_exhausted_fires_no_warnings_on_repeat(self) -> None:
         """Second call after counter exhaustion emits no FutureWarning."""
         fn = self._make_fresh()
         with pytest.warns(FutureWarning):
-            fn(2.0, scale=3.0)  # type: ignore[operator]  # exhausts both layer counters
+            fn(2.0, scale=3.0)  # exhausts both layer counters
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            fn(2.0, scale=3.0)  # type: ignore[operator]
+            fn(2.0, scale=3.0)
         assert not [w for w in caught if issubclass(w.category, FutureWarning)]

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -34,6 +34,7 @@ from tests.collection_deprecate import (
     CrossGuardModuleLevel,
     CrossGuardOldClass,
     CrossGuardSameClass,
+    make_depr_compute_power_stacked,
     pep702_stacked,
 )
 from tests.collection_targets import KeywordCallTarget, call_signature_source
@@ -1055,14 +1056,7 @@ class TestStackedArgsRemapNotify:
 
     def _make_fresh(self) -> object:
         """Return a fresh stacked fixture each time to avoid num_warns counter exhaustion."""
-
-        def compute(base: float, factor: float = 1, scale: float = 1) -> float:
-            return base**scale
-
-        inner = deprecated(target=TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")(compute)
-        return deprecated(
-            target=TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"factor": "scale"}
-        )(inner)
+        return make_depr_compute_power_stacked()
 
     def test_old_arg_fires_two_warnings(self) -> None:
         """Calling with the old arg name raises both the arg-rename and the function-deprecated warning."""

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1001,7 +1001,7 @@ class TestStackingGuards:
     remaining combinations.
     """
 
-    def _make_source(self, **kwargs: object) -> object:
+    def _make_source(self, **kwargs: Any) -> Any:
         """Return a minimal function decorated with @deprecated using the given kwargs."""
 
         def fn(x: int = 0) -> int:

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1017,32 +1017,57 @@ class TestStackingGuards:
         inner = self._make_source(
             target=TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"x": "y"}
         )
-        with pytest.warns(UserWarning, match="callable target stacked over.*ARGS_REMAP"):
+        with pytest.warns(UserWarning, match="callable target stacked over.*ARGS_REMAP") as record:
             deprecated(target=stacked_outer_target, deprecated_in="2.0", remove_in="3.0")(inner)
+        assert record[0].filename.endswith("test_deprecation.py")
 
     def test_args_remap_over_callable_warns(self) -> None:
         """ARGS_REMAP outer stacked over callable-target inner emits ``UserWarning``."""
         from tests.collection_targets import stacked_outer_target
 
         inner = self._make_source(target=stacked_outer_target, deprecated_in="1.0", remove_in="2.0")
-        with pytest.warns(UserWarning, match="ARGS_REMAP.*stacked over a callable"):
+        with pytest.warns(UserWarning, match="ARGS_REMAP.*stacked over a callable") as record:
             deprecated(target=TargetMode.ARGS_REMAP, deprecated_in="2.0", remove_in="3.0", args_mapping={"x": "y"})(
                 inner
             )
+        assert record[0].filename.endswith("test_deprecation.py")
 
     def test_notify_over_notify_warns(self) -> None:
         """Duplicate NOTIFY layers emit ``UserWarning`` at decoration time."""
         inner = self._make_source(target=TargetMode.NOTIFY, deprecated_in="1.0", remove_in="2.0")
-        with pytest.warns(UserWarning, match="duplicate.*NOTIFY"):
+        with pytest.warns(UserWarning, match="duplicate.*NOTIFY") as record:
             deprecated(target=TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")(inner)
+        assert record[0].filename.endswith("test_deprecation.py")
 
     def test_notify_over_args_remap_warns_with_order_hint(self) -> None:
         """NOTIFY outer + ARGS_REMAP inner (wrong order) emits ``UserWarning`` with order hint."""
         inner = self._make_source(
             target=TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"x": "y"}
         )
-        with pytest.warns(UserWarning, match="Reverse the decorator order"):
+        with pytest.warns(UserWarning, match="Reverse the decorator order") as record:
             deprecated(target=TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")(inner)
+        assert record[0].filename.endswith("test_deprecation.py")
+
+    def test_callable_over_notify_warns(self) -> None:
+        """Callable-target outer stacked over NOTIFY inner emits ``UserWarning``."""
+        from tests.collection_targets import stacked_outer_target
+
+        inner = self._make_source(target=TargetMode.NOTIFY, deprecated_in="1.0", remove_in="2.0")
+        with pytest.warns(UserWarning, match="callable target stacked over.*NOTIFY") as record:
+            deprecated(target=stacked_outer_target, deprecated_in="2.0", remove_in="3.0")(inner)
+        assert record[0].filename.endswith("test_deprecation.py")
+
+    def test_args_remap_over_args_remap_does_not_warn(self) -> None:
+        """Supported ARGS_REMAP+ARGS_REMAP stacking must not emit any UserWarning."""
+        inner = self._make_source(
+            target=TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"x": "y"}
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            deprecated(target=TargetMode.ARGS_REMAP, deprecated_in="2.0", remove_in="3.0", args_mapping={"y": "z"})(
+                inner
+            )
+        assert not [w for w in caught if issubclass(w.category, UserWarning)]
 
 
 class TestStackedArgsRemapNotify:
@@ -1090,3 +1115,13 @@ class TestStackedArgsRemapNotify:
             result = fn(2, 3)  # type: ignore[operator]
         assert result == 8.0
         assert len(record) == 2
+
+    def test_counter_exhausted_fires_no_warnings_on_repeat(self) -> None:
+        """Second call after counter exhaustion emits no FutureWarning."""
+        fn = self._make_fresh()
+        with pytest.warns(FutureWarning):
+            fn(2, factor=3)  # type: ignore[operator]  # exhausts both layer counters
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fn(2, factor=3)  # type: ignore[operator]
+        assert not [w for w in caught if issubclass(w.category, FutureWarning)]

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -997,9 +997,9 @@ class TestStackingGuards:
     """Decoration-time ``UserWarning`` for every unsupported stacking combination.
 
     Each guard surfaces a misconfiguration before the first call rather than producing
-    silently wrong results or raising ``TypeError`` at runtime.  The callable+callable
-    case is covered by ``TestStackedCallableTargetGuard``; this class covers the four
-    remaining combinations.
+    silently wrong results or raising ``TypeError`` at runtime. The callable+callable
+    case is covered by ``TestStackedCallableTargetGuard``; this class covers the other
+    unsupported stacking combinations exercised below.
     """
 
     def _make_source(self, **kwargs: Any) -> Callable[..., int]:  # noqa: ANN401

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -34,7 +34,9 @@ from tests.collection_deprecate import (
     CrossGuardModuleLevel,
     CrossGuardOldClass,
     CrossGuardSameClass,
+    make_depr_args_remap_notify_with_extra,
     make_depr_compute_power_stacked,
+    make_depr_notify_callable_stacked,
     pep702_stacked,
 )
 from tests.collection_targets import KeywordCallTarget, call_signature_source
@@ -1069,6 +1071,21 @@ class TestStackingGuards:
             )
         assert not [w for w in caught if issubclass(w.category, UserWarning)]
 
+    def test_non_stacked_args_remap_new_arg_silent(self) -> None:
+        """Regression: non-stacked ARGS_REMAP (_source_is_stacked=False) is silent when new arg used.
+
+        The early-return guard includes ``not _source_is_stacked``.  Verifies this condition still
+        allows a non-stacked ARGS_REMAP function to short-circuit with no warning when the caller
+        already uses the new argument name.
+        """
+        fn = self._make_source(
+            target=TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"old": "x"}
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fn(x=5)
+        assert not [w for w in caught if issubclass(w.category, FutureWarning)]
+
 
 class TestStackedArgsRemapNotify:
     """Behaviour of the supported ARGS_REMAP-outer + NOTIFY-inner lifecycle stacking.
@@ -1124,4 +1141,56 @@ class TestStackedArgsRemapNotify:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             fn(2, factor=3)  # type: ignore[operator]
+        assert not [w for w in caught if issubclass(w.category, FutureWarning)]
+
+    def test_args_extra_flows_through_notify_layer(self) -> None:
+        """args_extra on the outer ARGS_REMAP layer reaches the target via the inner NOTIFY layer.
+
+        Verifies that ``args_extra`` set on the outer ``ARGS_REMAP`` decorator is injected before
+        the call is handed off to the inner ``NOTIFY`` wrapper, so the final function receives the
+        extra kwargs correctly.
+        """
+        fn = make_depr_args_remap_notify_with_extra()
+        with pytest.warns(FutureWarning) as record:
+            result = fn(factor=3.0)
+        assert result == 8.0
+        assert len(record) == 2
+
+
+class TestStackedNotifyCallable:
+    """Call-time behaviour of the supported NOTIFY-outer + callable-target-inner stacking.
+
+    Pattern: ``@deprecated(TargetMode.NOTIFY, ...)`` on top, ``@deprecated(target=<fn>, ...)``
+    below.  The outer NOTIFY warns callers the function is going away; the inner callable-target
+    layer warns and forwards to the final function.  Both ``FutureWarning`` instances must fire
+    independently on every call until their counters are exhausted.
+    """
+
+    def _make_fresh(self) -> object:
+        """Return a fresh stacked fixture each time to avoid num_warns counter exhaustion."""
+        return make_depr_notify_callable_stacked()
+
+    def test_call_fires_two_warnings(self) -> None:
+        """Calling the stacked wrapper emits both the NOTIFY and callable-target FutureWarnings."""
+        fn = self._make_fresh()
+        with pytest.warns(FutureWarning) as record:
+            result = fn(2.0, scale=3.0)  # type: ignore[operator]
+        assert result == 8.0
+        assert len(record) == 2
+
+    def test_result_correctly_forwarded_to_target(self) -> None:
+        """The callable-target inner layer correctly forwards the call to the final function."""
+        fn = self._make_fresh()
+        with pytest.warns(FutureWarning):
+            result = fn(3.0, scale=2.0)  # type: ignore[operator]
+        assert result == 9.0
+
+    def test_counter_exhausted_fires_no_warnings_on_repeat(self) -> None:
+        """Second call after counter exhaustion emits no FutureWarning."""
+        fn = self._make_fresh()
+        with pytest.warns(FutureWarning):
+            fn(2.0, scale=3.0)  # type: ignore[operator]  # exhausts both layer counters
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            fn(2.0, scale=3.0)  # type: ignore[operator]
         assert not [w for w in caught if issubclass(w.category, FutureWarning)]

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -990,3 +990,109 @@ class TestStackedCallableTargetGuard:
         inner = deprecated(target=stacked_inner_target, deprecated_in="0.8", remove_in="1.0")(stacked_outer_target)
         with pytest.warns(UserWarning, match="callable target stacked"):
             deprecated(target=stacked_outer_target, deprecated_in="0.8", remove_in="1.0")(inner)
+
+
+class TestStackingGuards:
+    """Decoration-time ``UserWarning`` for every unsupported stacking combination.
+
+    Each guard surfaces a misconfiguration before the first call rather than producing
+    silently wrong results or raising ``TypeError`` at runtime.  The callable+callable
+    case is covered by ``TestStackedCallableTargetGuard``; this class covers the four
+    remaining combinations.
+    """
+
+    def _make_source(self, **kwargs: object) -> object:
+        """Return a minimal function decorated with @deprecated using the given kwargs."""
+
+        def fn(x: int = 0) -> int:
+            return x
+
+        return deprecated(**kwargs)(fn)
+
+    def test_callable_over_args_remap_warns(self) -> None:
+        """Callable-target outer stacked over ARGS_REMAP inner emits ``UserWarning``."""
+        from tests.collection_targets import stacked_outer_target
+
+        inner = self._make_source(
+            target=TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"x": "y"}
+        )
+        with pytest.warns(UserWarning, match="callable target stacked over.*ARGS_REMAP"):
+            deprecated(target=stacked_outer_target, deprecated_in="2.0", remove_in="3.0")(inner)
+
+    def test_args_remap_over_callable_warns(self) -> None:
+        """ARGS_REMAP outer stacked over callable-target inner emits ``UserWarning``."""
+        from tests.collection_targets import stacked_outer_target
+
+        inner = self._make_source(target=stacked_outer_target, deprecated_in="1.0", remove_in="2.0")
+        with pytest.warns(UserWarning, match="ARGS_REMAP.*stacked over a callable"):
+            deprecated(target=TargetMode.ARGS_REMAP, deprecated_in="2.0", remove_in="3.0", args_mapping={"x": "y"})(
+                inner
+            )
+
+    def test_notify_over_notify_warns(self) -> None:
+        """Duplicate NOTIFY layers emit ``UserWarning`` at decoration time."""
+        inner = self._make_source(target=TargetMode.NOTIFY, deprecated_in="1.0", remove_in="2.0")
+        with pytest.warns(UserWarning, match="duplicate.*NOTIFY"):
+            deprecated(target=TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")(inner)
+
+    def test_notify_over_args_remap_warns_with_order_hint(self) -> None:
+        """NOTIFY outer + ARGS_REMAP inner (wrong order) emits ``UserWarning`` with order hint."""
+        inner = self._make_source(
+            target=TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"x": "y"}
+        )
+        with pytest.warns(UserWarning, match="Reverse the decorator order"):
+            deprecated(target=TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")(inner)
+
+
+class TestStackedArgsRemapNotify:
+    """Behaviour of the supported ARGS_REMAP-outer + NOTIFY-inner lifecycle stacking.
+
+    Pattern: ``@deprecated(ARGS_REMAP, ...)`` on top, ``@deprecated(NOTIFY, ...)`` below.
+    This matches the lifecycle where arguments are renamed in an earlier release and the
+    whole function is deprecated in a later one.  Both warning layers must fire
+    independently; the inner NOTIFY must run even when no deprecated argument is present.
+    """
+
+    def _make_fresh(self) -> object:
+        """Return a fresh stacked fixture each time to avoid num_warns counter exhaustion."""
+
+        def compute(base: float, factor: float = 1, scale: float = 1) -> float:
+            return base**scale
+
+        inner = deprecated(target=TargetMode.NOTIFY, deprecated_in="2.0", remove_in="3.0")(compute)
+        return deprecated(
+            target=TargetMode.ARGS_REMAP, deprecated_in="1.0", remove_in="2.0", args_mapping={"factor": "scale"}
+        )(inner)
+
+    def test_old_arg_fires_two_warnings(self) -> None:
+        """Calling with the old arg name raises both the arg-rename and the function-deprecated warning."""
+        fn = self._make_fresh()
+        with pytest.warns(FutureWarning) as record:
+            result = fn(2, factor=3)  # type: ignore[operator]
+        assert result == 8.0
+        assert len(record) == 2
+
+    def test_new_arg_fires_only_notify(self) -> None:
+        """Calling with the new arg name raises only the function-deprecated (NOTIFY) warning."""
+        fn = self._make_fresh()
+        with pytest.warns(FutureWarning) as record:
+            result = fn(2, scale=3)  # type: ignore[operator]
+        assert result == 8.0
+        assert len(record) == 1
+
+    def test_no_deprecated_args_fires_only_notify(self) -> None:
+        """Calling with no arguments at all still fires the NOTIFY warning."""
+        fn = self._make_fresh()
+        with pytest.warns(FutureWarning) as record:
+            result = fn(2)  # type: ignore[operator]
+        assert result == 2.0
+        assert len(record) == 1
+
+    def test_positional_call_fires_two_warnings(self) -> None:
+        """Positional call mapping to the old arg position fires both warnings."""
+        fn = self._make_fresh()
+        # positional: base=2, factor=3 (old positional slot)
+        with pytest.warns(FutureWarning) as record:
+            result = fn(2, 3)  # type: ignore[operator]
+        assert result == 8.0
+        assert len(record) == 2

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1001,7 +1001,7 @@ class TestStackingGuards:
     remaining combinations.
     """
 
-    def _make_source(self, **kwargs: Any) -> Any:
+    def _make_source(self, **kwargs: object) -> Callable[..., int]:
         """Return a minimal function decorated with @deprecated using the given kwargs."""
 
         def fn(x: int = 0) -> int:


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fix early-return short-circuit (line ~851) that bypassed the inner NOTIFY layer when no deprecated args were present in the call, causing ARGS_REMAP-outer + NOTIFY-inner stacks to silently skip the whole-function deprecation notice.

Extract all decoration-time stacking guards into `_warn_stacking_misconfiguration`, replacing the old single callable+callable check with five cases:
- callable + callable (kept, message unchanged)
- callable + ARGS_REMAP (new) — collapse hint
- ARGS_REMAP + callable (new) — collapse hint
- NOTIFY + NOTIFY (new) — dedup hint
- NOTIFY + ARGS_REMAP (new) — wrong-order hint with exact fix

Add tests: `TestStackingGuards` (4 tests, all decoration-time guards) and `TestStackedArgsRemapNotify` (4 tests, correct lifecycle behavior including positional call and no-deprecated-args cases).

Add collection fixtures: `compute_power` target, `depr_compute_power_stacked` wrapper.

Update docs: rename "Chained deprecation levels" → "Stacked deprecation decorators" in use-cases.md and README; add Pattern 2 lifecycle example; add supported-combinations matrix; update docs/index.md and docs/llms.txt feature description, anti-pattern, and Decision Flowchart.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
