### PR TITLE
fix: guard wrong-order @{class/static}method at decoration time

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -283,7 +283,7 @@ git push origin fix/123-your-bug-description
 ### Style & Formatting
 
 - Follow [PEP 8](https://pep8.org/) style guidelines — enforced automatically by `ruff` via pre-commit hooks
-- Write clear, descriptive docstrings (Google-style convention) for all public functions, methods, and classes; include an `Example:` section for non-trivial behavior
+- Write clear, descriptive docstrings (Google-style convention) for all public functions, methods, and classes; include an `Example:` section for non-trivial behavior — omit only when an example literally cannot run (e.g., requires an external service or produces non-deterministic output); showing the call without output (`>>> result = fn(x)` with no output line) is fine and still counts as a runnable doctest; `# doctest: +SKIP` and `# phmdoctest:skip` are highly discouraged — each instance degrades testability; if you must use one, explain why in a comment on the same line
 - In docstrings, always reference project symbols with their full import path using Sphinx cross-reference syntax (e.g., `` :func:`~deprecate.deprecation.deprecated` `` rather than just `` :func:`deprecated` ``); standard library symbols (e.g., `FutureWarning`) do not need a module prefix
 - Use **MkDocs admonition syntax** for docstring notices in `src/deprecate/` by default — `!!! note`, `!!! warning "Deprecated in X.Y"`, etc. Do not use RST directives (`.. note::`, `.. deprecated::`) in package source docstrings unless the module specifically exists to integrate with Sphinx/RST docstrings (for example, `src/deprecate/docstring/sphinx_ext.py` and `src/deprecate/docstring/griffe_ext.py`). For demos, `demo-docs/sphinx/` follows RST conventions and `demo-docs/mkdocs/` follows MkDocs conventions — each demo matches its own renderer.
 - Keep functions focused and modular — a function should do one thing; if it needs a long comment to explain what it does, it probably needs to be split
@@ -291,7 +291,7 @@ git push origin fix/123-your-bug-description
 - Align type hint syntax with the **minimum supported Python version** (check `python_requires` in `setup.py`)
 - If unsure about syntax compatibility, consult the official Python documentation for that version or search for the relevant PEP
 - Write meaningful variable and function names — prefer `expired_callables` over `lst`, `source_func` over `f`
-- Add comments only where the logic is not self-evident — explain **why**, not __what__
+- Write Python code that is readable on its own — good names and structure are the primary documentation. Add an inline comment only when it carries context the code cannot: **why** a non-obvious choice was made, a hidden constraint, a subtle invariant, or a workaround for a specific external behaviour. One short line; never explain what the code does
 - When changing existing behavior, scan changed files for stale inline comments — update or remove them (stale comments mislead more than none)
 - No bare `except:` — always catch specific exceptions (e.g., `except ValueError:`, `except ImportError:`)
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ For most of these cases, you want to maintain some compatibility, so you cannot 
 
 Another good aspect is not overwhelming users with too many warnings, so per function/class, this warning is raised only N times in the preferred stream (warning, logger, etc.).
 
-> pyDeprecate is downloaded over **700,000 times per month** from PyPI (source: [pepy.tech](https://pepy.tech/project/pyDeprecate)) — a widely adopted solution for API deprecation in production Python codebases.
->
 > **Read:** [Mastering API Deprecation in Python — the pain points and how pyDeprecate can help](https://medium.com/codex/mastering-api-deprecation-in-python-the-pain-points-and-how-pydeprecate-can-help-1dbfd90e2b62) — CodeX / Medium
 
 ## ✨ Features

--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -156,7 +156,6 @@ print(old_internal(5))
 Pass `logging.warning` (or any logging level method) to route deprecation messages through Python's logging system. This plugs straight into your existing log aggregation, filtering, and formatting.
 
 ```python
-# phmdoctest:skip
 import logging
 from deprecate import deprecated
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -97,7 +97,7 @@ Some `TargetMode` + argument combinations are contradictory; pyDeprecate emits a
 Two fields on `DeprecationWrapperInfo` were renamed in v0.8 to be consistent with the rest of the API. The old names still work but emit a `DeprecationWarning` on access — swapping them out is a one-line change:
 
 ```python
-# phmdoctest:skip
+# phmdoctest:skip — info object requires audit context; snippet shows attribute names only
 # Legacy names — emit DeprecationWarning on access
 info.empty_mapping
 info.identity_mapping

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -103,7 +103,6 @@ calculate = deprecated(
 Use `args_mapping` when the new function accepts the same arguments under different names. The decorator translates old parameter names to new ones at call time, so callers can keep passing the old names during the deprecation window without any manual mapping code.
 
 ```python
-# phmdoctest:skip
 import logging
 from sklearn.metrics import accuracy_score
 from deprecate import deprecated, void

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,7 @@ from deprecate import deprecated
 Not:
 
 ```python
-# phmdoctest:skip
+# phmdoctest:skip — intentional wrong import; would raise ModuleNotFoundError
 from pydeprecate import deprecated  # wrong — no such module
 ```
 
@@ -80,7 +80,7 @@ class MyClass:
 Symptoms of the old behaviour:
 
 ```python
-# phmdoctest:skip
+# phmdoctest:skip — shows pre-v0.6 behaviour; current code uses a proxy and no longer produces these errors
 # --- Old broken pattern (pre-v0.6) ---
 from deprecate import deprecated
 
@@ -420,7 +420,6 @@ print(get_old_threshold())
 **A:** Pass any logging method as the `stream` parameter. The `stream` callable receives the formatted deprecation message as a single string argument — logging methods like `logging.warning` have exactly this signature. For the full range of `stream` options (silencing, custom callables, `print`), see [Deprecation Output Sink](guide/customization.md#deprecation-output-sink-stream).
 
 ```python
-# phmdoctest:skip
 import logging
 from deprecate import deprecated
 

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -766,8 +766,6 @@ def deprecated(
                 stacklevel=2,
             )
             return source
-        # Python 3.9–3.11: iscoroutinefunction(partial(async_fn)) returns False — flag lives on partial.func.
-        _source_for_predicates = source.func if isinstance(source, partial) else source
         # Probe ``template_mgs`` against every documented placeholder so typos and malformed
         # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
         _validate_template_mgs(template_mgs)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -761,7 +761,7 @@ def deprecated(
             kind = "classmethod" if isinstance(source, classmethod) else "staticmethod"
             warnings.warn(
                 f"@deprecated applied outside @{kind} for `{source.__func__.__name__}`."
-                " Apply @deprecated inside (closer to `def`). See docs/guide/use-cases.md#classmethod.",
+                " Apply @deprecated inside (closer to `def`). See docs/guide/use-cases.md.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -756,6 +756,18 @@ def deprecated(
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
     def packing(source: Callable) -> Callable:
+        # Wrong-order @classmethod/@staticmethod — source is a descriptor; wrapping it breaks __get__ dispatch.
+        if isinstance(source, (classmethod, staticmethod)):
+            kind = "classmethod" if isinstance(source, classmethod) else "staticmethod"
+            warnings.warn(
+                f"@deprecated applied outside @{kind} for `{source.__func__.__name__}`."
+                " Apply @deprecated inside (closer to `def`). See docs/guide/use-cases.md#classmethod.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return source
+        # Python 3.9–3.11: iscoroutinefunction(partial(async_fn)) returns False — flag lives on partial.func.
+        _source_for_predicates = source.func if isinstance(source, partial) else source
         # Probe ``template_mgs`` against every documented placeholder so typos and malformed
         # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
         _validate_template_mgs(template_mgs)

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1204,3 +1204,40 @@ class TestStackedNotifyCallable:
             warnings.simplefilter("always")
             fn(2.0, scale=3.0)
         assert not [w for w in caught if issubclass(w.category, FutureWarning)]
+
+
+class TestDescriptorOrderGuard:
+    """@deprecated applied outside @classmethod or @staticmethod emits UserWarning and returns descriptor unchanged.
+
+    Correct order has @deprecated closer to ``def`` (inside @classmethod/@staticmethod).
+    Wrong order passes a descriptor object to packing() instead of a plain function — the guard
+    surfaces this at decoration time and returns the descriptor unchanged so the class still works.
+    """
+
+    def test_wrong_order_classmethod_warns(self) -> None:
+        """Wrong-order @deprecated @classmethod emits UserWarning pointing at the decoration site."""
+        with pytest.warns(UserWarning, match=r"@deprecated applied outside @classmethod") as record:
+
+            class _Cls:
+                @deprecated(deprecated_in="1.0", remove_in="2.0")
+                @classmethod
+                def old_method(cls, x: int) -> int:
+                    """Old classmethod."""
+                    return x
+
+        assert record[0].filename.endswith("test_deprecation.py")
+        assert isinstance(_Cls.__dict__["old_method"], classmethod)
+
+    def test_wrong_order_staticmethod_warns(self) -> None:
+        """Wrong-order @deprecated @staticmethod emits UserWarning pointing at the decoration site."""
+        with pytest.warns(UserWarning, match=r"@deprecated applied outside @staticmethod") as record:
+
+            class _Cls:
+                @deprecated(deprecated_in="1.0", remove_in="2.0")
+                @staticmethod
+                def old_method(x: int) -> int:
+                    """Old staticmethod."""
+                    return x
+
+        assert record[0].filename.endswith("test_deprecation.py")
+        assert isinstance(_Cls.__dict__["old_method"], staticmethod)


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- Detect classmethod/staticmethod descriptor passed to packing() — wrong decorator order silently produced a broken wrapper
- Emit UserWarning naming the specific descriptor kind and return descriptor unchanged so class still works
- Add _source_for_predicates partial-unwrap after guard — prerequisite for async predicate checks (PR2)
- Tests: TestDescriptorOrderGuard covers classmethod and staticmethod wrong-order; stacklevel verified

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
