### PR TITLE
feat: order-agnostic @{class/static}method & audit dicovery

### DIFF
--- a/docs/guide/audit.md
+++ b/docs/guide/audit.md
@@ -139,10 +139,10 @@ for r in results[:5]:
 ```
 Found 0 deprecated wrappers with zero impact!
 tests.collection_deprecate.ChainedProxyColorEnum: no_effect=False
+tests.collection_deprecate.CrossGuardModuleLevel.old_method: no_effect=False
+tests.collection_deprecate.CrossGuardSameClass.old_method: no_effect=False
 tests.collection_deprecate.DecoratedDataClass: no_effect=False
 tests.collection_deprecate.DecoratedEnum: no_effect=False
-tests.collection_deprecate.DeprecatedColorDataClass: no_effect=False
-tests.collection_deprecate.DeprecatedColorEnum: no_effect=False
 ```
 
 </details>

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -916,6 +916,48 @@ Both decorator orders produce `classmethod(deprecated_wrapper)` or `staticmethod
 
     The inner-first order is the conventional Python style — outer decorators apply last. Follow this pattern for consistency if your team has no existing convention.
 
+## Properties and cached properties
+
+`@deprecated` works with `@property` and `@cached_property` in either decorator order — the deprecation warning fires correctly at access time regardless of which order the decorators were applied.
+
+```python
+from functools import cached_property
+
+from deprecate import deprecated
+
+
+class Config:
+    # @deprecated inside @property — conventional order
+    @property
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
+    def timeout(self) -> int:
+        return 30
+
+    # @deprecated outside @property — also works
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
+    @property
+    def retries(self) -> int:
+        return 3
+
+    # @deprecated inside @cached_property — conventional order
+    @cached_property
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
+    def base_url(self) -> str:
+        return "https://example.com"
+
+    # @deprecated outside @cached_property — also works
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
+    @cached_property
+    def legacy_url(self) -> str:
+        return "https://old.example.com"
+```
+
+The `FutureWarning` fires on **attribute access** (`obj.timeout`), not on a call. For `@cached_property`, the warning fires on **first access only** — subsequent accesses return the cached value without emitting another warning.
+
+!!! tip "Prefer `@property @deprecated` (deprecated closer to `def`)"
+
+    The inner-first order is the conventional Python style. Follow this pattern for consistency if your team has no existing convention.
+
 ## See also
 
 - [Customization](customization.md) — redirect deprecation output to a logger or use a custom message template

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -888,23 +888,23 @@ from deprecate import deprecated
 class ApiClient:
     # @deprecated inside @classmethod — conventional order, @deprecated closer to def
     @classmethod
-    @deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
     def from_url(cls, url: str) -> "ApiClient":
         return cls()
 
     # @deprecated outside @classmethod — also works; both produce the same descriptor
-    @deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
     @classmethod
     def from_config(cls, config: dict) -> "ApiClient":
         return cls()
 
     # Same flexibility with @staticmethod
     @staticmethod
-    @deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
     def version() -> str:
         return "1.0"
 
-    @deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+    @deprecated(deprecated_in="1.0", remove_in="2.0")
     @staticmethod
     def build_id() -> str:
         return "legacy"

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -910,7 +910,7 @@ class ApiClient:
         return "legacy"
 ```
 
-Both orders produce `classmethod(deprecated_wrapper)` internally. The deprecation `FutureWarning` fires at call time regardless of which order the decorators were applied.
+Both decorator orders produce `classmethod(deprecated_wrapper)` or `staticmethod(deprecated_wrapper)` respectively. The deprecation `FutureWarning` fires at call time regardless of which order the decorators were applied.
 
 !!! tip "Prefer `@classmethod @deprecated` (deprecated closer to `def`)"
 

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -877,6 +877,45 @@ Quick reference for choosing the right testing tool:
 
 Use `assert_no_warnings` in test assertions to verify that refactored code no longer triggers deprecation notices. Use `warnings.catch_warnings` in fixtures when you need to call deprecated code silently during setup.
 
+## Class methods and static methods
+
+`@deprecated` works with both `@classmethod` and `@staticmethod` in either decorator order — place `@deprecated` above or below the descriptor decorator and the deprecation warning fires correctly at call time either way.
+
+```python
+from deprecate import deprecated
+
+
+class ApiClient:
+    # @deprecated inside @classmethod — conventional order, @deprecated closer to def
+    @classmethod
+    @deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+    def from_url(cls, url: str) -> "ApiClient":
+        return cls()
+
+    # @deprecated outside @classmethod — also works; both produce the same descriptor
+    @deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+    @classmethod
+    def from_config(cls, config: dict) -> "ApiClient":
+        return cls()
+
+    # Same flexibility with @staticmethod
+    @staticmethod
+    @deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+    def version() -> str:
+        return "1.0"
+
+    @deprecated(target=None, deprecated_in="1.0", remove_in="2.0")
+    @staticmethod
+    def build_id() -> str:
+        return "legacy"
+```
+
+Both orders produce `classmethod(deprecated_wrapper)` internally. The deprecation `FutureWarning` fires at call time regardless of which order the decorators were applied.
+
+!!! tip "Prefer `@classmethod @deprecated` (deprecated closer to `def`)"
+
+    The inner-first order is the conventional Python style — outer decorators apply last. Follow this pattern for consistency if your team has no existing convention.
+
 ## See also
 
 - [Customization](customization.md) — redirect deprecation output to a logger or use a custom message template

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -202,7 +202,9 @@ pydeprecate all src/
 
 ## Agent Notes
 
-- `@deprecated` works with `@classmethod` and `@staticmethod` in either decorator order — `@classmethod @deprecated` and `@deprecated @classmethod` both produce `classmethod(deprecated_wrapper)`; `@staticmethod @deprecated` and `@deprecated @staticmethod` both produce `staticmethod(deprecated_wrapper)`. Both fire `FutureWarning` at call time.
+- `@deprecated` works with `@classmethod`, `@staticmethod`, `@property`, and `@cached_property` in either decorator order — `@classmethod @deprecated` and `@deprecated @classmethod` both produce `classmethod(deprecated_wrapper)`; `@staticmethod @deprecated` and `@deprecated @staticmethod` both produce `staticmethod(deprecated_wrapper)`. Both fire `FutureWarning` at call time.
+- `@property` with `@deprecated` in either order: warning fires on attribute access (`obj.prop` triggers it, not `obj.prop()`).
+- `@cached_property` with `@deprecated` in either order: warning fires on **first access only** — subsequent accesses hit the cached value and do not emit a warning.
 
 ## Anti-Patterns
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -202,7 +202,7 @@ pydeprecate all src/
 
 ## Agent Notes
 
-- `@deprecated` works with `@classmethod` and `@staticmethod` in either decorator order — `@classmethod @deprecated` and `@deprecated @classmethod` both produce `classmethod(deprecated_wrapper)` and fire `FutureWarning` at call time.
+- `@deprecated` works with `@classmethod` and `@staticmethod` in either decorator order — `@classmethod @deprecated` and `@deprecated @classmethod` both produce `classmethod(deprecated_wrapper)`; `@staticmethod @deprecated` and `@deprecated @staticmethod` both produce `staticmethod(deprecated_wrapper)`. Both fire `FutureWarning` at call time.
 
 ## Anti-Patterns
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -200,6 +200,10 @@ pydeprecate all src/
 5. Do you only need a warning? Use `TargetMode.NOTIFY` or omit `target`.
 6. Do you need removal governance? Add audit checks in CI.
 
+## Agent Notes
+
+- `@deprecated` works with `@classmethod` and `@staticmethod` in either decorator order — `@classmethod @deprecated` and `@deprecated @classmethod` both produce `classmethod(deprecated_wrapper)` and fire `FutureWarning` at call time.
+
 ## Anti-Patterns
 
 - Do not import `pydeprecate`; import `deprecate`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ warn_unused_configs = "True"
 warn_unused_ignores = "True"
 allow_redefinition = "True"
 warn_no_return = "True"
+overrides = [ { module = [ "tests.*" ], warn_unused_ignores = false } ]
 
 [tool.pytest]
 ini_options.testpaths = [ "src", "tests" ]

--- a/src/deprecate/audit.py
+++ b/src/deprecate/audit.py
@@ -716,7 +716,7 @@ def find_deprecation_wrappers(
 
     def _scan_callable(obj: Any, module_name: str, qualified_name: str) -> None:  # noqa: ANN401
         """Emit a result if ``obj`` carries ``__deprecated__`` metadata."""
-        if callable(obj) and hasattr(obj, "__deprecated__"):
+        if _has_deprecation_meta(obj):
             info = validate_deprecation_wrapper(obj)
             info = replace(info, module=module_name, function=qualified_name)
             results.append(info)
@@ -756,11 +756,8 @@ def find_deprecation_wrappers(
             if name.startswith("_"):
                 continue
 
-            # Check if it's a function or method with __deprecated__ attribute
-            if callable(obj) and hasattr(obj, "__deprecated__"):
-                # Validate the wrapper - extracts config from __deprecated__
+            if _has_deprecation_meta(obj):
                 info = validate_deprecation_wrapper(obj)
-                # Update with module-level info
                 info = replace(info, module=mod_name, function=name)
                 results.append(info)
             elif inspect.isclass(obj) and getattr(obj, "__module__", None) == mod_name:

--- a/src/deprecate/audit.py
+++ b/src/deprecate/audit.py
@@ -40,7 +40,7 @@ import warnings
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from functools import wraps
+from functools import cached_property, wraps
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 if TYPE_CHECKING:
@@ -714,14 +714,43 @@ def find_deprecation_wrappers(
     if isinstance(module, str):
         module = importlib.import_module(module)
 
+    def _scan_callable(obj: Any, module_name: str, qualified_name: str) -> None:  # noqa: ANN401
+        """Emit a result if ``obj`` carries ``__deprecated__`` metadata."""
+        if callable(obj) and hasattr(obj, "__deprecated__"):
+            info = validate_deprecation_wrapper(obj)
+            info = replace(info, module=module_name, function=qualified_name)
+            results.append(info)
+
+    def _scan_class(cls: Any, module_name: str, cls_name: str) -> None:  # noqa: ANN401
+        """Scan class members, peeking through descriptors."""
+        try:
+            members = _getmembers_static_compat(cls)
+        except (AttributeError, TypeError):
+            return
+        for attr_name, obj in members:
+            if attr_name.startswith("_"):
+                continue
+            qualified = f"{cls_name}.{attr_name}"
+            # Peek through descriptors to find the underlying function.
+            if isinstance(obj, (classmethod, staticmethod)):
+                _scan_callable(obj.__func__, module_name, qualified)
+            elif isinstance(obj, property):
+                if obj.fget is not None:
+                    _scan_callable(obj.fget, module_name, qualified)
+            elif isinstance(obj, cached_property):
+                _scan_callable(obj.func, module_name, qualified)
+            else:
+                _scan_callable(obj, module_name, qualified)
+
     def _scan_module(mod: Any) -> None:  # noqa: ANN401
-        """Scan a single module for deprecated functions."""
+        """Scan a single module for deprecated functions and class members."""
         try:
             # Static inspection avoids dynamic getattr/descriptor evaluation while scanning.
             members = _getmembers_static_compat(mod)
         except (AttributeError, TypeError, ImportError):
             return
 
+        mod_name = mod.__name__ if hasattr(mod, "__name__") else str(mod)
         for name, obj in members:
             # Skip private/magic attributes and imports from other modules
             if name.startswith("_"):
@@ -732,9 +761,10 @@ def find_deprecation_wrappers(
                 # Validate the wrapper - extracts config from __deprecated__
                 info = validate_deprecation_wrapper(obj)
                 # Update with module-level info
-                info = replace(info, module=mod.__name__ if hasattr(mod, "__name__") else str(mod), function=name)
-
+                info = replace(info, module=mod_name, function=name)
                 results.append(info)
+            elif inspect.isclass(obj) and getattr(obj, "__module__", None) == mod_name:
+                _scan_class(obj, mod_name, name)
 
     # Scan the main module
     _scan_module(module)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -755,24 +755,24 @@ def deprecated(
     """
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
-    def packing(source: Callable) -> Callable:
+    def packing(source: Callable, _stacklevel: int = 2) -> Callable:
         # Order-agnostic @classmethod/@staticmethod: unwrap → deprecate inner function → rewrap.
         # Both @classmethod orders produce classmethod(deprecated_wrapper);
         # both @staticmethod orders produce staticmethod(deprecated_wrapper).
         if isinstance(source, (classmethod, staticmethod)):
-            wrapped_inner = packing(source.__func__)
+            wrapped_inner = packing(source.__func__, _stacklevel + 1)
             return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)
         # Order-agnostic @property: unwrap → deprecate fget → rewrap preserving fset/fdel/doc.
         if isinstance(source, property):
             return property(
-                packing(source.fget) if source.fget is not None else None,
+                packing(source.fget, _stacklevel + 1) if source.fget is not None else None,
                 source.fset,
                 source.fdel,
                 source.__doc__,
             )
         # Order-agnostic @cached_property: unwrap → deprecate func → rewrap.
         if isinstance(source, cached_property):
-            return cached_property(packing(source.func))
+            return cached_property(packing(source.func, _stacklevel + 1))
         # Probe ``template_mgs`` against every documented placeholder so typos and malformed
         # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
         _validate_template_mgs(template_mgs)
@@ -784,7 +784,7 @@ def deprecated(
                 " Deprecation notices and generated documentation will omit the `deprecated_in` version."
                 " Pass `deprecated_in` for a meaningful deprecation notice.",
                 UserWarning,
-                stacklevel=2,
+                stacklevel=_stacklevel,
             )
         if inspect.isclass(source):
             import importlib
@@ -802,7 +802,7 @@ def deprecated(
                     " use `@deprecated_class(target=...)` instead."
                 )
             if stream is not None:
-                warnings.warn(message, UserWarning, stacklevel=2)
+                warnings.warn(message, UserWarning, stacklevel=_stacklevel)
 
             # _DeprecatedProxy auto-promotes ``None+args_mapping`` to ARGS_REMAP and reads
             # ``misconfigured`` from its own ``target is False`` check — by that point
@@ -815,7 +815,7 @@ def deprecated(
             elif target is None or isinstance(target, bool):
                 # None/True/False on a class is a class-misconfiguration, not a callable
                 # deprecation sentinel — the class misconfig UserWarning is the relevant signal.
-                forward_target = TargetMode._from_legacy(target, stacklevel=3)
+                forward_target = TargetMode._from_legacy(target, stacklevel=_stacklevel + 1)
             else:
                 forward_target = TargetMode.NOTIFY
 
@@ -831,7 +831,11 @@ def deprecated(
             forward_args_extra = args_extra
             if forward_target is TargetMode.NOTIFY:
                 TargetMode._validate(
-                    forward_target, source.__name__, args_mapping=args_mapping, args_extra=args_extra, stacklevel=3
+                    forward_target,
+                    source.__name__,
+                    args_mapping=args_mapping,
+                    args_extra=args_extra,
+                    stacklevel=_stacklevel + 1,
                 )
                 forward_args_mapping = None
                 forward_args_extra = None
@@ -865,7 +869,7 @@ def deprecated(
         _function_misconfigured = False
         if isinstance(_target, TargetMode) and isinstance(target, TargetMode):
             _function_misconfigured = TargetMode._validate(
-                _target, source.__name__, args_mapping=args_mapping, args_extra=args_extra, stacklevel=3
+                _target, source.__name__, args_mapping=args_mapping, args_extra=args_extra, stacklevel=_stacklevel + 1
             )
 
         source_has_var_positional = any(

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -755,16 +755,19 @@ def deprecated(
     """
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
-    def packing(source: Callable, _stacklevel: int = 2) -> Callable:
+    def packing(
+        source: Union[Callable, classmethod, staticmethod, property, cached_property],
+        _stacklevel: int = 2,
+    ) -> Callable:
         # Order-agnostic @classmethod/@staticmethod: unwrap → deprecate inner function → rewrap.
         # Both @classmethod orders produce classmethod(deprecated_wrapper);
         # both @staticmethod orders produce staticmethod(deprecated_wrapper).
         if isinstance(source, (classmethod, staticmethod)):
             wrapped_inner = packing(source.__func__, _stacklevel + 1)
-            return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)
+            return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)  # type: ignore[return-value]
         # Order-agnostic @property: unwrap → deprecate fget → rewrap preserving fset/fdel/doc.
         if isinstance(source, property):
-            return property(
+            return property(  # type: ignore[return-value]
                 packing(source.fget, _stacklevel + 1) if source.fget is not None else None,
                 source.fset,
                 source.fdel,
@@ -772,7 +775,7 @@ def deprecated(
             )
         # Order-agnostic @cached_property: unwrap → deprecate func → rewrap.
         if isinstance(source, cached_property):
-            return cached_property(packing(source.func, _stacklevel + 1))
+            return cached_property(packing(source.func, _stacklevel + 1))  # type: ignore[return-value]
         # Probe ``template_mgs`` against every documented placeholder so typos and malformed
         # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
         _validate_template_mgs(template_mgs)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -16,7 +16,7 @@ Copyright (C) 2020-2026 Jiri Borovec <6035284+Borda@users.noreply.github.com>
 import inspect
 import sys
 import warnings
-from functools import partial, wraps
+from functools import cached_property, partial, wraps
 from inspect import Parameter
 from typing import Any, Callable, Literal, Optional, Union, cast
 from warnings import warn
@@ -762,6 +762,17 @@ def deprecated(
         if isinstance(source, (classmethod, staticmethod)):
             wrapped_inner = packing(source.__func__)
             return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)
+        # Order-agnostic @property: unwrap → deprecate fget → rewrap preserving fset/fdel/doc.
+        if isinstance(source, property):
+            return property(
+                packing(source.fget) if source.fget is not None else None,
+                source.fset,
+                source.fdel,
+                source.__doc__,
+            )
+        # Order-agnostic @cached_property: unwrap → deprecate func → rewrap.
+        if isinstance(source, cached_property):
+            return cached_property(packing(source.func))
         # Probe ``template_mgs`` against every documented placeholder so typos and malformed
         # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
         _validate_template_mgs(template_mgs)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -756,16 +756,11 @@ def deprecated(
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
     def packing(source: Callable) -> Callable:
-        # Wrong-order @classmethod/@staticmethod — source is a descriptor; wrapping it breaks __get__ dispatch.
+        # Order-agnostic @classmethod/@staticmethod: unwrap → deprecate inner function → rewrap.
+        # Both @classmethod @deprecated and @deprecated @classmethod produce classmethod(deprecated_wrapper).
         if isinstance(source, (classmethod, staticmethod)):
-            kind = "classmethod" if isinstance(source, classmethod) else "staticmethod"
-            warnings.warn(
-                f"@deprecated applied outside @{kind} for `{source.__func__.__name__}`."
-                " Apply @deprecated inside (closer to `def`). See docs/guide/use-cases.md.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return source
+            wrapped_inner = packing(source.__func__)
+            return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)
         # Probe ``template_mgs`` against every documented placeholder so typos and malformed
         # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
         _validate_template_mgs(template_mgs)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -757,7 +757,8 @@ def deprecated(
 
     def packing(source: Callable) -> Callable:
         # Order-agnostic @classmethod/@staticmethod: unwrap → deprecate inner function → rewrap.
-        # Both @classmethod @deprecated and @deprecated @classmethod produce classmethod(deprecated_wrapper).
+        # Both @classmethod orders produce classmethod(deprecated_wrapper);
+        # both @staticmethod orders produce staticmethod(deprecated_wrapper).
         if isinstance(source, (classmethod, staticmethod)):
             wrapped_inner = packing(source.__func__)
             return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -767,11 +767,15 @@ def deprecated(
             return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)  # type: ignore[return-value]
         # Order-agnostic @property: unwrap → deprecate fget → rewrap preserving fset/fdel/doc.
         if isinstance(source, property):
+            # Preserve explicit doc only when it differs from fget's doc (author override)
+            # or when fget is absent (setter/deleter-only property with doc= supplied).
+            # Otherwise pass None so property() inherits the deprecation-injected fget.__doc__.
+            explicit_doc = source.__doc__ if (source.fget is None or source.__doc__ != source.fget.__doc__) else None
             return property(  # type: ignore[return-value]
                 packing(source.fget, _stacklevel + 1) if source.fget is not None else None,
                 source.fset,
                 source.fdel,
-                source.__doc__,
+                explicit_doc,
             )
         # Order-agnostic @cached_property: unwrap → deprecate func → rewrap.
         if isinstance(source, cached_property):

--- a/tests/unittests/test_audit.py
+++ b/tests/unittests/test_audit.py
@@ -381,7 +381,7 @@ class TestDwiCompatInit:
     def test_old_empty_mapping_kwarg_is_translated(self) -> None:
         """DeprecationWrapperInfo(empty_mapping=True) emits DeprecationWarning and sets empty_args_mapping."""
         with pytest.warns(DeprecationWarning, match="renamed to 'empty_args_mapping'"):
-            info = DeprecationWrapperInfo(
+            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
                 function="f",
                 deprecated_info=DeprecationConfig(),
                 empty_mapping=True,
@@ -391,7 +391,7 @@ class TestDwiCompatInit:
     def test_old_identity_mapping_kwarg_is_translated(self) -> None:
         """DeprecationWrapperInfo(identity_mapping=[...]) emits DeprecationWarning and sets identity_args_mapping."""
         with pytest.warns(DeprecationWarning, match="renamed to 'identity_args_mapping'"):
-            info = DeprecationWrapperInfo(
+            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
                 function="f",
                 deprecated_info=DeprecationConfig(),
                 identity_mapping=["a"],
@@ -401,7 +401,7 @@ class TestDwiCompatInit:
     def test_both_old_kwargs_each_emit_deprecation_warning(self) -> None:
         """Passing both old kwargs emits one DeprecationWarning per renamed field."""
         with pytest.warns(DeprecationWarning, match="renamed") as caught:
-            DeprecationWrapperInfo(
+            DeprecationWrapperInfo(  # type: ignore[call-arg]
                 function="f",
                 deprecated_info=DeprecationConfig(),
                 empty_mapping=True,
@@ -414,7 +414,7 @@ class TestDwiCompatInit:
     def test_conflict_old_name_wins_when_both_supplied(self) -> None:
         """When both old and new names are supplied (as in replace()), old-name value is honoured."""
         with pytest.warns(DeprecationWarning, match="renamed to 'empty_args_mapping'"):
-            info = DeprecationWrapperInfo(
+            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
                 function="f",
                 deprecated_info=DeprecationConfig(),
                 empty_mapping=True,
@@ -437,7 +437,7 @@ class TestDwiCompatInit:
         )
 
         with pytest.warns(DeprecationWarning, match="renamed to 'empty_args_mapping'"):
-            result = dataclasses.replace(base, empty_mapping=True)
+            result = dataclasses.replace(base, empty_mapping=True)  # type: ignore[call-arg]
 
         assert result.empty_args_mapping is True
 

--- a/tests/unittests/test_audit.py
+++ b/tests/unittests/test_audit.py
@@ -549,3 +549,87 @@ class TestFindDeprecationWrappersClassScan:
 
         names = [r.function for r in results]
         assert any("old_cp" in n for n in names)
+
+    def test_finds_outer_deprecated_classmethod(self) -> None:
+        """Outer @deprecated @classmethod order: wrapper is discovered by audit scan (N5)."""
+        mod = types.ModuleType("test_mod_outer_cm")
+
+        class OldCls:
+            @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[arg-type]
+            @classmethod
+            def old_cm(cls: type) -> int:
+                """Old classmethod."""
+                return 1
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_cm" in n for n in names)
+
+    def test_finds_outer_deprecated_staticmethod(self) -> None:
+        """Outer @deprecated @staticmethod order: wrapper is discovered by audit scan (N5)."""
+        mod = types.ModuleType("test_mod_outer_sm")
+
+        class OldCls:
+            @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[arg-type]
+            @staticmethod
+            def old_sm() -> int:
+                """Old staticmethod."""
+                return 1
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_sm" in n for n in names)
+
+    def test_finds_outer_deprecated_property(self) -> None:
+        """Outer @deprecated @property order: wrapper is discovered by audit scan (N6)."""
+        mod = types.ModuleType("test_mod_outer_prop")
+
+        class OldCls:
+            @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
+            @property
+            def old_prop(self: object) -> int:
+                """Old property."""
+                return 1
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_prop" in n for n in names)
+
+    def test_finds_outer_deprecated_cached_property(self) -> None:
+        """Outer @deprecated @cached_property order: wrapper is discovered by audit scan (N6)."""
+        mod = types.ModuleType("test_mod_outer_cp")
+
+        class OldCls:
+            @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
+            @cached_property
+            def old_cp(self: object) -> int:
+                """Old cached_property."""
+                return 1
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_cp" in n for n in names)

--- a/tests/unittests/test_audit.py
+++ b/tests/unittests/test_audit.py
@@ -6,6 +6,7 @@ import importlib.metadata
 import importlib.util
 import types
 import warnings
+from functools import cached_property
 from typing import Union
 
 import pytest
@@ -380,7 +381,7 @@ class TestDwiCompatInit:
     def test_old_empty_mapping_kwarg_is_translated(self) -> None:
         """DeprecationWrapperInfo(empty_mapping=True) emits DeprecationWarning and sets empty_args_mapping."""
         with pytest.warns(DeprecationWarning, match="renamed to 'empty_args_mapping'"):
-            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
+            info = DeprecationWrapperInfo(
                 function="f",
                 deprecated_info=DeprecationConfig(),
                 empty_mapping=True,
@@ -390,7 +391,7 @@ class TestDwiCompatInit:
     def test_old_identity_mapping_kwarg_is_translated(self) -> None:
         """DeprecationWrapperInfo(identity_mapping=[...]) emits DeprecationWarning and sets identity_args_mapping."""
         with pytest.warns(DeprecationWarning, match="renamed to 'identity_args_mapping'"):
-            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
+            info = DeprecationWrapperInfo(
                 function="f",
                 deprecated_info=DeprecationConfig(),
                 identity_mapping=["a"],
@@ -400,7 +401,7 @@ class TestDwiCompatInit:
     def test_both_old_kwargs_each_emit_deprecation_warning(self) -> None:
         """Passing both old kwargs emits one DeprecationWarning per renamed field."""
         with pytest.warns(DeprecationWarning, match="renamed") as caught:
-            DeprecationWrapperInfo(  # type: ignore[call-arg]
+            DeprecationWrapperInfo(
                 function="f",
                 deprecated_info=DeprecationConfig(),
                 empty_mapping=True,
@@ -413,11 +414,11 @@ class TestDwiCompatInit:
     def test_conflict_old_name_wins_when_both_supplied(self) -> None:
         """When both old and new names are supplied (as in replace()), old-name value is honoured."""
         with pytest.warns(DeprecationWarning, match="renamed to 'empty_args_mapping'"):
-            info = DeprecationWrapperInfo(  # type: ignore[call-arg]
+            info = DeprecationWrapperInfo(
                 function="f",
                 deprecated_info=DeprecationConfig(),
                 empty_mapping=True,
-                empty_args_mapping=False,  # auto-injected by replace(); caller's old-name wins
+                empty_args_mapping=False,
             )
         assert info.empty_args_mapping is True
 
@@ -436,6 +437,115 @@ class TestDwiCompatInit:
         )
 
         with pytest.warns(DeprecationWarning, match="renamed to 'empty_args_mapping'"):
-            result = dataclasses.replace(base, empty_mapping=True)  # type: ignore[call-arg]
+            result = dataclasses.replace(base, empty_mapping=True)
 
         assert result.empty_args_mapping is True
+
+
+class TestFindDeprecationWrappersClassScan:
+    """find_deprecation_wrappers discovers @deprecated on class members, peeking through descriptors."""
+
+    def test_finds_deprecated_regular_method(self) -> None:
+        """Deprecated regular method on a class is discovered by find_deprecation_wrappers."""
+        mod = types.ModuleType("test_mod_method")
+
+        @deprecated(deprecated_in="1.0", remove_in="2.0")
+        def _new(self: object) -> int:
+            return 1
+
+        class OldCls:
+            old_method = _new
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_method" in n for n in names)
+
+    def test_finds_deprecated_classmethod(self) -> None:
+        """Deprecated classmethod (correct @classmethod @deprecated order) is discovered."""
+        mod = types.ModuleType("test_mod_cm")
+
+        class OldCls:
+            @classmethod
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            def old_cm(cls: type) -> int:
+                """Old classmethod."""
+                return 1
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_cm" in n for n in names)
+
+    def test_finds_deprecated_staticmethod(self) -> None:
+        """Deprecated staticmethod (correct @staticmethod @deprecated order) is discovered."""
+        mod = types.ModuleType("test_mod_sm")
+
+        class OldCls:
+            @staticmethod
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            def old_sm() -> int:
+                """Old staticmethod."""
+                return 1
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_sm" in n for n in names)
+
+    def test_finds_deprecated_property(self) -> None:
+        """Deprecated property (correct @property @deprecated order) is discovered."""
+        mod = types.ModuleType("test_mod_prop")
+
+        class OldCls:
+            @property
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            def old_prop(self: object) -> int:
+                """Old property."""
+                return 1
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_prop" in n for n in names)
+
+    def test_finds_deprecated_cached_property(self) -> None:
+        """Deprecated cached_property (correct @cached_property @deprecated order) is discovered."""
+        mod = types.ModuleType("test_mod_cp")
+
+        class OldCls:
+            @cached_property
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            def old_cp(self: object) -> int:
+                """Old cached_property."""
+                return 1
+
+        OldCls.__module__ = mod.__name__
+        mod.OldCls = OldCls  # type: ignore[attr-defined]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            results = find_deprecation_wrappers(mod)
+
+        names = [r.function for r in results]
+        assert any("old_cp" in n for n in names)

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -5,6 +5,7 @@ import sys
 import warnings
 from dataclasses import dataclass
 from enum import Enum
+from functools import cached_property
 from typing import Any, Callable, Union, cast
 from unittest.mock import MagicMock
 
@@ -1301,5 +1302,107 @@ class TestDescriptorOrderAgnostic:
                 def old_method(x: int) -> int:
                     """Old staticmethod."""
                     return x
+
+        assert not [w for w in caught if issubclass(w.category, UserWarning)]
+
+
+class TestPropertyOrderAgnostic:
+    """@deprecated on property/cached_property works in both decorator orders (N6).
+
+    Correct order: ``@property @deprecated`` (``@deprecated`` closer to ``def``).
+    Wrong order: ``@deprecated @property`` (``@deprecated`` outermost).
+    N6 transparent unwrap+rewrap makes both orders produce ``property(deprecated_fget)`` — functionally identical.
+    The deprecation warning fires at attribute access time in both cases; no UserWarning at decoration time.
+    """
+
+    def test_correct_order_property_fires_on_access(self) -> None:
+        """Correct @property @deprecated order: FutureWarning fires on attribute access, descriptor preserved."""
+
+        class _Cls:
+            @property
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            def value(self) -> int:
+                """Old property."""
+                return 42
+
+        obj = _Cls()
+        with pytest.warns(FutureWarning):
+            result = obj.value
+        assert result == 42
+        assert isinstance(_Cls.__dict__["value"], property)
+
+    def test_wrong_order_property_fires_on_access(self) -> None:
+        """Wrong @deprecated @property order: FutureWarning fires on attribute access, descriptor preserved."""
+
+        class _Cls:
+            @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
+            @property
+            def value(self) -> int:
+                """Old property."""
+                return 42
+
+        obj = _Cls()
+        with pytest.warns(FutureWarning):
+            result = obj.value
+        assert result == 42
+        assert isinstance(_Cls.__dict__["value"], property)
+
+    def test_wrong_order_property_no_decoration_time_warning(self) -> None:
+        """Wrong @deprecated @property order: no UserWarning at decoration time (N6 transparent unwrap)."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            class _Cls:
+                @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
+                @property
+                def value(self) -> int:
+                    """Old property."""
+                    return 42
+
+        assert not [w for w in caught if issubclass(w.category, UserWarning)]
+
+    def test_correct_order_cached_property_fires_on_access(self) -> None:
+        """Correct @cached_property @deprecated order: FutureWarning fires on first access."""
+
+        class _Cls:
+            @cached_property
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            def value(self) -> int:
+                """Old cached_property."""
+                return 42
+
+        obj = _Cls()
+        with pytest.warns(FutureWarning):
+            result = obj.value
+        assert result == 42
+        assert isinstance(_Cls.__dict__["value"], cached_property)
+
+    def test_wrong_order_cached_property_fires_on_access(self) -> None:
+        """Wrong @deprecated @cached_property order: FutureWarning fires on first access, descriptor preserved."""
+
+        class _Cls:
+            @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
+            @cached_property
+            def value(self) -> int:
+                """Old cached_property."""
+                return 42
+
+        obj = _Cls()
+        with pytest.warns(FutureWarning):
+            result = obj.value
+        assert result == 42
+        assert isinstance(_Cls.__dict__["value"], cached_property)
+
+    def test_wrong_order_cached_property_no_decoration_time_warning(self) -> None:
+        """Wrong @deprecated @cached_property order: no UserWarning at decoration time."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            class _Cls:
+                @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
+                @cached_property
+                def value(self) -> int:
+                    """Old cached_property."""
+                    return 42
 
         assert not [w for w in caught if issubclass(w.category, UserWarning)]

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1211,7 +1211,7 @@ class TestDescriptorOrderAgnostic:
     """@deprecated on classmethod/staticmethod works in both decorator orders (N5).
 
     Correct order: ``@classmethod @deprecated`` (``@deprecated`` closer to ``def``).
-    Wrong order: ``@deprecated @classmethod`` (``@deprecated`` outermost).
+    Outer-deprecated order: ``@deprecated @classmethod`` (``@deprecated`` outermost).
     N5 transparent unwrap+rewrap preserves the descriptor type: both @classmethod orders produce
     classmethod(deprecated_wrapper), both @staticmethod orders produce staticmethod(deprecated_wrapper).
     The deprecation warning fires at call time in both cases; no UserWarning fires at decoration time.
@@ -1232,8 +1232,8 @@ class TestDescriptorOrderAgnostic:
         assert result == 5
         assert isinstance(_Cls.__dict__["old_method"], classmethod)
 
-    def test_wrong_order_classmethod_fires_on_call(self) -> None:
-        """Wrong @deprecated @classmethod order: deprecation FutureWarning still fires on call, descriptor preserved."""
+    def test_outer_deprecated_classmethod_fires_on_call(self) -> None:
+        """Outer @deprecated @classmethod order: deprecation FutureWarning still fires on call, descriptor preserved."""
 
         class _Cls:
             @deprecated(deprecated_in="1.0", remove_in="2.0")
@@ -1247,8 +1247,8 @@ class TestDescriptorOrderAgnostic:
         assert result == 5
         assert isinstance(_Cls.__dict__["old_method"], classmethod)
 
-    def test_wrong_order_classmethod_no_decoration_time_warning(self) -> None:
-        """Wrong @deprecated @classmethod order: no UserWarning at decoration time (N5 transparent unwrap)."""
+    def test_outer_deprecated_classmethod_no_decoration_time_warning(self) -> None:
+        """Outer @deprecated @classmethod order: no UserWarning at decoration time (N5 transparent unwrap)."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 
@@ -1276,8 +1276,8 @@ class TestDescriptorOrderAgnostic:
         assert result == 5
         assert isinstance(_Cls.__dict__["old_method"], staticmethod)
 
-    def test_wrong_order_staticmethod_fires_on_call(self) -> None:
-        """Wrong @deprecated @staticmethod order: deprecation FutureWarning fires on call, descriptor preserved."""
+    def test_outer_deprecated_staticmethod_fires_on_call(self) -> None:
+        """Outer @deprecated @staticmethod order: deprecation FutureWarning fires on call, descriptor preserved."""
 
         class _Cls:
             @deprecated(deprecated_in="1.0", remove_in="2.0")
@@ -1291,8 +1291,8 @@ class TestDescriptorOrderAgnostic:
         assert result == 5
         assert isinstance(_Cls.__dict__["old_method"], staticmethod)
 
-    def test_wrong_order_staticmethod_no_decoration_time_warning(self) -> None:
-        """Wrong @deprecated @staticmethod order: no UserWarning at decoration time (N5 transparent unwrap)."""
+    def test_outer_deprecated_staticmethod_no_decoration_time_warning(self) -> None:
+        """Outer @deprecated @staticmethod order: no UserWarning at decoration time (N5 transparent unwrap)."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 
@@ -1310,7 +1310,7 @@ class TestPropertyOrderAgnostic:
     """@deprecated on property/cached_property works in both decorator orders (N6).
 
     Correct order: ``@property @deprecated`` (``@deprecated`` closer to ``def``).
-    Wrong order: ``@deprecated @property`` (``@deprecated`` outermost).
+    Outer-deprecated order: ``@deprecated @property`` (``@deprecated`` outermost).
     N6 transparent unwrap+rewrap makes both orders produce ``property(deprecated_fget)`` — functionally identical.
     The deprecation warning fires at attribute access time in both cases; no UserWarning at decoration time.
     """
@@ -1331,8 +1331,8 @@ class TestPropertyOrderAgnostic:
         assert result == 42
         assert isinstance(_Cls.__dict__["value"], property)
 
-    def test_wrong_order_property_fires_on_access(self) -> None:
-        """Wrong @deprecated @property order: FutureWarning fires on attribute access, descriptor preserved."""
+    def test_outer_deprecated_property_fires_on_access(self) -> None:
+        """Outer @deprecated @property order: FutureWarning fires on attribute access, descriptor preserved."""
 
         class _Cls:
             @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
@@ -1347,8 +1347,8 @@ class TestPropertyOrderAgnostic:
         assert result == 42
         assert isinstance(_Cls.__dict__["value"], property)
 
-    def test_wrong_order_property_no_decoration_time_warning(self) -> None:
-        """Wrong @deprecated @property order: no UserWarning at decoration time (N6 transparent unwrap)."""
+    def test_outer_deprecated_property_no_decoration_time_warning(self) -> None:
+        """Outer @deprecated @property order: no UserWarning at decoration time (N6 transparent unwrap)."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 
@@ -1377,8 +1377,8 @@ class TestPropertyOrderAgnostic:
         assert result == 42
         assert isinstance(_Cls.__dict__["value"], cached_property)
 
-    def test_wrong_order_cached_property_fires_on_access(self) -> None:
-        """Wrong @deprecated @cached_property order: FutureWarning fires on first access, descriptor preserved."""
+    def test_outer_deprecated_cached_property_fires_on_access(self) -> None:
+        """Outer @deprecated @cached_property order: FutureWarning fires on first access, descriptor preserved."""
 
         class _Cls:
             @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
@@ -1393,8 +1393,8 @@ class TestPropertyOrderAgnostic:
         assert result == 42
         assert isinstance(_Cls.__dict__["value"], cached_property)
 
-    def test_wrong_order_cached_property_no_decoration_time_warning(self) -> None:
-        """Wrong @deprecated @cached_property order: no UserWarning at decoration time."""
+    def test_outer_deprecated_cached_property_no_decoration_time_warning(self) -> None:
+        """Outer @deprecated @cached_property order: no UserWarning at decoration time."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1210,15 +1210,15 @@ class TestStackedNotifyCallable:
 class TestDescriptorOrderAgnostic:
     """@deprecated on classmethod/staticmethod works in both decorator orders (N5).
 
-    Correct order: ``@classmethod @deprecated`` (``@deprecated`` closer to ``def``).
+    Inner-deprecated order: ``@classmethod @deprecated`` (``@deprecated`` closer to ``def``).
     Outer-deprecated order: ``@deprecated @classmethod`` (``@deprecated`` outermost).
     N5 transparent unwrap+rewrap preserves the descriptor type: both @classmethod orders produce
     classmethod(deprecated_wrapper), both @staticmethod orders produce staticmethod(deprecated_wrapper).
     The deprecation warning fires at call time in both cases; no UserWarning fires at decoration time.
     """
 
-    def test_correct_order_classmethod_fires_on_call(self) -> None:
-        """Correct @classmethod @deprecated order: deprecation FutureWarning fires on call, descriptor preserved."""
+    def test_inner_deprecated_classmethod_fires_on_call(self) -> None:
+        """Inner @classmethod @deprecated order: deprecation FutureWarning fires on call, descriptor preserved."""
 
         class _Cls:
             @classmethod
@@ -1261,8 +1261,8 @@ class TestDescriptorOrderAgnostic:
 
         assert not [w for w in caught if issubclass(w.category, UserWarning)]
 
-    def test_correct_order_staticmethod_fires_on_call(self) -> None:
-        """Correct @staticmethod @deprecated order: deprecation FutureWarning fires on call, descriptor preserved."""
+    def test_inner_deprecated_staticmethod_fires_on_call(self) -> None:
+        """Inner @staticmethod @deprecated order: deprecation FutureWarning fires on call, descriptor preserved."""
 
         class _Cls:
             @staticmethod
@@ -1309,14 +1309,14 @@ class TestDescriptorOrderAgnostic:
 class TestPropertyOrderAgnostic:
     """@deprecated on property/cached_property works in both decorator orders (N6).
 
-    Correct order: ``@property @deprecated`` (``@deprecated`` closer to ``def``).
+    Inner-deprecated order: ``@property @deprecated`` (``@deprecated`` closer to ``def``).
     Outer-deprecated order: ``@deprecated @property`` (``@deprecated`` outermost).
     N6 transparent unwrap+rewrap makes both orders produce ``property(deprecated_fget)`` — functionally identical.
     The deprecation warning fires at attribute access time in both cases; no UserWarning at decoration time.
     """
 
-    def test_correct_order_property_fires_on_access(self) -> None:
-        """Correct @property @deprecated order: FutureWarning fires on attribute access, descriptor preserved."""
+    def test_inner_deprecated_property_fires_on_access(self) -> None:
+        """Inner @property @deprecated order: FutureWarning fires on attribute access, descriptor preserved."""
 
         class _Cls:
             @property
@@ -1361,8 +1361,8 @@ class TestPropertyOrderAgnostic:
 
         assert not [w for w in caught if issubclass(w.category, UserWarning)]
 
-    def test_correct_order_cached_property_fires_on_access(self) -> None:
-        """Correct @cached_property @deprecated order: FutureWarning fires on first access."""
+    def test_inner_deprecated_cached_property_fires_on_access(self) -> None:
+        """Inner @cached_property @deprecated order: FutureWarning fires on first access."""
 
         class _Cls:
             @cached_property

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1352,7 +1352,7 @@ class TestPropertyOrderAgnostic:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 
-            class _Cls:
+            class _UnusedCls:
                 @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
                 @property
                 def value(self) -> int:
@@ -1398,7 +1398,7 @@ class TestPropertyOrderAgnostic:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 
-            class _Cls:
+            class _UnusedCls:
                 @deprecated(deprecated_in="1.0", remove_in="2.0")  # type: ignore[prop-decorator]
                 @cached_property
                 def value(self) -> int:

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1211,7 +1211,7 @@ class TestDescriptorOrderAgnostic:
 
     Correct order: ``@classmethod @deprecated`` (``@deprecated`` closer to ``def``).
     Wrong order: ``@deprecated @classmethod`` (``@deprecated`` outermost).
-    N5 transparent unwrap+rewrap makes both orders produce ``classmethod(deprecated_wrapper)`` — functionally identical.
+    N5 transparent unwrap+rewrap preserves the descriptor type: both @classmethod orders produce classmethod(deprecated_wrapper), both @staticmethod orders produce staticmethod(deprecated_wrapper).
     The deprecation warning fires at call time in both cases; no UserWarning fires at decoration time.
     """
 

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1211,7 +1211,8 @@ class TestDescriptorOrderAgnostic:
 
     Correct order: ``@classmethod @deprecated`` (``@deprecated`` closer to ``def``).
     Wrong order: ``@deprecated @classmethod`` (``@deprecated`` outermost).
-    N5 transparent unwrap+rewrap preserves the descriptor type: both @classmethod orders produce classmethod(deprecated_wrapper), both @staticmethod orders produce staticmethod(deprecated_wrapper).
+    N5 transparent unwrap+rewrap preserves the descriptor type: both @classmethod orders produce
+    classmethod(deprecated_wrapper), both @staticmethod orders produce staticmethod(deprecated_wrapper).
     The deprecation warning fires at call time in both cases; no UserWarning fires at decoration time.
     """
 

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -1206,17 +1206,49 @@ class TestStackedNotifyCallable:
         assert not [w for w in caught if issubclass(w.category, FutureWarning)]
 
 
-class TestDescriptorOrderGuard:
-    """@deprecated applied outside @classmethod or @staticmethod emits UserWarning and returns descriptor unchanged.
+class TestDescriptorOrderAgnostic:
+    """@deprecated on classmethod/staticmethod works in both decorator orders (N5).
 
-    Correct order has @deprecated closer to ``def`` (inside @classmethod/@staticmethod).
-    Wrong order passes a descriptor object to packing() instead of a plain function — the guard
-    surfaces this at decoration time and returns the descriptor unchanged so the class still works.
+    Correct order: ``@classmethod @deprecated`` (``@deprecated`` closer to ``def``).
+    Wrong order: ``@deprecated @classmethod`` (``@deprecated`` outermost).
+    N5 transparent unwrap+rewrap makes both orders produce ``classmethod(deprecated_wrapper)`` — functionally identical.
+    The deprecation warning fires at call time in both cases; no UserWarning fires at decoration time.
     """
 
-    def test_wrong_order_classmethod_warns(self) -> None:
-        """Wrong-order @deprecated @classmethod emits UserWarning pointing at the decoration site."""
-        with pytest.warns(UserWarning, match=r"@deprecated applied outside @classmethod") as record:
+    def test_correct_order_classmethod_fires_on_call(self) -> None:
+        """Correct @classmethod @deprecated order: deprecation FutureWarning fires on call, descriptor preserved."""
+
+        class _Cls:
+            @classmethod
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            def old_method(cls, x: int) -> int:
+                """Old classmethod."""
+                return x
+
+        with pytest.warns(FutureWarning):
+            result = _Cls.old_method(5)
+        assert result == 5
+        assert isinstance(_Cls.__dict__["old_method"], classmethod)
+
+    def test_wrong_order_classmethod_fires_on_call(self) -> None:
+        """Wrong @deprecated @classmethod order: deprecation FutureWarning still fires on call, descriptor preserved."""
+
+        class _Cls:
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            @classmethod
+            def old_method(cls, x: int) -> int:
+                """Old classmethod."""
+                return x
+
+        with pytest.warns(FutureWarning):
+            result = _Cls.old_method(5)
+        assert result == 5
+        assert isinstance(_Cls.__dict__["old_method"], classmethod)
+
+    def test_wrong_order_classmethod_no_decoration_time_warning(self) -> None:
+        """Wrong @deprecated @classmethod order: no UserWarning at decoration time (N5 transparent unwrap)."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
 
             class _Cls:
                 @deprecated(deprecated_in="1.0", remove_in="2.0")
@@ -1225,12 +1257,42 @@ class TestDescriptorOrderGuard:
                     """Old classmethod."""
                     return x
 
-        assert record[0].filename.endswith("test_deprecation.py")
-        assert isinstance(_Cls.__dict__["old_method"], classmethod)
+        assert not [w for w in caught if issubclass(w.category, UserWarning)]
 
-    def test_wrong_order_staticmethod_warns(self) -> None:
-        """Wrong-order @deprecated @staticmethod emits UserWarning pointing at the decoration site."""
-        with pytest.warns(UserWarning, match=r"@deprecated applied outside @staticmethod") as record:
+    def test_correct_order_staticmethod_fires_on_call(self) -> None:
+        """Correct @staticmethod @deprecated order: deprecation FutureWarning fires on call, descriptor preserved."""
+
+        class _Cls:
+            @staticmethod
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            def old_method(x: int) -> int:
+                """Old staticmethod."""
+                return x
+
+        with pytest.warns(FutureWarning):
+            result = _Cls.old_method(5)
+        assert result == 5
+        assert isinstance(_Cls.__dict__["old_method"], staticmethod)
+
+    def test_wrong_order_staticmethod_fires_on_call(self) -> None:
+        """Wrong @deprecated @staticmethod order: deprecation FutureWarning fires on call, descriptor preserved."""
+
+        class _Cls:
+            @deprecated(deprecated_in="1.0", remove_in="2.0")
+            @staticmethod
+            def old_method(x: int) -> int:
+                """Old staticmethod."""
+                return x
+
+        with pytest.warns(FutureWarning):
+            result = _Cls.old_method(5)
+        assert result == 5
+        assert isinstance(_Cls.__dict__["old_method"], staticmethod)
+
+    def test_wrong_order_staticmethod_no_decoration_time_warning(self) -> None:
+        """Wrong @deprecated @staticmethod order: no UserWarning at decoration time (N5 transparent unwrap)."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
 
             class _Cls:
                 @deprecated(deprecated_in="1.0", remove_in="2.0")
@@ -1239,5 +1301,4 @@ class TestDescriptorOrderGuard:
                     """Old staticmethod."""
                     return x
 
-        assert record[0].filename.endswith("test_deprecation.py")
-        assert isinstance(_Cls.__dict__["old_method"], staticmethod)
+        assert not [w for w in caught if issubclass(w.category, UserWarning)]


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- Replace N3 warn+bail guard with transparent packing(source.__func__) + classmethod/staticmethod rewrap
- Both @classmethod @deprecated and @deprecated @classmethod now produce classmethod(deprecated_wrapper) — FutureWarning fires at call time in both orders
- Replace TestDescriptorOrderGuard (2 warn tests) with TestDescriptorOrderAgnostic (6 tests: both orders work × classmethod + staticmethod, no decoration-time UserWarning)
- Add "Class methods and static methods" section to docs/guide/use-cases.md with both-order examples
- Add Agent Notes to docs/llms.txt noting order-agnostic behavior

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
