### PR TITLE
feat: async def support

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,7 +7,21 @@
 #     - push → main                                    → build + deploy to dev/
 #     - push → version-like tag (v1.2, 1.2.3, …)       → build + deploy to <tag>/ (and stable/ if highest)
 #     - pull_request → main                            → build only (no deploy)
-#     - workflow_dispatch (tag input)                  → build + deploy to <tag>/ (no set-default change)
+#     - workflow_dispatch (tag, refresh_root_files inputs)
+#                                                      → build + deploy to <tag>/ (no set-default change)
+#
+#   workflow_dispatch inputs:
+#     - tag                   (optional, default main) git tag or branch; 'main' maps to 'dev' docs version
+#                             alias auto-derived: latest release tag → stable alias; main/branch → none
+#     - refresh_root_files    (optional, default false) overwrite gh-pages root files
+#                             (llms.txt, llms-full.txt, robots.txt, sitemap.xml) with versions from
+#                             this tag's docs/. Defaults false — safe for historical backfills where
+#                             files may be stale or absent. Auto-enabled when tag resolves to stable.
+#
+#   Root-level AI discoverability files (llms.txt, robots.txt, sitemap.xml, llms-full.txt):
+#     - deploy on every push trigger (main → dev/, tag → <tag>/)
+#     - skipped on workflow_dispatch unless refresh_root_files=true or tag resolves to stable alias
+#     - missing source files at historical refs emit ::warning:: and are skipped gracefully
 #
 #   Jobs:
 #     build-landing-docs ──┐
@@ -18,6 +32,7 @@
 #                          ├─ inject sphinx + mkdocs artifacts into docs/
 #                          ├─ mike deploy <version_path> [aliases…] --update-aliases
 #                          ├─ mike set-default <latest|stable>  [skipped on workflow_dispatch]
+#                          ├─ deploy root AI discoverability files  [push always; dispatch opt-in]
 #                          ├─ git push gh-pages [push + workflow_dispatch events] — this IS the deploy
 #                          │  (GitHub Pages serves directly from the gh-pages branch)
 #                          └─ upload built site as workflow artifact (manual inspection)
@@ -42,14 +57,19 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Git tag to backfill (e.g. v0.7.0). Must already exist on the remote."
-        required: true
-        type: string
-      alias:
-        description: "Optional mike alias to attach (e.g. stable). Leave empty for none."
+        description: "Git tag or branch to deploy (e.g. v0.7.0 or main). Must already exist on the remote. 'main' maps to the 'dev' docs version."
         required: false
         type: string
-        default: ""
+        default: "main"
+      refresh_root_files:
+        description: >
+          Overwrite the gh-pages root files (llms.txt, llms-full.txt, robots.txt, sitemap.xml)
+          with the versions from this tag's docs/. Enable only when this tag's metadata is the
+          canonical content you want AI crawlers to see. Auto-enabled when tag is the latest release.
+          Defaults to false — safe for historical backfills where these files may be stale or absent.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -66,8 +86,24 @@ defaults:
     shell: bash
 
 jobs:
+  validate-dispatch-inputs:
+    name: Validate dispatch inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔎 Verify tag is a valid git ref
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if ! git ls-remote --exit-code "https://github.com/${{ github.repository }}.git" \
+              "refs/tags/${INPUT_TAG}" "refs/heads/${INPUT_TAG}" >/dev/null 2>&1; then
+            echo "::error::Input tag='${INPUT_TAG}' is not a valid git tag or branch. Mike version names (dev, stable) are not git refs — use a real tag like v0.8.0 or branch name like main."
+            exit 1
+          fi
+
   build-landing-docs:
     name: Portal (landing-docs)
+    needs: [validate-dispatch-inputs]
     runs-on: ubuntu-latest
 
     steps:
@@ -85,9 +121,11 @@ jobs:
 
       - name: 🔎 Verify mkdocs.yml exists at this ref
         if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ ! -f mkdocs.yml ]; then
-            echo "::error::Tag '${{ inputs.tag }}' has no mkdocs.yml — cannot build docs. Earliest supported tag: v0.7.0."
+            echo "::error::Tag '${INPUT_TAG}' has no mkdocs.yml — cannot build docs. Earliest supported tag: v0.7.0."
             exit 1
           fi
 
@@ -126,6 +164,7 @@ jobs:
 
   build-demo-sphinx:
     name: Demo Sphinx (RST)
+    needs: [validate-dispatch-inputs]
     runs-on: ubuntu-latest
 
     steps:
@@ -160,6 +199,7 @@ jobs:
 
   build-demo-mkdocs:
     name: Demo MkDocs (Markdown)
+    needs: [validate-dispatch-inputs]
     runs-on: ubuntu-latest
 
     steps:
@@ -259,6 +299,8 @@ jobs:
           path: docs/demo-mkdocs
 
       - name: 🏷️ Resolve version path
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
 
@@ -268,9 +310,18 @@ jobs:
           STABLE_TAG=""
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            # Backfill: use the user-supplied tag; never change set-default.
-            VERSION_PATH="${{ inputs.tag }}"
-            ALIASES="${{ inputs.alias }}"
+            # Map branch names to canonical mike versions (main → dev).
+            VERSION_PATH="${INPUT_TAG}"
+            case "${VERSION_PATH}" in
+              main) VERSION_PATH="dev" ;;
+            esac
+            # Auto-derive alias: if dispatching the latest release tag, assign stable.
+            if [[ "${VERSION_PATH}" != "dev" ]]; then
+              STABLE_TAG="$(git tag --list | { grep -E "${RELEASE_TAG_PATTERN}" || true; } | sort -V | tail -1)"
+              if [ -n "${STABLE_TAG}" ] && [ "${VERSION_PATH}" = "${STABLE_TAG}" ]; then
+                ALIASES="stable"
+              fi
+            fi
           elif [ "${GITHUB_REF_TYPE}" = "branch" ]; then
             # Unreleased main branch — never set as default; users want stable docs by default.
             VERSION_PATH="dev"
@@ -296,16 +347,31 @@ jobs:
             echo "SET_DEFAULT=${SET_DEFAULT}"
           } >> "$GITHUB_ENV"
 
+      - name: 🗑️ Delete conflicting mike versions
+        if: env.SKIP != 'true' && env.ALIASES != ''
+        # mike refuses to reassign an existing version name as an alias, even with --update-aliases.
+        # Check each alias against the current gh-pages version list and delete any that conflict.
+        # mike delete is fail-fast under set -e; failure is intentional — re-run is idempotent
+        # because the grep guard above skips delete when the version is already gone.
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "${GH_PAGES_BRANCH}" >/dev/null 2>&1; then
+            EXISTING_VERSIONS=$(mike list --branch "${GH_PAGES_BRANCH}" --json | jq -r '.[].version')
+            read -ra aliases <<< "${ALIASES}"
+            for _alias in "${aliases[@]}"; do
+              if echo "${EXISTING_VERSIONS}" | grep -qx "${_alias}"; then
+                echo "→ Alias '${_alias}' is currently a standalone version — deleting before reassigning"
+                mike delete --branch "${GH_PAGES_BRANCH}" "${_alias}"
+              fi
+            done
+          fi
+
       - name: 🚀 Mike deploy
         if: env.SKIP != 'true'
         run: |
           set -euo pipefail
-
-          # Re-expand space-separated aliases string into a bash array.
           # `${aliases[@]+"${aliases[@]}"}` is the empty-array-safe expansion under `set -u`.
           read -ra aliases <<< "${ALIASES}"
-
-          # Run mike without --push; single git push below lands deploy + set-default atomically.
           mike deploy \
             --update-aliases \
             --branch "${GH_PAGES_BRANCH}" \
@@ -322,7 +388,9 @@ jobs:
             "${SET_DEFAULT}"
 
       - name: 🤖 Deploy root-level AI discoverability files
-        if: env.SET_DEFAULT != ''
+        if: >-
+          env.SKIP != 'true' &&
+          (github.event_name != 'workflow_dispatch' || inputs.refresh_root_files || env.ALIASES == 'stable')
         run: |
           set -euo pipefail
           # robots.txt and llms.txt must live at the gh-pages root so AI crawlers find them
@@ -333,11 +401,20 @@ jobs:
           TMPWORKTREE="/tmp/pyDeprecate-gh-pages-$$"
           git worktree add "$TMPWORKTREE" "${GH_PAGES_BRANCH}"
           trap 'git worktree remove --force "$TMPWORKTREE" 2>/dev/null || true' EXIT
-          cp docs/robots.txt "$TMPWORKTREE/robots.txt"
-          cp docs/llms.txt "$TMPWORKTREE/llms.txt"
-          cp docs/llms-full.txt "$TMPWORKTREE/llms-full.txt"
-          cp docs/root-sitemap.xml "$TMPWORKTREE/sitemap.xml"
-          git -C "$TMPWORKTREE" add robots.txt llms.txt llms-full.txt sitemap.xml
+          for src_dest in \
+            "docs/robots.txt:robots.txt" \
+            "docs/llms.txt:llms.txt" \
+            "docs/llms-full.txt:llms-full.txt" \
+            "docs/root-sitemap.xml:sitemap.xml"; do
+            src="${src_dest%%:*}"
+            dst="${src_dest##*:}"
+            if [ -f "$src" ]; then
+              cp "$src" "$TMPWORKTREE/$dst"
+            else
+              echo "::warning::$src absent at this ref — skipping $dst in root-metadata deploy"
+            fi
+          done
+          git -C "$TMPWORKTREE" add robots.txt llms.txt llms-full.txt sitemap.xml 2>/dev/null || true
           git -C "$TMPWORKTREE" diff --cached --quiet \
             || git -C "$TMPWORKTREE" commit -m "chore(deploy): sync root AI discoverability files (robots.txt, llms.txt, llms-full.txt, sitemap.xml)"
           trap - EXIT

--- a/.github/workflows/ci_check-links.yml
+++ b/.github/workflows/ci_check-links.yml
@@ -49,5 +49,5 @@ jobs:
             --exclude file://.*demo-sphinx.*
             --exclude file://.*demo-mkdocs.*
             --exclude '^https[:]//borda[/]$'
-            --exclude '[hH]ttps://github\.com/\$'
+            --exclude '[hH]ttps://github\.com/\$\{\{[^}]+\}\}(\.git)?$'
           fail: true

--- a/.github/workflows/ci_check-links.yml
+++ b/.github/workflows/ci_check-links.yml
@@ -49,5 +49,5 @@ jobs:
             --exclude file://.*demo-sphinx.*
             --exclude file://.*demo-mkdocs.*
             --exclude '^https[:]//borda[/]$'
-            --exclude '[hH]ttps://github\.com/\$\{\{[^}]+\}\}(\.git)?$'
+            --exclude '^[hH]ttps://github\.com/\$(\.git)?$'
           fail: true

--- a/.github/workflows/ci_check-links.yml
+++ b/.github/workflows/ci_check-links.yml
@@ -48,12 +48,6 @@ jobs:
             --exclude http://127.0.0.1
             --exclude file://.*demo-sphinx.*
             --exclude file://.*demo-mkdocs.*
-            --exclude https://borda.github.io/pyDeprecate/stable.*
-            --exclude https://borda.github.io/pyDeprecate/llms.txt
-            --exclude https://borda.github.io/pyDeprecate/llms-full.txt
-            --exclude https://borda.github.io/pyDeprecate/robots.txt
-            --exclude https://borda.github.io/pyDeprecate/sitemap.xml
-            # TODO: remove the four excludes above once docs-discovery-assets workflow
-            # has run on main and populated gh-pages with these root files.
             --exclude '^https[:]//borda[/]$'
+            --exclude 'https://github\.com/\$'
           fail: true

--- a/.github/workflows/ci_check-links.yml
+++ b/.github/workflows/ci_check-links.yml
@@ -49,5 +49,5 @@ jobs:
             --exclude file://.*demo-sphinx.*
             --exclude file://.*demo-mkdocs.*
             --exclude '^https[:]//borda[/]$'
-            --exclude 'https://github\.com/\$'
+            --exclude '[hH]ttps://github\.com/\$'
           fail: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Generator function support for `@deprecated`.** Decorating a generator function now emits the deprecation warning eagerly at call time — before the first `next()` — consistent with regular function behavior. The generator body executes lazily as normal when iterated. All three `TargetMode` variants (`NOTIFY`, `ARGS_REMAP`, callable target) work transparently; no `isgeneratorfunction` check is required. ([#176](https://github.com/Borda/pyDeprecate/pull/176))
+- **`async def` coroutine wrapper support for `@deprecated`.** Decorating an `async def` function now produces an `async def` wrapper — `inspect.iscoroutinefunction(wrapper)` returns `True`. All three `TargetMode` variants (`NOTIFY`, `ARGS_REMAP`, callable target) work with async sources and async targets. The deprecation warning fires when the coroutine is awaited, not when the wrapper is called. `pytest-asyncio` is required in the test suite to run the async integration tests.
 - **Order-agnostic `classmethod`/`staticmethod` guard.** Applying `@deprecated` outside `@classmethod` (wrong decorator order) is now silently rescued at decoration time: the descriptor is unwrapped, the inner function is deprecated, and the result is re-wrapped as `classmethod(deprecated_wrapper)`. No `UserWarning` is emitted; a `FutureWarning` fires normally at call time. The preferred order (`@classmethod` outermost, `@deprecated` closer to `def`) is unchanged. ([#176](https://github.com/Borda/pyDeprecate/pull/176))
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ ______________________________________________________________________
   - [Deprecating Enums and dataclasses](#deprecating-enums-and-dataclasses)
   - [Automatic docstring updates](#automatic-docstring-updates)
   - [Injecting new required arguments](#injecting-new-required-arguments)
+  - [Async functions](#-async-functions)
 - [🔇 Understanding the void() Helper](#understanding-the-void-helper)
 - [🔍 Audit](#audit)
   - [Validating Wrapper Configuration](#validating-wrapper-configuration)
@@ -68,7 +69,7 @@ Another good aspect is not overwhelming users with too many warnings, so per fun
 - 🔄 Arguments are automatically mapped to the target function
 - 🚫 The deprecated function body is never executed when using `target`
 - ⚡ Minimal runtime overhead with zero dependencies (Python standard library only)
-- 🛠️ Supports deprecating callables: functions, methods, class constructors, and **generator functions** (`def gen(): yield`) — warning fires eagerly at call time, before iteration begins
+- 🛠️ Supports deprecating callables: functions, methods, class constructors, **generator functions** (`def gen(): yield` — warning fires eagerly at call time, before iteration begins), and **`async def` coroutine functions** (wrapper is `async def`, `inspect.iscoroutinefunction(wrapper)` returns `True`; warning fires when the coroutine is awaited)
 - 📦 Supports deprecating classes, Enums, dataclasses, and module-level constants/objects via transparent proxies (`deprecated_class` for types; `deprecated_instance` for objects, with optional read-only enforcement — blocks standard collection mutators: `append`, `pop`, `update`, `clear`, etc.; custom mutator names bypass this guard)
 - 📝 Optionally, docstrings can be updated automatically in RST/Sphinx or MkDocs/Markdown format (auto-detected); ships bundled Griffe and Sphinx doc-engine extensions
 - 🔍 Preserves original function signature, annotations and metadata for introspection
@@ -1020,6 +1021,57 @@ Sent to 'alice@example.com': 'Hello' [normal]
 
 > [!NOTE]
 > `args_extra` is merged into kwargs _after_ `args_mapping` is applied, so extra values can override mapped ones. It is used when `target` is a Callable or `TargetMode.ARGS_REMAP` (with `args_mapping`). For `TargetMode.NOTIFY`, it is ignored and a construction-time `UserWarning` is emitted by validation.
+
+### 🌀 Async functions
+
+`@deprecated` works natively on `async def` functions. The resulting wrapper is itself `async def`, so `inspect.iscoroutinefunction(wrapper)` returns `True` and asyncio frameworks (FastAPI, `asyncio.run`, `asyncio.gather`) recognise it. All three `TargetMode` variants work; the deprecation warning fires when the coroutine is awaited, not when the wrapper is called.
+
+```python
+import asyncio
+from deprecate import TargetMode, deprecated, void
+
+
+# NEW/FUTURE API
+async def download(url: str) -> bytes:
+    return url.encode()
+
+
+# 1) target=<callable> — forward to a replacement async function
+@deprecated(target=download, deprecated_in="0.9", remove_in="1.0")
+async def fetch(url: str) -> bytes:
+    """Deprecated — use download() instead."""
+    return void(url)
+
+
+# 2) TargetMode.NOTIFY — warn callers; the async body still runs
+@deprecated(deprecated_in="0.9", remove_in="1.0")
+async def legacy_ping() -> str:
+    """Deprecated — going away; remove call sites."""
+    return "pong"
+
+
+# 3) TargetMode.ARGS_REMAP — rename an argument within the same async function
+@deprecated(
+    target=TargetMode.ARGS_REMAP,
+    args_mapping={"endpoint": "url"},
+    deprecated_in="0.9",
+    remove_in="1.0",
+)
+async def fetch_data(endpoint: str = "", url: str = "") -> bytes:
+    """Deprecated argument `endpoint` renamed to `url`."""
+    return url.encode()
+
+
+asyncio.run(fetch("https://example.com"))
+asyncio.run(legacy_ping())
+asyncio.run(fetch_data(endpoint="https://example.com"))
+```
+
+> [!WARNING]
+> Do not apply `@deprecated` to **async generator functions** (`async def` + `yield`). These are not detected at decoration time and the wrapper will not behave correctly. Full async generator support is planned for a future release.
+
+> [!NOTE]
+> `_WrapperState` fields are plain dataclass fields with no asyncio lock — concurrent coroutines sharing one deprecated wrapper can race on warning counts. Set `num_warns=-1` to bypass the count gate in tests that assert exact emission counts.
 
 ## 🔇 Understanding the `void()` Helper
 

--- a/README.md
+++ b/README.md
@@ -1068,7 +1068,7 @@ asyncio.run(fetch_data(endpoint="https://example.com"))
 ```
 
 > [!WARNING]
-> Do not apply `@deprecated` to **async generator functions** (`async def` + `yield`). These are not detected at decoration time and the wrapper will not behave correctly. Full async generator support is planned for a future release.
+> Do not apply `@deprecated` to **async generator functions** (`async def` + `yield`). These are detected at decoration time and currently trigger a `UserWarning`, but they are still unsupported because the produced wrapper is synchronous and is not an async generator function. Full async generator support is planned for a future release.
 
 > [!NOTE]
 > `_WrapperState` fields are plain dataclass fields with no asyncio lock — concurrent coroutines sharing one deprecated wrapper can race on warning counts. Set `num_warns=-1` to bypass the count gate in tests that assert exact emission counts.

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -1051,6 +1051,80 @@ def old_range(start: int, stop: int):
 
     Internally, the deprecated wrapper for a generator is a regular (non-generator) function that fires the warning eagerly and then returns the actual generator object. In the current implementation, `_WrapperState.called` is incremented once per external call via the wrapper's normal dispatch path. Warning deduplication still works correctly: warnings fire at most `num_warns` times as configured.
 
+## Async
+
+`@deprecated` works on `async def` functions natively. The wrapper produced is itself `async def`, so `inspect.iscoroutinefunction(wrapper)` returns `True` and callers can `await` it as expected.
+
+All three TargetModes work with async functions. The deprecation warning fires at call time (when the coroutine is created), consistent with regular function behaviour.
+
+**`TargetMode.NOTIFY` — warn and keep the async body:**
+
+```python
+import asyncio
+from deprecate import deprecated
+
+
+@deprecated(deprecated_in="0.9", remove_in="1.0")
+async def fetch_data(url: str) -> bytes:
+    """Deprecated — no replacement yet; remove call sites."""
+    return b""
+
+
+asyncio.run(fetch_data("https://example.com"))
+```
+
+**`TargetMode.ARGS_REMAP` — rename an argument within the same async function:**
+
+```python
+import asyncio
+from deprecate import TargetMode, deprecated
+
+
+@deprecated(
+    target=TargetMode.ARGS_REMAP,
+    args_mapping={"endpoint": "url"},
+    deprecated_in="0.9",
+    remove_in="1.0",
+)
+async def fetch_data(endpoint: str = "", url: str = "") -> bytes:
+    """Deprecated argument `endpoint` renamed to `url`."""
+    return url.encode()
+
+
+asyncio.run(fetch_data(endpoint="https://example.com"))
+```
+
+**`target=<callable>` — forward to a replacement async function:**
+
+```python
+import asyncio
+from deprecate import deprecated, void
+
+
+async def download(url: str) -> bytes:
+    """New async API."""
+    return url.encode()
+
+
+@deprecated(target=download, deprecated_in="0.9", remove_in="1.0")
+async def fetch(url: str) -> bytes:
+    """Deprecated — use download() instead."""
+    return void(url)
+
+
+asyncio.run(fetch("https://example.com"))
+```
+
+!!! warning "Concurrent coroutines and warning counts"
+
+    `_WrapperState` fields (`called`, `warned_calls`, `warned_args`) are plain dataclass fields — there is no asyncio lock protecting them. If multiple coroutines share one deprecated wrapper and run concurrently, they can race on the warning counter: the same wrapper may emit more or fewer warnings than `num_warns` specifies, depending on scheduling.
+
+    This is an accepted limitation for v0.9. If exact warning counts matter (for example in tests), either run deprecated coroutines sequentially or set `num_warns=-1` to bypass the gate entirely.
+
+!!! note "Async generators are not yet supported"
+
+    Applying `@deprecated` to an `async def` function that contains `yield` (an async generator function) emits `UserWarning` at **decoration time**. The wrapper produced is sync, so `inspect.isasyncgenfunction(wrapper)` returns `False`. Full async generator support is tracked as a future enhancement.
+
 ## See also
 
 - [Customization](customization.md) — redirect deprecation output to a logger or use a custom message template

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -1055,7 +1055,7 @@ def old_range(start: int, stop: int):
 
 `@deprecated` works on `async def` functions natively. The wrapper produced is itself `async def`, so `inspect.iscoroutinefunction(wrapper)` returns `True` and callers can `await` it as expected.
 
-All three TargetModes work with async functions. The deprecation warning fires at call time (when the coroutine is created), consistent with regular function behaviour.
+All three TargetModes work with async functions. The deprecation warning fires when the coroutine is awaited — not when it is created by calling the wrapper — because the warning logic runs inside the `async def` body. This differs from sync and generator wrappers where the warning fires eagerly at call time.
 
 **`TargetMode.NOTIFY` — warn and keep the async body:**
 
@@ -1121,9 +1121,9 @@ asyncio.run(fetch("https://example.com"))
 
     This is an accepted limitation for v0.9. If exact warning counts matter (for example in tests), either run deprecated coroutines sequentially or set `num_warns=-1` to bypass the gate entirely.
 
-!!! note "Async generators are not yet supported"
+!!! warning "Async generator functions are not supported"
 
-    Applying `@deprecated` to an `async def` function that contains `yield` (an async generator function) emits `UserWarning` at **decoration time**. The wrapper produced is sync, so `inspect.isasyncgenfunction(wrapper)` returns `False`. Full async generator support is tracked as a future enhancement.
+    Do not apply `@deprecated` to `async def` functions that contain `yield` (async generator functions). pyDeprecate does not detect async generators at decoration time — the wrapper is created as a regular sync function (`inspect.iscoroutinefunction` returns `False` for async generators), so the regular sync wrapper path is used and calling the result will not behave as expected. Full async generator support is planned for a future release.
 
 ## See also
 

--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -1123,7 +1123,7 @@ asyncio.run(fetch("https://example.com"))
 
 !!! warning "Async generator functions are not supported"
 
-    Do not apply `@deprecated` to `async def` functions that contain `yield` (async generator functions). pyDeprecate does not detect async generators at decoration time — the wrapper is created as a regular sync function (`inspect.iscoroutinefunction` returns `False` for async generators), so the regular sync wrapper path is used and calling the result will not behave as expected. Full async generator support is planned for a future release.
+    Do not apply `@deprecated` to `async def` functions that contain `yield` (async generator functions). pyDeprecate **does** detect async generators at decoration time and raises a `UserWarning`, but full async-generator wrapper support is still not provided. The generated wrapper remains a regular sync function rather than an async generator wrapper, so `inspect.isasyncgenfunction(...)` on the decorated function will be `False` and calling the result will not behave as expected. Full async generator support is planned for a future release.
 
 ## See also
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -149,7 +149,7 @@ What is being deprecated?
   │    → use @deprecated_class(target=NewCls, ...) — NOT @deprecated
   │      (classes are callables, but @deprecated is for functions/methods only)
   │
-  └─ A function or method (including generator functions — `def gen(): yield`)?
+  └─ A function or method (including generator functions — `def gen(): yield` — and async functions — `async def fn()`)?
        → use @deprecated; then choose target= based on the replacement:
          ├─ Has a replacement function/method?
          │    → target=<callable>; leave body empty (pass / void())
@@ -164,6 +164,9 @@ What is being deprecated?
                 (ARGS_REMAP outer + NOTIFY inner — both layers fire independently)
          Note: for generator functions the warning fires eagerly at call time (before first next()),
                not on first iteration — consistent with regular function behavior.
+         Note: for async def functions, the wrapper is async def; inspect.iscoroutinefunction(wrapper)
+               returns True. async generator functions (async def + yield) are not yet supported —
+               decoration emits UserWarning at decoration time and produces a sync wrapper.
 ```
 
 ### Enforce removal deadlines in CI
@@ -207,6 +210,8 @@ pydeprecate all src/
 - `@deprecated` works with `@classmethod`, `@staticmethod`, `@property`, and `@cached_property` in either decorator order — `@classmethod @deprecated` and `@deprecated @classmethod` both produce `classmethod(deprecated_wrapper)`; `@staticmethod @deprecated` and `@deprecated @staticmethod` both produce `staticmethod(deprecated_wrapper)`. Both fire `FutureWarning` at call time.
 - `@property` with `@deprecated` in either order: warning fires on attribute access (`obj.prop` triggers it, not `obj.prop()`).
 - `@cached_property` with `@deprecated` in either order: warning fires on **first access only** — subsequent accesses hit the cached value and do not emit a warning.
+- `@deprecated` on `async def` functions: the wrapper is `async def`; `inspect.iscoroutinefunction(wrapper)` returns `True`. All three TargetModes work. Warning fires at await time (call time), consistent with sync behaviour.
+- `@deprecated` on async generator functions (`async def` + `yield`): emits `UserWarning` at decoration time; the wrapper produced is sync; `inspect.isasyncgenfunction(wrapper)` returns `False`. Not yet fully supported — see Known Limitations.
 
 ## Anti-Patterns
 
@@ -216,11 +221,14 @@ pydeprecate all src/
 - Do not call the target inside a deprecated function body when `target=<callable>`.
 - Do not use raw `warnings.warn` for public API migrations that need forwarding, argument mapping, class proxying, warning frequency control, or CI audit.
 - `@deprecated` works with `@classmethod` and `@staticmethod` in either order. pyDeprecate unwraps the underlying function (`.__func__`), applies the deprecation wrapper, and re-wraps the descriptor, so the method remains deprecated regardless of decorator order.
+- Do not apply `@deprecated` to async generator functions — the wrapper degrades to sync and emits `UserWarning` at decoration time. Wait for full async generator support in a future release.
 
 ## Known Limitations
 
 - `_WrapperState.called` is incremented once per deprecated wrapper invocation in the current implementation. Warning deduplication still works correctly — warnings fire at most `num_warns` times — and the stored call count reflects wrapper invocations rather than a generator-specific double increment.
 - `_WrapperState` has no thread or async locks. Concurrent calls to the same deprecated wrapper can race on the `called` counter (pre-existing limitation, identical to regular function wrappers).
+- **Async generator functions not yet supported**: `@deprecated` on `async def` functions containing `yield` emits `UserWarning` at decoration time and produces a sync wrapper. `inspect.isasyncgenfunction(wrapper)` returns `False`. Full support is planned for a future release.
+- **`_WrapperState` concurrency under async**: for `async def` wrappers, `_WrapperState` fields (`called`, `warned_calls`, `warned_args`) are plain dataclass fields with no asyncio lock. Concurrent coroutines sharing one deprecated wrapper can race on warning counts — the wrapper may emit fewer warnings than `num_warns` specifies. Set `num_warns=-1` to bypass the count gate if exact emission counts matter in tests.
 
 ## Full Context
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -231,6 +231,7 @@ pydeprecate all src/
 - **`_WrapperState` concurrency under async**: for `async def` wrappers, `_WrapperState` fields (`called`, `warned_calls`, `warned_args`) are plain dataclass fields with no asyncio lock. Concurrent coroutines sharing one deprecated wrapper can race on warning counts — the wrapper may emit fewer warnings than `num_warns` specifies. Set `num_warns=-1` to bypass the count gate if exact emission counts matter in tests.
 - **`functools.partial` of `async def` loses coroutine flag on Python 3.9–3.11**: `inspect.iscoroutinefunction(functools.partial(async_fn))` returns `False` on Python ≤3.11 — `partial` does not propagate the coroutine flag. Apply `@deprecated` to the `async def` directly; use `partial` on the already-deprecated wrapper if needed. Resolved in Python 3.12+.
 - **Sync wrapper over `async def` loses coroutine flag**: a sync decorator applied over a `@deprecated async def` wrapper produces a sync callable — `inspect.iscoroutinefunction` returns `False`. Outer decorators must use an `async def` wrapper when wrapping async functions; otherwise frameworks (FastAPI route handlers, asyncio task creation) will reject the result.
+- **Callable objects with `async def __call__` not detected**: `inspect.iscoroutinefunction(callable_obj)` returns `False` for callable objects whose `__call__` is `async def` — `@deprecated` installs the sync wrapper and `await wrapper(...)` will fail. Workaround: wrap in a plain `async def my_wrapper(*a, **kw): return await callable_obj(*a, **kw)` before applying `@deprecated`.
 
 ## Full Context
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -211,7 +211,7 @@ pydeprecate all src/
 - `@property` with `@deprecated` in either order: warning fires on attribute access (`obj.prop` triggers it, not `obj.prop()`).
 - `@cached_property` with `@deprecated` in either order: warning fires on **first access only** — subsequent accesses hit the cached value and do not emit a warning.
 - `@deprecated` on `async def` functions: the wrapper is `async def`; `inspect.iscoroutinefunction(wrapper)` returns `True`. All three TargetModes work. Warning fires when the coroutine is awaited, not when the wrapper is called — `coro = wrapper(x=1)` produces no warning; `await coro` fires it.
-- `@deprecated` on async generator functions (`async def` + `yield`): not detected at decoration time — `inspect.iscoroutinefunction` returns `False` for async generators, so the regular sync wrapper path is taken and the result is incorrect. Not supported — see Known Limitations.
+- `@deprecated` on async generator functions (`async def` + `yield`): detected at decoration time via `inspect.isasyncgenfunction(source)`, and pyDeprecate warns at decoration time rather than pretending they are regular coroutine functions. Async generators remain unsupported — see Known Limitations.
 
 ## Anti-Patterns
 
@@ -221,13 +221,13 @@ pydeprecate all src/
 - Do not call the target inside a deprecated function body when `target=<callable>`.
 - Do not use raw `warnings.warn` for public API migrations that need forwarding, argument mapping, class proxying, warning frequency control, or CI audit.
 - `@deprecated` works with `@classmethod` and `@staticmethod` in either order. pyDeprecate unwraps the underlying function (`.__func__`), applies the deprecation wrapper, and re-wraps the descriptor, so the method remains deprecated regardless of decorator order.
-- Do not apply `@deprecated` to async generator functions (`async def` + `yield`) — they are not detected at decoration time and the wrapper will not behave correctly. Full async generator support is planned for a future release.
+- Do not apply `@deprecated` to async generator functions (`async def` + `yield`) — pyDeprecate detects them at decoration time and emits a `UserWarning`, but full async generator support is not implemented and the wrapper will not behave correctly. Full async generator support is planned for a future release.
 
 ## Known Limitations
 
 - `_WrapperState.called` is incremented once per deprecated wrapper invocation in the current implementation. Warning deduplication still works correctly — warnings fire at most `num_warns` times — and the stored call count reflects wrapper invocations rather than a generator-specific double increment.
 - `_WrapperState` has no thread or async locks. Concurrent calls to the same deprecated wrapper can race on the `called` counter (pre-existing limitation, identical to regular function wrappers).
-- **Async generator functions not yet supported**: `@deprecated` on `async def` functions containing `yield` (async generator functions) is not detected at decoration time — `inspect.iscoroutinefunction` returns `False` for async generators, so the regular sync wrapper path is used and the result is incorrect. Do not use. Full support is planned for a future release.
+- **Async generator functions not yet supported**: `@deprecated` on `async def` functions containing `yield` (async generator functions) is detected at decoration time and triggers a `UserWarning`, but full support is not implemented. Do not use. Full support is planned for a future release.
 - **`_WrapperState` concurrency under async**: for `async def` wrappers, `_WrapperState` fields (`called`, `warned_calls`, `warned_args`) are plain dataclass fields with no asyncio lock. Concurrent coroutines sharing one deprecated wrapper can race on warning counts — the wrapper may emit fewer warnings than `num_warns` specifies. Set `num_warns=-1` to bypass the count gate if exact emission counts matter in tests.
 - **`functools.partial` of `async def` loses coroutine flag on Python 3.9–3.11**: `inspect.iscoroutinefunction(functools.partial(async_fn))` returns `False` on Python ≤3.11 — `partial` does not propagate the coroutine flag. Apply `@deprecated` to the `async def` directly; use `partial` on the already-deprecated wrapper if needed. Resolved in Python 3.12+.
 - **Sync wrapper over `async def` loses coroutine flag**: a sync decorator applied over a `@deprecated async def` wrapper produces a sync callable — `inspect.iscoroutinefunction` returns `False`. Outer decorators must use an `async def` wrapper when wrapping async functions; otherwise frameworks (FastAPI route handlers, asyncio task creation) will reject the result.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -165,8 +165,8 @@ What is being deprecated?
          Note: for generator functions the warning fires eagerly at call time (before first next()),
                not on first iteration — consistent with regular function behavior.
          Note: for async def functions, the wrapper is async def; inspect.iscoroutinefunction(wrapper)
-               returns True. async generator functions (async def + yield) are not yet supported —
-               decoration emits UserWarning at decoration time and produces a sync wrapper.
+               returns True. Warning fires on await, not on call. async generator functions
+               (async def + yield) are not supported — do not apply @deprecated to them.
 ```
 
 ### Enforce removal deadlines in CI
@@ -210,8 +210,8 @@ pydeprecate all src/
 - `@deprecated` works with `@classmethod`, `@staticmethod`, `@property`, and `@cached_property` in either decorator order — `@classmethod @deprecated` and `@deprecated @classmethod` both produce `classmethod(deprecated_wrapper)`; `@staticmethod @deprecated` and `@deprecated @staticmethod` both produce `staticmethod(deprecated_wrapper)`. Both fire `FutureWarning` at call time.
 - `@property` with `@deprecated` in either order: warning fires on attribute access (`obj.prop` triggers it, not `obj.prop()`).
 - `@cached_property` with `@deprecated` in either order: warning fires on **first access only** — subsequent accesses hit the cached value and do not emit a warning.
-- `@deprecated` on `async def` functions: the wrapper is `async def`; `inspect.iscoroutinefunction(wrapper)` returns `True`. All three TargetModes work. Warning fires at await time (call time), consistent with sync behaviour.
-- `@deprecated` on async generator functions (`async def` + `yield`): emits `UserWarning` at decoration time; the wrapper produced is sync; `inspect.isasyncgenfunction(wrapper)` returns `False`. Not yet fully supported — see Known Limitations.
+- `@deprecated` on `async def` functions: the wrapper is `async def`; `inspect.iscoroutinefunction(wrapper)` returns `True`. All three TargetModes work. Warning fires when the coroutine is awaited, not when the wrapper is called — `coro = wrapper(x=1)` produces no warning; `await coro` fires it.
+- `@deprecated` on async generator functions (`async def` + `yield`): not detected at decoration time — `inspect.iscoroutinefunction` returns `False` for async generators, so the regular sync wrapper path is taken and the result is incorrect. Not supported — see Known Limitations.
 
 ## Anti-Patterns
 
@@ -221,14 +221,16 @@ pydeprecate all src/
 - Do not call the target inside a deprecated function body when `target=<callable>`.
 - Do not use raw `warnings.warn` for public API migrations that need forwarding, argument mapping, class proxying, warning frequency control, or CI audit.
 - `@deprecated` works with `@classmethod` and `@staticmethod` in either order. pyDeprecate unwraps the underlying function (`.__func__`), applies the deprecation wrapper, and re-wraps the descriptor, so the method remains deprecated regardless of decorator order.
-- Do not apply `@deprecated` to async generator functions — the wrapper degrades to sync and emits `UserWarning` at decoration time. Wait for full async generator support in a future release.
+- Do not apply `@deprecated` to async generator functions (`async def` + `yield`) — they are not detected at decoration time and the wrapper will not behave correctly. Full async generator support is planned for a future release.
 
 ## Known Limitations
 
 - `_WrapperState.called` is incremented once per deprecated wrapper invocation in the current implementation. Warning deduplication still works correctly — warnings fire at most `num_warns` times — and the stored call count reflects wrapper invocations rather than a generator-specific double increment.
 - `_WrapperState` has no thread or async locks. Concurrent calls to the same deprecated wrapper can race on the `called` counter (pre-existing limitation, identical to regular function wrappers).
-- **Async generator functions not yet supported**: `@deprecated` on `async def` functions containing `yield` emits `UserWarning` at decoration time and produces a sync wrapper. `inspect.isasyncgenfunction(wrapper)` returns `False`. Full support is planned for a future release.
+- **Async generator functions not yet supported**: `@deprecated` on `async def` functions containing `yield` (async generator functions) is not detected at decoration time — `inspect.iscoroutinefunction` returns `False` for async generators, so the regular sync wrapper path is used and the result is incorrect. Do not use. Full support is planned for a future release.
 - **`_WrapperState` concurrency under async**: for `async def` wrappers, `_WrapperState` fields (`called`, `warned_calls`, `warned_args`) are plain dataclass fields with no asyncio lock. Concurrent coroutines sharing one deprecated wrapper can race on warning counts — the wrapper may emit fewer warnings than `num_warns` specifies. Set `num_warns=-1` to bypass the count gate if exact emission counts matter in tests.
+- **`functools.partial` of `async def` loses coroutine flag on Python 3.9–3.11**: `inspect.iscoroutinefunction(functools.partial(async_fn))` returns `False` on Python ≤3.11 — `partial` does not propagate the coroutine flag. Apply `@deprecated` to the `async def` directly; use `partial` on the already-deprecated wrapper if needed. Resolved in Python 3.12+.
+- **Sync wrapper over `async def` loses coroutine flag**: a sync decorator applied over a `@deprecated async def` wrapper produces a sync callable — `inspect.iscoroutinefunction` returns `False`. Outer decorators must use an `async def` wrapper when wrapping async functions; otherwise frameworks (FastAPI route handlers, asyncio task creation) will reject the result.
 
 ## Full Context
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -252,6 +252,14 @@
             "@type": "Answer",
             "text": "Yes. pyDeprecate silently rescues the misordered stack: it detects the classmethod descriptor, unwraps it, applies the deprecation wrapper to the underlying function, and re-wraps the result in classmethod. No UserWarning is emitted at decoration time, and a FutureWarning fires normally when the method is called. The preferred order is still @classmethod outermost with @deprecated closer to def, as it is explicit and avoids the silent rescue."
           }
+        },
+        {
+          "@type": "Question",
+          "name": "Why do concurrent async calls to a deprecated wrapper emit fewer warnings than expected?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "_WrapperState fields (called, warned_calls, warned_args) are plain Python dataclass fields with no asyncio lock. Concurrent coroutines sharing one deprecated wrapper race on the warning counter, causing fewer warnings than num_warns specifies to be emitted. Workaround: set num_warns=-1 to bypass the count gate entirely — the warning then fires unconditionally on every call regardless of scheduling."
+          }
         }
       ]
     }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -721,8 +721,6 @@ The same rule applies to `@staticmethod`.
 
 ______________________________________________________________________
 
-______________________________________________________________________
-
 ## Concurrent async calls and warning counts
 
 **Q:** I have multiple coroutines all calling the same deprecated `async def` wrapper concurrently. The deprecation notice only appeared once, but I expected it to fire `num_warns` times. What happened?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -759,6 +759,72 @@ asyncio.run(main())
 
 If you need to assert exactly one warning fires in a test, run the deprecated coroutines sequentially rather than with `asyncio.gather`.
 
+## I wrapped a `functools.partial` of an `async def` and the wrapper is not async
+
+**Q:** I applied `@deprecated` to a `functools.partial` of an `async def` function, but the resulting wrapper is synchronous — `inspect.iscoroutinefunction(wrapper)` returns `False` and `await wrapper(...)` raises a `TypeError`. What is happening?
+
+**A:** On Python 3.9–3.11, `inspect.iscoroutinefunction(functools.partial(async_fn))` returns `False` — the `partial` object does not propagate the coroutine flag of its wrapped callable. pyDeprecate's async branch in `packing()` checks `inspect.iscoroutinefunction(source)` to decide whether to produce an `async def` wrapper, so wrapping a `partial` of an `async def` falls through to the sync wrapper path and yields a regular function instead of a coroutine function.
+
+**Workaround:** Apply `@deprecated` to the `async def` directly, then use `functools.partial` on the already-deprecated async wrapper if you need preset arguments.
+
+```python
+import asyncio
+import functools
+from deprecate import deprecated
+
+
+async def new_fetch(url: str, timeout: int = 30) -> bytes:
+    return url.encode()
+
+
+# Correct: apply @deprecated to the async def directly
+@deprecated(target=new_fetch, deprecated_in="0.9", remove_in="1.0")
+async def old_fetch(url: str, timeout: int = 30) -> bytes:
+    pass
+
+
+# Then use partial on the already-deprecated async wrapper if needed
+fetch_with_timeout = functools.partial(old_fetch, timeout=10)
+asyncio.run(old_fetch("https://example.com"))
+```
+
+This limitation is resolved in Python 3.12+ where `inspect.iscoroutinefunction` correctly handles `functools.partial` objects whose underlying callable is an `async def`.
+
+______________________________________________________________________
+
+## A non-async decorator applied over my `@deprecated` async wrapper no longer looks like a coroutine
+
+**Q:** I have `@my_decorator @deprecated(...) async def fn(...)`. After decoration, `inspect.iscoroutinefunction(fn)` returns `False` and asyncio frameworks (FastAPI route handlers, `asyncio.create_task`) reject it. Why?
+
+**A:** When you wrap a `@deprecated async def` with a sync decorator — one that returns a sync `wrapper(*args, **kwargs)` via `functools.wraps` — the result is a sync callable. `inspect.iscoroutinefunction` inspects the outermost callable's `CO_COROUTINE` flag, not the wrapped function, so the coroutine nature is lost the moment a sync wrapper is placed on top.
+
+**Solution:** Make any outer decorator that may be applied over an async wrapper coroutine-aware. Inspect the wrapped callable and emit either an `async def` or a sync wrapper accordingly.
+
+```python
+import functools
+import inspect
+
+
+def my_decorator(fn):
+    if inspect.iscoroutinefunction(fn):
+
+        @functools.wraps(fn)
+        async def async_wrapper(*args, **kwargs):
+            return await fn(*args, **kwargs)
+
+        return async_wrapper
+
+    @functools.wraps(fn)
+    def sync_wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return sync_wrapper
+```
+
+With this pattern, stacking `@my_decorator` above `@deprecated` on an `async def` produces an `async def` wrapper whose `inspect.iscoroutinefunction(...)` returns `True`.
+
+______________________________________________________________________
+
 ## Still stuck?
 
 !!! question "Open a GitHub issue"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -721,6 +721,44 @@ The same rule applies to `@staticmethod`.
 
 ______________________________________________________________________
 
+______________________________________________________________________
+
+## Concurrent async calls and warning counts
+
+**Q:** I have multiple coroutines all calling the same deprecated `async def` wrapper concurrently. The deprecation notice only appeared once, but I expected it to fire `num_warns` times. What happened?
+
+**A:** `_WrapperState` fields — `called`, `warned_calls`, and `warned_args` — are plain Python dataclass fields with no asyncio lock. When multiple coroutines share a single deprecated wrapper and run concurrently in the same event loop, they race on the warning counter. One coroutine may read the counter, another may increment it, and the first may then emit or skip based on the stale value. The result is that fewer warnings than `num_warns` specifies may be emitted.
+
+This is an accepted limitation for v0.9 — adding an asyncio lock would change the public behaviour of synchronous wrappers and is deferred to a future release.
+
+**Workaround:** Set `num_warns=-1` to bypass the count gate entirely. With `num_warns=-1` the warning fires unconditionally on every call, so no race can suppress it.
+
+```python
+import asyncio
+from deprecate import deprecated
+
+
+async def new_fetch(url: str) -> bytes:
+    return url.encode()
+
+
+# num_warns=-1 emits the deprecation notice on every call regardless of concurrency
+@deprecated(target=new_fetch, deprecated_in="0.9", remove_in="1.0", num_warns=-1)
+async def old_fetch(url: str) -> bytes:
+    pass
+
+
+async def main():
+    urls = ["https://a.example.com", "https://b.example.com", "https://c.example.com"]
+    # All three tasks fire the deprecation notice — no race suppression possible
+    await asyncio.gather(*[old_fetch(u) for u in urls])
+
+
+asyncio.run(main())
+```
+
+If you need to assert exactly one warning fires in a test, run the deprecated coroutines sequentially rather than with `asyncio.gather`.
+
 ## Still stuck?
 
 !!! question "Open a GitHub issue"

--- a/src/deprecate/_types.py
+++ b/src/deprecate/_types.py
@@ -399,10 +399,12 @@ class _CallPlan:
     to invoke ``source`` or a forwarded target callable, and with which kwargs shape.
 
     Attributes:
-        short_circuit: ``True`` when the wrapper must call ``source(**resolved_kwargs)`` (no warning, no remap, no
-            target lookup) — this is the "migrated caller using the new arg name" fast path before any warning logic
-            runs.  When ``True``, :attr:`resolved_kwargs` equals the kwargs after
-            :func:`_update_kwargs_with_args`, before defaults / remap / extras are applied.
+        short_circuit: ``True`` when the wrapper must call ``source`` directly (no warning, no remap, no target
+            lookup) — this is the "migrated caller using the new arg name" fast path before any warning logic runs.
+            The wrapper calls ``source(**resolved_kwargs)`` for sources without ``*args``, or
+            ``source(*args, **original_kwargs)`` when the source declares a var-positional parameter so that
+            extra positional arguments are forwarded correctly.  When ``True``, :attr:`resolved_kwargs` equals the
+            kwargs after :func:`_update_kwargs_with_args`, before defaults / remap / extras are applied.
         original_kwargs: A shallow copy of the wrapper's incoming ``kwargs`` (before positional args were converted to
             keyword form).  Used by the var-positional branch when no argument-rename reason fired, so that the source
             sees its original positional/keyword shape.

--- a/src/deprecate/_types.py
+++ b/src/deprecate/_types.py
@@ -388,3 +388,38 @@ class _DeprecatedCallable(Protocol):
     def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         """Call the deprecated callable."""
         raise NotImplementedError
+
+
+@dataclass
+class _CallPlan:
+    """Resolved dispatch plan returned by :func:`deprecate.deprecation._build_call_plan`.
+
+    Captures the outcome of all decision-making shared between the sync and async wrappers in :func:`deprecated`: state
+    mutation, kwargs assembly, warning emission, target resolution.  The wrapper consumes this struct to decide whether
+    to invoke ``source`` (with original or resolved kwargs, depending on var-positional shape) or a forwarded target
+    callable.
+
+    Attributes:
+        short_circuit: ``True`` when the wrapper must call ``source(**original_kwargs)`` (no warning, no remap, no
+            target lookup) — this is the "migrated caller using the new arg name" fast path before any warning logic
+            runs.  When ``True``, :attr:`resolved_kwargs` equals the kwargs after :func:`_update_kwargs_with_args` but
+            before defaults / remap / extras are applied.
+        original_kwargs: A shallow copy of the wrapper's incoming ``kwargs`` (before positional args were converted to
+            keyword form).  Used by the var-positional branch when no argument-rename reason fired, so that the source
+            sees its original positional/keyword shape.
+        resolved_kwargs: Final kwargs after defaults injection, ``args_mapping`` remap, and ``args_extra`` merge.  This
+            is what the target (or source, in the non-callable-target branch) should be invoked with.
+        reason_argument: Subset of ``args_mapping`` whose old-arg names appeared in the caller's kwargs.  Non-empty
+            value means the argument-rename warning fired (or was suppressed by ``num_warns`` quota).  Empty when the
+            warning reason was callable-deprecation or when no rename was triggered.
+        target_func: Resolved target callable when forwarding is required, or ``None`` when the source body should be
+            invoked instead.  ``None`` for :attr:`TargetMode.NOTIFY` and :attr:`TargetMode.ARGS_REMAP`; a validated
+            callable when the user passed a forwarding target.
+
+    """
+
+    short_circuit: bool
+    original_kwargs: dict[str, Any]
+    resolved_kwargs: dict[str, Any]
+    reason_argument: dict[str, Optional[str]] = field(default_factory=dict)
+    target_func: Optional[Callable[..., Any]] = None

--- a/src/deprecate/_types.py
+++ b/src/deprecate/_types.py
@@ -396,19 +396,19 @@ class _CallPlan:
 
     Captures the outcome of all decision-making shared between the sync and async wrappers in :func:`deprecated`: state
     mutation, kwargs assembly, warning emission, target resolution.  The wrapper consumes this struct to decide whether
-    to invoke ``source`` (with original or resolved kwargs, depending on var-positional shape) or a forwarded target
-    callable.
+    to invoke ``source`` or a forwarded target callable, and with which kwargs shape.
 
     Attributes:
-        short_circuit: ``True`` when the wrapper must call ``source(**original_kwargs)`` (no warning, no remap, no
+        short_circuit: ``True`` when the wrapper must call ``source(**resolved_kwargs)`` (no warning, no remap, no
             target lookup) — this is the "migrated caller using the new arg name" fast path before any warning logic
-            runs.  When ``True``, :attr:`resolved_kwargs` equals the kwargs after :func:`_update_kwargs_with_args` but
-            before defaults / remap / extras are applied.
+            runs.  When ``True``, :attr:`resolved_kwargs` equals the kwargs after
+            :func:`_update_kwargs_with_args`, before defaults / remap / extras are applied.
         original_kwargs: A shallow copy of the wrapper's incoming ``kwargs`` (before positional args were converted to
             keyword form).  Used by the var-positional branch when no argument-rename reason fired, so that the source
             sees its original positional/keyword shape.
-        resolved_kwargs: Final kwargs after defaults injection, ``args_mapping`` remap, and ``args_extra`` merge.  This
-            is what the target (or source, in the non-callable-target branch) should be invoked with.
+        resolved_kwargs: Final kwargs after defaults injection, ``args_mapping`` remap, and ``args_extra`` merge when
+            the normal planning path runs.  On the :attr:`short_circuit` path, this instead holds the kwargs produced
+            immediately after :func:`_update_kwargs_with_args`, and that is what the wrapper passes to ``source``.
         reason_argument: Subset of ``args_mapping`` whose old-arg names appeared in the caller's kwargs.  Non-empty
             value means the argument-rename warning fired (or was suppressed by ``num_warns`` quota).  Empty when the
             warning reason was callable-deprecation or when no rename was triggered.

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -753,23 +753,23 @@ def _build_call_plan(
             # Use original `target` (not remapped normalized_target) so the warning
             # names the class (e.g. "NewCls") rather than "__init__".
             _raise_warn_callable(
-                stream,
-                source,
-                target,
-                dep_cfg.deprecated_in,
-                dep_cfg.remove_in,
-                dep_cfg.template_mgs,
+                stream=stream,
+                source=source,
+                target=target,
+                deprecated_in=dep_cfg.deprecated_in,
+                remove_in=dep_cfg.remove_in,
+                template_mgs=dep_cfg.template_mgs,
                 stacklevel=_stacklevel_to_caller,
             )
             state.warned_calls += 1
         elif reason_argument:
             _raise_warn_arguments(
-                stream,
-                source,
-                reason_argument,
-                dep_cfg.deprecated_in,
-                dep_cfg.remove_in,
-                dep_cfg.template_mgs,
+                stream=stream,
+                source=source,
+                arguments=reason_argument,
+                deprecated_in=dep_cfg.deprecated_in,
+                remove_in=dep_cfg.remove_in,
+                template_mgs=dep_cfg.template_mgs,
                 stacklevel=_stacklevel_to_caller,
             )
             for arg in reason_argument:

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -1155,6 +1155,8 @@ def deprecated(
                 )
 
                 if plan.short_circuit:
+                    if source_has_var_positional:
+                        return await source(*args, **plan.original_kwargs)
                     return await source(**plan.resolved_kwargs)
 
                 if plan.target_func is None:
@@ -1213,6 +1215,8 @@ def deprecated(
             )
 
             if plan.short_circuit:
+                if source_has_var_positional:
+                    return source(*args, **plan.original_kwargs)
                 return source(**plan.resolved_kwargs)
 
             if plan.target_func is None:

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -1211,6 +1211,11 @@ def deprecated(
                     call_kwargs = plan.original_kwargs if not plan.reason_argument else plan.resolved_kwargs
                     return source(*args, **call_kwargs)
                 return source(**plan.resolved_kwargs)
+            if inspect.iscoroutinefunction(plan.target_func):
+                raise TypeError(
+                    f"Async target `{plan.target_func.__name__}` cannot be invoked from a sync wrapper."
+                    f" Declare `{source.__name__}` as `async def`, or replace the target with a sync callable."
+                )
             return plan.target_func(**plan.resolved_kwargs)
 
         wrapped_fn_typed = cast(_DeprecatedCallable, wrapped_fn)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -1168,6 +1168,15 @@ def deprecated(
 
             return async_wrapped_fn
 
+        if inspect.isasyncgenfunction(source):
+            warnings.warn(
+                f"`@deprecated` on async generator `{source.__name__}` is not yet supported. "
+                "The wrapper will be a sync function and `await wrapper(...)` will fail. "
+                "Remove `@deprecated` from async generators until full support lands.",
+                UserWarning,
+                stacklevel=_stacklevel,
+            )
+
         @wraps(source)
         def wrapped_fn(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
             shall_skip = skip_if() if callable(skip_if) else bool(skip_if)

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -749,7 +749,9 @@ def _build_call_plan(
         nb_warned = state.warned_calls
 
     # +1 stacklevel: extraction added one frame (caller → wrapper_fn → _build_call_plan → _raise_warn_*)
-    # over the previous in-wrapper call chain.
+    # over the previous in-wrapper call chain.  Async path has the same frame depth:
+    # caller → coroutine `async_wrapped_fn` body → _build_call_plan → _raise_warn_* — the asyncio runner
+    # frames sit *below* the caller and are skipped by warnings.warn's stacklevel walk.
     _stacklevel_to_caller = _DEFAULT_STACKLEVEL_TO_CALLER + 1
     if stream and (num_warns < 0 or nb_warned < num_warns):
         if reason_callable:

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -655,14 +655,14 @@ def _build_call_plan(
     wrapper_fn: Callable[..., Any],
     source: Callable[..., Any],
     target: Union[bool, None, Callable[..., Any], TargetMode],
-    _target: Union[Callable[..., Any], TargetMode],
+    normalized_target: Union[Callable[..., Any], TargetMode],
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
     dep_cfg: DeprecationConfig,
     stream: Optional[Callable[..., None]],
     num_warns: int,
     source_has_var_positional: bool,
-    _source_is_stacked: bool,
+    source_is_stacked: bool,
 ) -> _CallPlan:
     """Compute the dispatch plan shared by the sync and async wrappers inside :func:`deprecated`.
 
@@ -686,7 +686,7 @@ def _build_call_plan(
         source: The decorated callable.
         target: The raw ``target`` argument given to ``@deprecated`` — preserved for warning emission so callable
             targets that are classes are named by their user-facing name rather than ``__init__``.
-        _target: The normalised target (a :class:`TargetMode` member or callable) returned by
+        normalized_target: The normalised target (a :class:`TargetMode` member or callable) returned by
             :func:`_normalize_target`.
         args: The positional arguments the caller passed to the wrapper.
         kwargs: The keyword arguments the caller passed to the wrapper.
@@ -696,18 +696,13 @@ def _build_call_plan(
         num_warns: Maximum number of times to emit the warning per wrapper / per renamed argument.
         source_has_var_positional: ``True`` when ``source`` declares ``*args`` — affects fast-path dispatch in the
             wrapper but is also needed inside this helper for the short-circuit branch.
-        _source_is_stacked: ``True`` when ``source`` is itself a ``@deprecated`` wrapper.
+        source_is_stacked: ``True`` when ``source`` is itself a ``@deprecated`` wrapper.
 
     Returns:
         A :class:`_CallPlan` describing the resolved dispatch outcome.
 
     """
     state = cast(_DeprecatedCallable, wrapper_fn)._state
-    args_mapping = dep_cfg.args_mapping
-    args_extra = dep_cfg.args_extra
-    deprecated_in = dep_cfg.deprecated_in
-    remove_in = dep_cfg.remove_in
-    template_mgs = dep_cfg.template_mgs
     state.called += 1
     if dep_cfg.misconfigured and stream and not state.warned_misconfigured:
         warnings.warn(
@@ -722,18 +717,18 @@ def _build_call_plan(
     original_kwargs = dict(kwargs)
     kwargs = _update_kwargs_with_args(source, args, kwargs)
 
-    reason_callable = _target is TargetMode.NOTIFY or callable(_target)
+    reason_callable = normalized_target is TargetMode.NOTIFY or callable(normalized_target)
     reason_argument: dict[str, Optional[str]] = {}
-    if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
-        reason_argument = {a: b for a, b in args_mapping.items() if a in kwargs}
+    if dep_cfg.args_mapping and (normalized_target is TargetMode.ARGS_REMAP or callable(normalized_target)):
+        reason_argument = {a: b for a, b in dep_cfg.args_mapping.items() if a in kwargs}
     # Migrated callers (using the new arg name) produce empty reason_argument;
     # without the args_extra guard they short-circuit before extras are injected.
     # When source is a stacked @deprecated wrapper (e.g. ARGS_REMAP outer + NOTIFY inner),
     # do not short-circuit even with no reason — the inner layer may still need to run.
     if (
         not (reason_callable or reason_argument)
-        and not (args_extra and _target is TargetMode.ARGS_REMAP)
-        and not _source_is_stacked
+        and not (dep_cfg.args_extra and normalized_target is TargetMode.ARGS_REMAP)
+        and not source_is_stacked
     ):
         return _CallPlan(
             short_circuit=True,
@@ -755,15 +750,15 @@ def _build_call_plan(
     _stacklevel_to_caller = _DEFAULT_STACKLEVEL_TO_CALLER + 1
     if stream and (num_warns < 0 or nb_warned < num_warns):
         if reason_callable:
-            # Use original `target` (not remapped _target) so the warning
+            # Use original `target` (not remapped normalized_target) so the warning
             # names the class (e.g. "NewCls") rather than "__init__".
             _raise_warn_callable(
                 stream,
                 source,
                 target,
-                deprecated_in,
-                remove_in,
-                template_mgs,
+                dep_cfg.deprecated_in,
+                dep_cfg.remove_in,
+                dep_cfg.template_mgs,
                 stacklevel=_stacklevel_to_caller,
             )
             state.warned_calls += 1
@@ -772,9 +767,9 @@ def _build_call_plan(
                 stream,
                 source,
                 reason_argument,
-                deprecated_in,
-                remove_in,
-                template_mgs,
+                dep_cfg.deprecated_in,
+                dep_cfg.remove_in,
+                dep_cfg.template_mgs,
                 stacklevel=_stacklevel_to_caller,
             )
             for arg in reason_argument:
@@ -784,16 +779,17 @@ def _build_call_plan(
         # Source defaults for renamed args survive _update_kwargs_with_defaults and
         # would be forwarded under the new name, silently overriding the target's own
         # default. Drop only when the caller never supplied the old or new name.
-        if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
+        if dep_cfg.args_mapping and (normalized_target is TargetMode.ARGS_REMAP or callable(normalized_target)):
+            _am = dep_cfg.args_mapping  # narrowed: non-None inside this branch; needed for nested closure
             caller_keys = set(kwargs)
-            rename_targets = {v for v in args_mapping.values() if v}
-            rename_sources = set(args_mapping)
+            rename_targets = {v for v in _am.values() if v}
+            rename_sources = set(_am)
             # For ARGS_REMAP, source IS the target; Python applies its own default
             # when the kwarg is absent, so treating rename_targets as target_defaults is safe.
-            if callable(_target):
+            if callable(normalized_target):
                 target_defaults = {
                     arg[0]
-                    for arg in get_func_arguments_types_defaults(_target)
+                    for arg in get_func_arguments_types_defaults(normalized_target)
                     if arg[2] is not inspect.Parameter.empty
                 }
             else:
@@ -801,26 +797,26 @@ def _build_call_plan(
             full_defaults = _update_kwargs_with_defaults(source, kwargs)
 
             def is_default_dropped(k: str) -> bool:
-                remapped = k in rename_sources and args_mapping.get(k) in target_defaults
+                remapped = k in rename_sources and _am.get(k) in target_defaults
                 return k not in rename_targets and not remapped
 
             kwargs = {k: v for k, v in full_defaults.items() if k in caller_keys or is_default_dropped(k)}
         else:
             kwargs = _update_kwargs_with_defaults(source, kwargs)
-    if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
-        args_skip = [arg for arg in args_mapping if not args_mapping[arg]]
-        kwargs = {(args_mapping.get(arg) or arg): val for arg, val in kwargs.items() if arg not in args_skip}
+    if dep_cfg.args_mapping and (normalized_target is TargetMode.ARGS_REMAP or callable(normalized_target)):
+        args_skip = [arg for arg in dep_cfg.args_mapping if not dep_cfg.args_mapping[arg]]
+        kwargs = {(dep_cfg.args_mapping.get(arg) or arg): val for arg, val in kwargs.items() if arg not in args_skip}
 
-    if args_extra and (_target is TargetMode.ARGS_REMAP or callable(_target)):
-        kwargs.update(args_extra)
+    if dep_cfg.args_extra and (normalized_target is TargetMode.ARGS_REMAP or callable(normalized_target)):
+        kwargs.update(dep_cfg.args_extra)
 
     # ``source_has_var_positional`` is accepted for symmetry with the wrapper closure: the helper itself does
     # not branch on it (the wrapper consumes it after reading the plan to decide whether to forward positional
     # args or kwargs to the source).  Keeping it in the signature lets future callers pass a single,
     # uniform argument set even if the helper later needs to switch on var-positional shape.
     target_func: Optional[Callable[..., Any]] = None
-    if callable(_target):
-        target_func = _prepare_target_call(source, _target, kwargs)
+    if callable(normalized_target):
+        target_func = _prepare_target_call(source, normalized_target, kwargs)
 
     return _CallPlan(
         short_circuit=False,
@@ -1111,13 +1107,6 @@ def deprecated(
         )
         _dep_cfg = dep_meta
 
-        # N1-step2 — ``async def`` source: build a coroutine ``async_wrapped_fn`` that mirrors the sync wrapper
-        # exactly, except every callable invocation is ``await``-ed.  Sync targets are dispatched without
-        # ``await`` (``inspect.iscoroutinefunction(target_func)`` gates the choice) so callers can migrate
-        # from a sync to async API in one step.  All closure variables (``_target``, ``args_mapping``,
-        # ``args_extra``, ``stream``, ``num_warns``, ``skip_if``, etc.) are captured exactly as in the sync
-        # path; the early return below means the sync ``wrapped_fn`` definition runs only for non-async
-        # sources.
         #
         # Known false-negatives of ``inspect.iscoroutinefunction`` — these sources silently receive the sync
         # wrapper, meaning ``await wrapper(...)`` will fail or return a bare coroutine:
@@ -1144,14 +1133,14 @@ def deprecated(
                     wrapper_fn=async_wrapped_fn,
                     source=source,
                     target=target,
-                    _target=_target,
+                    normalized_target=_target,
                     args=args,
                     kwargs=kwargs,
                     dep_cfg=_dep_cfg,
                     stream=stream,
                     num_warns=num_warns,
                     source_has_var_positional=source_has_var_positional,
-                    _source_is_stacked=_source_is_stacked,
+                    source_is_stacked=_source_is_stacked,
                 )
 
                 if plan.short_circuit:
@@ -1204,14 +1193,14 @@ def deprecated(
                 wrapper_fn=wrapped_fn,
                 source=source,
                 target=target,
-                _target=_target,
+                normalized_target=_target,
                 args=args,
                 kwargs=kwargs,
                 dep_cfg=_dep_cfg,
                 stream=stream,
                 num_warns=num_warns,
                 source_has_var_positional=source_has_var_positional,
-                _source_is_stacked=_source_is_stacked,
+                source_is_stacked=_source_is_stacked,
             )
 
             if plan.short_circuit:

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -24,6 +24,7 @@ from warnings import warn
 from deprecate._types import (
     DeprecationConfig,
     TargetMode,
+    _CallPlan,
     _DeprecatedCallable,
     _has_deprecation_meta,
     _HasDeprecationMeta,
@@ -650,6 +651,184 @@ def _raise_warn_arguments(
     )
 
 
+def _build_call_plan(
+    wrapper_fn: Callable[..., Any],
+    source: Callable[..., Any],
+    target: Union[bool, None, Callable[..., Any], TargetMode],
+    _target: Union[Callable[..., Any], TargetMode],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    dep_cfg: DeprecationConfig,
+    stream: Optional[Callable[..., None]],
+    num_warns: int,
+    source_has_var_positional: bool,
+    _source_is_stacked: bool,
+) -> _CallPlan:
+    """Compute the dispatch plan shared by the sync and async wrappers inside :func:`deprecated`.
+
+    Extracted verbatim from the body of ``wrapped_fn`` / ``async_wrapped_fn`` so that the wrappers differ only by
+    ``await`` on the final source/target call.  All closure variables that the wrapper needs are passed explicitly so
+    this helper has no dependency on the enclosing ``packing`` scope and can be unit-tested in isolation.
+
+    Side effects (carried over from the original inline logic):
+
+    - Mutates ``wrapper_fn._state`` — bumps ``called``, optionally bumps ``warned_calls`` / ``warned_args``, and sets
+      ``warned_misconfigured`` on the first misconfiguration warning.
+    - Emits the one-time misconfiguration ``UserWarning`` via :func:`warnings.warn` when ``dep_cfg.misconfigured`` is
+      set, ``stream`` is non-``None``, and the state has not yet seen it.
+    - Emits the deprecation warning through ``stream`` when the per-call quota allows it — callable-reason via
+      :func:`_raise_warn_callable`, argument-rename-reason via :func:`_raise_warn_arguments`.
+
+    Args:
+        wrapper_fn: The wrapping function itself, used to read mutable ``_state`` via the
+            :class:`_DeprecatedCallable` protocol.  Passing the wrapper instead of a bare state lets the wrapper
+            preserve its existing ``cast(_DeprecatedCallable, ...)._state`` access pattern.
+        source: The decorated callable.
+        target: The raw ``target`` argument given to ``@deprecated`` — preserved for warning emission so callable
+            targets that are classes are named by their user-facing name rather than ``__init__``.
+        _target: The normalised target (a :class:`TargetMode` member or callable) returned by
+            :func:`_normalize_target`.
+        args: The positional arguments the caller passed to the wrapper.
+        kwargs: The keyword arguments the caller passed to the wrapper.
+        dep_cfg: The frozen :class:`DeprecationConfig` for this wrapper.  ``args_mapping``, ``args_extra``,
+            ``deprecated_in``, ``remove_in``, and ``template_mgs`` are all read from this object.
+        stream: Warning stream (typically :func:`warnings.warn` partial), or ``None`` to suppress.
+        num_warns: Maximum number of times to emit the warning per wrapper / per renamed argument.
+        source_has_var_positional: ``True`` when ``source`` declares ``*args`` — affects fast-path dispatch in the
+            wrapper but is also needed inside this helper for the short-circuit branch.
+        _source_is_stacked: ``True`` when ``source`` is itself a ``@deprecated`` wrapper.
+
+    Returns:
+        A :class:`_CallPlan` describing the resolved dispatch outcome.
+
+    """
+    state = cast(_DeprecatedCallable, wrapper_fn)._state
+    args_mapping = dep_cfg.args_mapping
+    args_extra = dep_cfg.args_extra
+    deprecated_in = dep_cfg.deprecated_in
+    remove_in = dep_cfg.remove_in
+    template_mgs = dep_cfg.template_mgs
+    state.called += 1
+    if dep_cfg.misconfigured and stream and not state.warned_misconfigured:
+        warnings.warn(
+            f"'{source.__name__}' has an invalid deprecation configuration;"
+            f" verify your `@deprecated(target=...)` arguments. Will be TypeError in {_V1_BREAK_VERSION}.",
+            UserWarning,
+            stacklevel=3,  # caller → wrapper_fn → _build_call_plan → warn
+        )
+        state.warned_misconfigured = True
+
+    # *args sources need the unremapped tuple; remapping happens on kwargs only.
+    original_kwargs = dict(kwargs)
+    kwargs = _update_kwargs_with_args(source, args, kwargs)
+
+    reason_callable = _target is TargetMode.NOTIFY or callable(_target)
+    reason_argument: dict[str, Optional[str]] = {}
+    if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
+        reason_argument = {a: b for a, b in args_mapping.items() if a in kwargs}
+    # Migrated callers (using the new arg name) produce empty reason_argument;
+    # without the args_extra guard they short-circuit before extras are injected.
+    # When source is a stacked @deprecated wrapper (e.g. ARGS_REMAP outer + NOTIFY inner),
+    # do not short-circuit even with no reason — the inner layer may still need to run.
+    if (
+        not (reason_callable or reason_argument)
+        and not (args_extra and _target is TargetMode.ARGS_REMAP)
+        and not _source_is_stacked
+    ):
+        return _CallPlan(
+            short_circuit=True,
+            original_kwargs=original_kwargs,
+            resolved_kwargs=kwargs,
+            reason_argument={},
+            target_func=None,
+        )
+
+    if reason_argument:
+        nb_warned = min((state.warned_args.get(arg, 0) for arg in reason_argument), default=0)
+    else:
+        nb_warned = state.warned_calls
+
+    # +1 stacklevel: extraction added one frame (caller → wrapper_fn → _build_call_plan → _raise_warn_*)
+    # over the previous in-wrapper call chain.
+    _stacklevel_to_caller = _DEFAULT_STACKLEVEL_TO_CALLER + 1
+    if stream and (num_warns < 0 or nb_warned < num_warns):
+        if reason_callable:
+            # Use original `target` (not remapped _target) so the warning
+            # names the class (e.g. "NewCls") rather than "__init__".
+            _raise_warn_callable(
+                stream,
+                source,
+                target,
+                deprecated_in,
+                remove_in,
+                template_mgs,
+                stacklevel=_stacklevel_to_caller,
+            )
+            state.warned_calls += 1
+        elif reason_argument:
+            _raise_warn_arguments(
+                stream,
+                source,
+                reason_argument,
+                deprecated_in,
+                remove_in,
+                template_mgs,
+                stacklevel=_stacklevel_to_caller,
+            )
+            for arg in reason_argument:
+                state.warned_args[arg] = state.warned_args.get(arg, 0) + 1
+
+    if reason_callable:
+        # Source defaults for renamed args survive _update_kwargs_with_defaults and
+        # would be forwarded under the new name, silently overriding the target's own
+        # default. Drop only when the caller never supplied the old or new name.
+        if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
+            caller_keys = set(kwargs)
+            rename_targets = {v for v in args_mapping.values() if v}
+            rename_sources = set(args_mapping)
+            # For ARGS_REMAP, source IS the target; Python applies its own default
+            # when the kwarg is absent, so treating rename_targets as target_defaults is safe.
+            if callable(_target):
+                target_defaults = {
+                    arg[0]
+                    for arg in get_func_arguments_types_defaults(_target)
+                    if arg[2] is not inspect.Parameter.empty
+                }
+            else:
+                target_defaults = rename_targets
+            full_defaults = _update_kwargs_with_defaults(source, kwargs)
+
+            def is_default_dropped(k: str) -> bool:
+                remapped = k in rename_sources and args_mapping.get(k) in target_defaults
+                return k not in rename_targets and not remapped
+
+            kwargs = {k: v for k, v in full_defaults.items() if k in caller_keys or is_default_dropped(k)}
+        else:
+            kwargs = _update_kwargs_with_defaults(source, kwargs)
+    if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
+        args_skip = [arg for arg in args_mapping if not args_mapping[arg]]
+        kwargs = {(args_mapping.get(arg) or arg): val for arg, val in kwargs.items() if arg not in args_skip}
+
+    if args_extra and (_target is TargetMode.ARGS_REMAP or callable(_target)):
+        kwargs.update(args_extra)
+
+    # ``source_has_var_positional`` is accepted for symmetry with the wrapper closure: the helper itself does
+    # not branch on it (the wrapper consumes it after reading the plan to decide whether to forward positional
+    # args or kwargs to the source).  Keeping it in the signature lets future callers pass a single,
+    # uniform argument set even if the helper later needs to switch on var-positional shape.
+    target_func: Optional[Callable[..., Any]] = None
+    if callable(_target):
+        target_func = _prepare_target_call(source, _target, kwargs)
+
+    return _CallPlan(
+        short_circuit=False,
+        original_kwargs=original_kwargs,
+        resolved_kwargs=kwargs,
+        reason_argument=reason_argument,
+        target_func=target_func,
+    )
+
+
 def deprecated(
     target: Union[bool, None, Callable, TargetMode] = TargetMode.NOTIFY,
     deprecated_in: str = "",
@@ -926,8 +1105,66 @@ def deprecated(
             args_extra=args_extra,
             misconfigured=misconfigured,
             docstring_style=normalized_docstring_style,
+            template_mgs=template_mgs,
         )
         _dep_cfg = dep_meta
+
+        # N1-step2 — ``async def`` source: build a coroutine ``async_wrapped_fn`` that mirrors the sync wrapper
+        # exactly, except every callable invocation is ``await``-ed.  Sync targets are dispatched without
+        # ``await`` (``inspect.iscoroutinefunction(target_func)`` gates the choice) so callers can migrate
+        # from a sync to async API in one step.  All closure variables (``_target``, ``args_mapping``,
+        # ``args_extra``, ``stream``, ``num_warns``, ``skip_if``, etc.) are captured exactly as in the sync
+        # path; the early return below means the sync ``wrapped_fn`` definition runs only for non-async
+        # sources.
+        if inspect.iscoroutinefunction(source):
+
+            @wraps(source)
+            async def async_wrapped_fn(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+                shall_skip = skip_if() if callable(skip_if) else bool(skip_if)
+                if not isinstance(shall_skip, bool):
+                    raise TypeError(f"User function 'skip_if' shall return bool, but got: {type(shall_skip)}")
+                if shall_skip:
+                    return await source(*args, **kwargs)
+
+                # Read DeprecationConfig from the closure rather than re-reading
+                # ``async_wrapped_fn.__deprecated__``: a PEP 702 ``typing_extensions.deprecated``
+                # decorator stacked outside this one overwrites that attribute with a plain string.
+                plan = _build_call_plan(
+                    wrapper_fn=async_wrapped_fn,
+                    source=source,
+                    target=target,
+                    _target=_target,
+                    args=args,
+                    kwargs=kwargs,
+                    dep_cfg=_dep_cfg,
+                    stream=stream,
+                    num_warns=num_warns,
+                    source_has_var_positional=source_has_var_positional,
+                    _source_is_stacked=_source_is_stacked,
+                )
+
+                if plan.short_circuit:
+                    return await source(**plan.resolved_kwargs)
+
+                if plan.target_func is None:
+                    if source_has_var_positional:
+                        call_kwargs = plan.original_kwargs if not plan.reason_argument else plan.resolved_kwargs
+                        return await source(*args, **call_kwargs)
+                    return await source(**plan.resolved_kwargs)
+                # Sync target under async source: invoke directly so callers can migrate from a sync to async
+                # API in one step without forcing every legacy target to be redeclared ``async def``.
+                if inspect.iscoroutinefunction(plan.target_func):
+                    return await plan.target_func(**plan.resolved_kwargs)
+                return plan.target_func(**plan.resolved_kwargs)
+
+            async_wrapped_fn_typed = cast(_DeprecatedCallable, async_wrapped_fn)
+            async_wrapped_fn_typed.__deprecated__ = dep_meta
+            async_wrapped_fn_typed._state = _WrapperState()
+
+            if update_docstring:
+                _update_docstring_with_deprecation(async_wrapped_fn)
+
+            return async_wrapped_fn
 
         @wraps(source)
         def wrapped_fn(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
@@ -937,114 +1174,33 @@ def deprecated(
             if shall_skip:
                 return source(*args, **kwargs)
 
-            state = cast(_DeprecatedCallable, wrapped_fn)._state
-            state.called += 1
             # Read DeprecationConfig from the closure rather than re-reading
             # ``wrapped_fn.__deprecated__``: a PEP 702 ``typing_extensions.deprecated``
             # decorator stacked outside this one overwrites that attribute with a plain
-            # string, which then crashes on ``.misconfigured`` access. ``_state`` must
-            # still be read via attribute because it is mutable and updated between calls.
-            dep_cfg = _dep_cfg
-            if dep_cfg.misconfigured and stream and not state.warned_misconfigured:
-                warnings.warn(
-                    f"'{source.__name__}' has an invalid deprecation configuration;"
-                    f" verify your `@deprecated(target=...)` arguments. Will be TypeError in {_V1_BREAK_VERSION}.",
-                    UserWarning,
-                    stacklevel=2,  # caller → wrapped_fn → warn
-                )
-                state.warned_misconfigured = True
-            # *args sources need the unremapped tuple; remapping happens on kwargs only.
-            original_kwargs = dict(kwargs)
-            kwargs = _update_kwargs_with_args(source, args, kwargs)
+            # string, which then crashes on ``.misconfigured`` access.
+            plan = _build_call_plan(
+                wrapper_fn=wrapped_fn,
+                source=source,
+                target=target,
+                _target=_target,
+                args=args,
+                kwargs=kwargs,
+                dep_cfg=_dep_cfg,
+                stream=stream,
+                num_warns=num_warns,
+                source_has_var_positional=source_has_var_positional,
+                _source_is_stacked=_source_is_stacked,
+            )
 
-            reason_callable = _target is TargetMode.NOTIFY or callable(_target)
-            reason_argument = {}
-            if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
-                reason_argument = {a: b for a, b in args_mapping.items() if a in kwargs}
-            # Migrated callers (using the new arg name) produce empty reason_argument;
-            # without the args_extra guard they short-circuit before extras are injected.
-            # When source is a stacked @deprecated wrapper (e.g. ARGS_REMAP outer + NOTIFY inner),
-            # do not short-circuit even with no reason — the inner layer may still need to run.
-            if (
-                not (reason_callable or reason_argument)
-                and not (args_extra and _target is TargetMode.ARGS_REMAP)
-                and not _source_is_stacked
-            ):
-                return source(**kwargs)
+            if plan.short_circuit:
+                return source(**plan.resolved_kwargs)
 
-            if reason_argument:
-                nb_warned = min((state.warned_args.get(arg, 0) for arg in reason_argument), default=0)
-            else:
-                nb_warned = state.warned_calls
-
-            if stream and (num_warns < 0 or nb_warned < num_warns):
-                if reason_callable:
-                    # Use original `target` (not remapped _target) so the warning
-                    # names the class (e.g. "NewCls") rather than "__init__".
-                    _raise_warn_callable(
-                        stream,
-                        source,
-                        target,
-                        deprecated_in,
-                        remove_in,
-                        template_mgs,
-                        stacklevel=_DEFAULT_STACKLEVEL_TO_CALLER,
-                    )
-                    state.warned_calls += 1
-                elif reason_argument:
-                    _raise_warn_arguments(
-                        stream,
-                        source,
-                        reason_argument,
-                        deprecated_in,
-                        remove_in,
-                        template_mgs,
-                        stacklevel=_DEFAULT_STACKLEVEL_TO_CALLER,
-                    )
-                    for arg in reason_argument:
-                        state.warned_args[arg] = state.warned_args.get(arg, 0) + 1
-
-            if reason_callable:
-                # Source defaults for renamed args survive _update_kwargs_with_defaults and
-                # would be forwarded under the new name, silently overriding the target's own
-                # default. Drop only when the caller never supplied the old or new name.
-                if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
-                    caller_keys = set(kwargs)
-                    rename_targets = {v for v in args_mapping.values() if v}
-                    rename_sources = set(args_mapping)
-                    # For ARGS_REMAP, source IS the target; Python applies its own default
-                    # when the kwarg is absent, so treating rename_targets as target_defaults is safe.
-                    if callable(_target):
-                        target_defaults = {
-                            arg[0]
-                            for arg in get_func_arguments_types_defaults(_target)
-                            if arg[2] is not inspect.Parameter.empty
-                        }
-                    else:
-                        target_defaults = rename_targets
-                    full_defaults = _update_kwargs_with_defaults(source, kwargs)
-
-                    def is_default_dropped(k: str) -> bool:
-                        remapped = k in rename_sources and args_mapping.get(k) in target_defaults
-                        return k not in rename_targets and not remapped
-
-                    kwargs = {k: v for k, v in full_defaults.items() if k in caller_keys or is_default_dropped(k)}
-                else:
-                    kwargs = _update_kwargs_with_defaults(source, kwargs)
-            if args_mapping and (_target is TargetMode.ARGS_REMAP or callable(_target)):
-                args_skip = [arg for arg in args_mapping if not args_mapping[arg]]
-                kwargs = {(args_mapping.get(arg) or arg): val for arg, val in kwargs.items() if arg not in args_skip}
-
-            if args_extra and (_target is TargetMode.ARGS_REMAP or callable(_target)):
-                kwargs.update(args_extra)
-
-            if not callable(_target):
+            if plan.target_func is None:
                 if source_has_var_positional:
-                    call_kwargs = original_kwargs if not reason_argument else kwargs
+                    call_kwargs = plan.original_kwargs if not plan.reason_argument else plan.resolved_kwargs
                     return source(*args, **call_kwargs)
-                return source(**kwargs)
-            target_func = _prepare_target_call(source, _target, kwargs)
-            return target_func(**kwargs)
+                return source(**plan.resolved_kwargs)
+            return plan.target_func(**plan.resolved_kwargs)
 
         wrapped_fn_typed = cast(_DeprecatedCallable, wrapped_fn)
         wrapped_fn_typed.__deprecated__ = dep_meta

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -1118,6 +1118,15 @@ def deprecated(
         # ``args_extra``, ``stream``, ``num_warns``, ``skip_if``, etc.) are captured exactly as in the sync
         # path; the early return below means the sync ``wrapped_fn`` definition runs only for non-async
         # sources.
+        #
+        # Known false-negatives of ``inspect.iscoroutinefunction`` — these sources silently receive the sync
+        # wrapper, meaning ``await wrapper(...)`` will fail or return a bare coroutine:
+        #   • async function wrapped by a decorator that does NOT propagate ``__wrapped__`` / use
+        #     ``functools.wraps`` (``inspect.iscoroutinefunction`` walks ``__wrapped__``, not ``__call__``).
+        #   • callable objects whose ``__call__`` is ``async def`` — use ``async def`` thin wrapper instead.
+        #   • ``functools.partial(async_fn)`` on Python ≤ 3.11 (``partial`` does not copy ``__wrapped__``).
+        # Workaround for all three: wrap the callable in a plain ``async def my_wrapper(*a, **kw): return
+        # await callable(*a, **kw)`` before applying ``@deprecated``.
         if inspect.iscoroutinefunction(source):
 
             @wraps(source)

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -62,6 +62,7 @@ from tests.collection_targets import (
     TimerDecorator,
     _Pep702ProxyTarget,  # private alias — see B1b regression fixture below
     add_values,
+    async_target,
     base_pow_args,
     base_sum_kwargs,
     both_old_new_target,
@@ -1527,3 +1528,53 @@ gen_callable = deprecated(target=gen_target, deprecated_in="1.0", remove_in="2.0
 gen_notify_unlimited = deprecated(target=TargetMode.NOTIFY, deprecated_in="1.0", remove_in="2.0", num_warns=-1)(
     gen_target
 )
+
+
+# ========== async callable kind fixtures (N1-step2) ==========
+# Three wrappers exercise the ``@deprecated`` async path (``inspect.iscoroutinefunction`` branch in ``packing()``).
+# Each pairs an ``async def`` source with one of the three ``TargetMode`` variants so the integration tests can
+# confirm: (a) round-trip awaited result, (b) eager warning timing — fired at call time, before ``await``, and
+# (c) stacklevel pointing back to the user's call site rather than to ``deprecation.py``.
+
+
+async def _async_source_notify(x: int) -> int:
+    """NOTIFY-mode async source: body runs unchanged after warning fires.
+
+    Doubles its input so the integration test can assert end-to-end equivalence without referencing the target.
+
+    """
+    return x * 2
+
+
+async def _async_source_remap(old_x: int = 0, x: int = 0) -> int:
+    """Self-deprecation async source for ``async_args_remap``: accepts legacy arg ``old_x`` (mapped to ``x``).
+
+    Body executes under :attr:`~deprecate.TargetMode.ARGS_REMAP` so it must be a real ``async def``; only the
+    remapped ``x`` is read in the body.
+
+    """
+    return x * 2
+
+
+async def _async_source_callable(x: int = 0) -> int:
+    """Placeholder async source for ``async_callable``: body never executes under callable-target mode.
+
+    Declared as ``async def`` so :func:`inspect.iscoroutinefunction` returns ``True`` and the async wrapper engages.
+    The body is unreachable because ``target=async_target`` forwards every call.
+
+    """
+    return x  # pragma: no cover - unreachable; target forwards every call
+
+
+#: NOTIFY mode — source body runs unchanged (warning-only). Uses default ``num_warns=1``;
+#: warning fires once per call. Tests reset ``warned_calls`` between parametrize cases.
+async_notify = deprecated(target=TargetMode.NOTIFY, deprecated_in="1.0", remove_in="2.0")(_async_source_notify)
+#: ARGS_REMAP mode — self-deprecation; legacy arg ``old_x`` mapped to ``x`` before source body executes.
+async_args_remap = deprecated(
+    target=TargetMode.ARGS_REMAP,
+    args_mapping={"old_x": "x"},
+    deprecated_in="1.0",
+    remove_in="2.0",
+)(_async_source_remap)
+#: Callable-target mode — call forwarded to ``async_target``; source body never executes.
+async_callable = deprecated(target=async_target, deprecated_in="1.0", remove_in="2.0")(_async_source_callable)

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -1530,7 +1530,7 @@ gen_notify_unlimited = deprecated(target=TargetMode.NOTIFY, deprecated_in="1.0",
 )
 
 
-# ========== async callable kind fixtures (N1-step2) ==========
+# ========== async callable kind fixtures ==========
 # Three wrappers exercise the ``@deprecated`` async path (``inspect.iscoroutinefunction`` branch in ``packing()``).
 # Each pairs an ``async def`` source with one of the three ``TargetMode`` variants so the integration tests can
 # confirm: (a) round-trip awaited result, (b) warning timing for async wrappers — fired when the returned coroutine

--- a/tests/collection_deprecate.py
+++ b/tests/collection_deprecate.py
@@ -1533,8 +1533,9 @@ gen_notify_unlimited = deprecated(target=TargetMode.NOTIFY, deprecated_in="1.0",
 # ========== async callable kind fixtures (N1-step2) ==========
 # Three wrappers exercise the ``@deprecated`` async path (``inspect.iscoroutinefunction`` branch in ``packing()``).
 # Each pairs an ``async def`` source with one of the three ``TargetMode`` variants so the integration tests can
-# confirm: (a) round-trip awaited result, (b) eager warning timing — fired at call time, before ``await``, and
-# (c) stacklevel pointing back to the user's call site rather than to ``deprecation.py``.
+# confirm: (a) round-trip awaited result, (b) warning timing for async wrappers — fired when the returned coroutine
+# is awaited, before the wrapped async body/result completes — and (c) stacklevel pointing back to the user's call
+# site rather than to ``deprecation.py``.
 
 
 async def _async_source_notify(x: int) -> int:

--- a/tests/collection_targets.py
+++ b/tests/collection_targets.py
@@ -320,3 +320,15 @@ def gen_target(x: int) -> Iterator[int]:
     """
     for i in range(1, 4):
         yield x * i
+
+
+async def async_target(x: int) -> int:
+    """Replacement async function used by ``async_callable`` deprecation wrapper tests.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.run(async_target(x=3))
+        6
+
+    """
+    return x * 2

--- a/tests/integration/test_callable_kinds.py
+++ b/tests/integration/test_callable_kinds.py
@@ -196,21 +196,24 @@ async def test_async_round_trip(wrapper: object, call_kwargs: dict) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_warning_fires_eagerly() -> None:
-    """Warning fires when the coroutine is created (before ``await``), not when it is awaited.
+async def test_async_warning_fires_on_await_not_on_call() -> None:
+    """Warning fires when coroutine is awaited, not when the wrapper is called.
 
-    The wrapper is itself an ``async def`` — calling it returns an un-awaited coroutine.  pyDeprecate's wrapper
-    body emits the warning synchronously on the first statement of the coroutine, so the warning is observable
-    immediately after ``await`` resumes but never deferred behind any I/O the wrapped coroutine may perform.
+    The async wrapper body runs lazily — calling the wrapper creates an unawaited coroutine
+    with no side effects. The deprecation warning fires on the first ``await``.
 
     """
-    with warnings.catch_warnings(record=True) as warned:
+    with warnings.catch_warnings(record=True) as warned_before:
         warnings.simplefilter("always")
         coro = async_notify(x=1)
-        # Warnings are collected the moment the coroutine body starts running — no later than the first await point.
+    pre_await_warnings = [w for w in warned_before if w.category in (FutureWarning, DeprecationWarning)]
+    assert not pre_await_warnings, "Warning must not fire at call time — only fires on await"
+
+    with warnings.catch_warnings(record=True) as warned_after:
+        warnings.simplefilter("always")
         result = await coro
-    deprecation_warnings = [w for w in warned if w.category in (FutureWarning, DeprecationWarning)]
-    assert deprecation_warnings, "Async wrapper must emit a deprecation warning"
+    post_await_warnings = [w for w in warned_after if w.category in (FutureWarning, DeprecationWarning)]
+    assert post_await_warnings, "Warning must fire when coroutine is awaited"
     assert result == 2
 
 

--- a/tests/integration/test_callable_kinds.py
+++ b/tests/integration/test_callable_kinds.py
@@ -4,9 +4,9 @@ Covers four concerns:
 
 - Round-trip equivalence under all three :class:`~deprecate.TargetMode` variants (NOTIFY, ARGS_REMAP, callable) for
   both sync generators (``yield``) and ``async def`` coroutines (N1-step2).
-- Eager warning timing — for generators the warning fires when the generator object is created (before first
-  :func:`next` call); for coroutines it fires when the coroutine is *created* (before ``await``).  Both kinds run
-  the warning synchronously inside ``wrapped_fn`` before returning the generator/coroutine.
+- Warning timing — for generators the warning fires when the generator object is created (before first
+  :func:`next` call); for coroutines it fires when the coroutine is awaited, not when the coroutine object is
+  created.
 - Stacklevel — the warning must point to the user's call site, not to ``deprecation.py``.
 Also covers order-agnostic classmethod rescue: ``@deprecated`` applied OUTSIDE ``@classmethod`` is silently rescued
 at decoration time via transparent unwrap + rewrap, producing a working deprecated classmethod descriptor without

--- a/tests/integration/test_callable_kinds.py
+++ b/tests/integration/test_callable_kinds.py
@@ -1,19 +1,20 @@
-"""Integration tests for generator callable kind support.
+"""Integration tests for generator and async callable kind support.
 
-Covers three concerns:
+Covers four concerns:
 
-- Round-trip yield equivalence under all three :class:`~deprecate.TargetMode` variants (NOTIFY, ARGS_REMAP, callable).
-- Eager warning timing — the deprecation warning must fire at call time (when the wrapped generator is *created*), not
-  on the first :func:`next` call.  Generator bodies do not execute until iterated, so a naïve forwarder would defer the
-  warning until iteration.  ``_dispatch`` fires the warning synchronously before returning the generator object.
+- Round-trip equivalence under all three :class:`~deprecate.TargetMode` variants (NOTIFY, ARGS_REMAP, callable) for
+  both sync generators (``yield``) and ``async def`` coroutines (N1-step2).
+- Eager warning timing — for generators the warning fires when the generator object is created (before first
+  :func:`next` call); for coroutines it fires when the coroutine is *created* (before ``await``).  Both kinds run
+  the warning synchronously inside ``wrapped_fn`` before returning the generator/coroutine.
 - Stacklevel — the warning must point to the user's call site, not to ``deprecation.py``.
-
 Also covers order-agnostic classmethod rescue: ``@deprecated`` applied OUTSIDE ``@classmethod`` is silently rescued
 at decoration time via transparent unwrap + rewrap, producing a working deprecated classmethod descriptor without
 emitting a warning.
 
 """
 
+import inspect
 import warnings
 from typing import cast
 
@@ -21,7 +22,15 @@ import pytest
 
 from deprecate import deprecated
 from deprecate._types import _DeprecatedCallable
-from tests.collection_deprecate import gen_args_remap, gen_callable, gen_notify, gen_notify_unlimited
+from tests.collection_deprecate import (
+    async_args_remap,
+    async_callable,
+    async_notify,
+    gen_args_remap,
+    gen_callable,
+    gen_notify,
+    gen_notify_unlimited,
+)
 
 # Pair each wrapper with the argument it expects.  ``gen_args_remap`` is the only one with a
 # non-default argument name because its source carries the legacy ``old_x`` parameter.
@@ -145,3 +154,86 @@ def test_wrong_order_classmethod_silently_rescued() -> None:
         warnings.simplefilter("always")
         _Foo.old_method()
     assert any(issubclass(w.category, FutureWarning) for w in call_warned), "Deprecation warning must fire on call"
+
+
+# ========== Async ``def`` wrapper integration tests (N1-step2) ==========
+# Async wrappers under test:
+#   - ``async_notify``      — TargetMode.NOTIFY; source body runs unchanged.
+#   - ``async_args_remap``  — TargetMode.ARGS_REMAP; legacy arg ``old_x`` is mapped to ``x`` before body executes.
+#   - ``async_callable``    — callable target (``async_target``); source body never executes.
+# Each call expects ``x=1`` (or ``old_x=1`` for args_remap) and produces ``2``.
+
+_ASYNC_WRAPPER_CASES = [
+    pytest.param(async_notify, {"x": 1}, id="notify"),
+    pytest.param(async_args_remap, {"old_x": 1}, id="args_remap"),
+    pytest.param(async_callable, {"x": 1}, id="callable"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_async_state() -> None:
+    """Reset the warning counter on each module-level async wrapper before each test.
+
+    Mirrors ``_reset_gen_state`` for the async fixtures: ``num_warns=1`` (default) would otherwise suppress the
+    second parametrize case.  Only ``warned_calls`` and ``warned_args`` are cleared — ``called`` and
+    ``warned_misconfigured`` are left intact.
+
+    """
+    for wrapper in (async_notify, async_args_remap, async_callable):
+        state = cast(_DeprecatedCallable, wrapper)._state
+        state.warned_calls = 0
+        state.warned_args.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("wrapper", "call_kwargs"), _ASYNC_WRAPPER_CASES)
+async def test_async_round_trip(wrapper: object, call_kwargs: dict) -> None:
+    """Wrapped async fn returns the same value as the underlying ``async_target`` (``x * 2``)."""
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        result = await wrapper(**call_kwargs)  # type: ignore[operator]
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_async_warning_fires_eagerly() -> None:
+    """Warning fires when the coroutine is created (before ``await``), not when it is awaited.
+
+    The wrapper is itself an ``async def`` — calling it returns an un-awaited coroutine.  pyDeprecate's wrapper
+    body emits the warning synchronously on the first statement of the coroutine, so the warning is observable
+    immediately after ``await`` resumes but never deferred behind any I/O the wrapped coroutine may perform.
+
+    """
+    with warnings.catch_warnings(record=True) as warned:
+        warnings.simplefilter("always")
+        coro = async_notify(x=1)
+        # Warnings are collected the moment the coroutine body starts running — no later than the first await point.
+        result = await coro
+    deprecation_warnings = [w for w in warned if w.category in (FutureWarning, DeprecationWarning)]
+    assert deprecation_warnings, "Async wrapper must emit a deprecation warning"
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_async_warning_stacklevel() -> None:
+    """Async wrapper warning filename points to the caller's file, not to ``deprecation.py``."""
+    with warnings.catch_warnings(record=True) as warned:
+        warnings.simplefilter("always")
+        await async_notify(x=1)
+    deprecation_warnings = [w for w in warned if w.category in (FutureWarning, DeprecationWarning)]
+    assert deprecation_warnings, "Async wrapper must emit a deprecation warning"
+    w = deprecation_warnings[0]
+    assert w.filename.endswith("test_callable_kinds.py"), f"Expected caller file, got {w.filename}"
+
+
+def test_async_callable_wrapper_is_coroutine_function() -> None:
+    """The async-source wrapper itself must remain a coroutine function after decoration.
+
+    ``functools.wraps`` preserves ``__wrapped__``, but ``inspect.iscoroutinefunction`` checks the wrapper's own
+    ``CO_COROUTINE`` flag.  The dedicated async branch in ``packing()`` defines the wrapper with ``async def`` so
+    callers and frameworks (e.g. ``asyncio.run``, FastAPI dependency injection) recognise it.
+
+    """
+    assert inspect.iscoroutinefunction(async_notify), "async_notify wrapper must be a coroutine function"
+    assert inspect.iscoroutinefunction(async_args_remap), "async_args_remap wrapper must be a coroutine function"
+    assert inspect.iscoroutinefunction(async_callable), "async_callable wrapper must be a coroutine function"

--- a/tests/integration/test_callable_kinds.py
+++ b/tests/integration/test_callable_kinds.py
@@ -3,7 +3,7 @@
 Covers four concerns:
 
 - Round-trip equivalence under all three :class:`~deprecate.TargetMode` variants (NOTIFY, ARGS_REMAP, callable) for
-  both sync generators (``yield``) and ``async def`` coroutines (N1-step2).
+  both sync generators (``yield``) and ``async def`` coroutines.
 - Warning timing — for generators the warning fires when the generator object is created (before first
   :func:`next` call); for coroutines it fires when the coroutine is awaited, not when the coroutine object is
   created.
@@ -156,7 +156,7 @@ def test_wrong_order_classmethod_silently_rescued() -> None:
     assert any(issubclass(w.category, FutureWarning) for w in call_warned), "Deprecation warning must fire on call"
 
 
-# ========== Async ``def`` wrapper integration tests (N1-step2) ==========
+# ========== Async ``def`` wrapper integration tests ==========
 # Async wrappers under test:
 #   - ``async_notify``      — TargetMode.NOTIFY; source body runs unchanged.
 #   - ``async_args_remap``  — TargetMode.ARGS_REMAP; legacy arg ``old_x`` is mapped to ``x`` before body executes.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 pytest >=8.4.2
 pytest-cov >=7.1.0
+pytest-asyncio >=0.21  # N1-step2: async def @deprecated wrapper tests
 scikit-learn >=1.6.1
 phmdoctest >=1.4.0
 dataclasses  # needed for phmdoctest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest >=8.4.2
 pytest-cov >=7.1.0
-pytest-asyncio >=0.21  # N1-step2: async def @deprecated wrapper tests
+pytest-asyncio >=0.21
 scikit-learn >=1.6.1
 phmdoctest >=1.4.0
 dataclasses  # needed for phmdoctest

--- a/tests/unittests/test_call_plan.py
+++ b/tests/unittests/test_call_plan.py
@@ -21,6 +21,7 @@ from typing import Any, Callable
 from deprecate import TargetMode
 from deprecate._types import DeprecationConfig, _DeprecatedCallable, _WrapperState
 from deprecate.deprecation import _build_call_plan
+from tests.collection_targets import double_value, identity_value
 
 
 def _make_wrapper_stub(source: Callable[..., Any], dep_cfg: DeprecationConfig) -> _DeprecatedCallable:
@@ -41,14 +42,6 @@ def _make_wrapper_stub(source: Callable[..., Any], dep_cfg: DeprecationConfig) -
     return _stub  # type: ignore[return-value]
 
 
-def _double(x: int) -> int:
-    return x * 2
-
-
-def _identity(x: int = 0) -> int:
-    return x
-
-
 # ---------------------------------------------------------------------------
 # Callable-target dispatch — happy path
 # ---------------------------------------------------------------------------
@@ -56,13 +49,13 @@ def _identity(x: int = 0) -> int:
 
 def test_callable_target_round_trip_returns_target_func() -> None:
     """Callable target with matching kwargs returns ``short_circuit=False`` and the resolved ``target_func``."""
-    cfg = DeprecationConfig(deprecated_in="1.0", remove_in="2.0", name="src", target=_double)
-    wrapper = _make_wrapper_stub(_double, cfg)
+    cfg = DeprecationConfig(deprecated_in="1.0", remove_in="2.0", name="src", target=double_value)
+    wrapper = _make_wrapper_stub(double_value, cfg)
     plan = _build_call_plan(
         wrapper_fn=wrapper,
-        source=_double,
-        target=_double,
-        _target=_double,
+        source=double_value,
+        target=double_value,
+        _target=double_value,
         args=(),
         kwargs={"x": 3},
         dep_cfg=cfg,
@@ -73,7 +66,7 @@ def test_callable_target_round_trip_returns_target_func() -> None:
     )
 
     assert plan.short_circuit is False
-    assert plan.target_func is _double
+    assert plan.target_func is double_value
     assert plan.resolved_kwargs == {"x": 3}
     assert plan.reason_argument == {}
     # State must be bumped exactly once per call.
@@ -100,10 +93,10 @@ def test_args_remap_migrated_caller_short_circuits() -> None:
         target=TargetMode.ARGS_REMAP,
         args_mapping={"old_x": "x"},
     )
-    wrapper = _make_wrapper_stub(_identity, cfg)
+    wrapper = _make_wrapper_stub(identity_value, cfg)
     plan = _build_call_plan(
         wrapper_fn=wrapper,
-        source=_identity,
+        source=identity_value,
         target=TargetMode.ARGS_REMAP,
         _target=TargetMode.ARGS_REMAP,
         args=(),
@@ -129,10 +122,10 @@ def test_args_remap_migrated_caller_short_circuits() -> None:
 def test_notify_mode_returns_none_target_func() -> None:
     """:attr:`TargetMode.NOTIFY` never resolves a target; the wrapper must execute the source body."""
     cfg = DeprecationConfig(deprecated_in="1.0", remove_in="2.0", name="src", target=TargetMode.NOTIFY)
-    wrapper = _make_wrapper_stub(_identity, cfg)
+    wrapper = _make_wrapper_stub(identity_value, cfg)
     plan = _build_call_plan(
         wrapper_fn=wrapper,
-        source=_identity,
+        source=identity_value,
         target=TargetMode.NOTIFY,
         _target=TargetMode.NOTIFY,
         args=(),

--- a/tests/unittests/test_call_plan.py
+++ b/tests/unittests/test_call_plan.py
@@ -55,14 +55,14 @@ def test_callable_target_round_trip_returns_target_func() -> None:
         wrapper_fn=wrapper,
         source=double_value,
         target=double_value,
-        _target=double_value,
+        normalized_target=double_value,
         args=(),
         kwargs={"x": 3},
         dep_cfg=cfg,
         stream=None,  # suppress real warning emission
         num_warns=1,
         source_has_var_positional=False,
-        _source_is_stacked=False,
+        source_is_stacked=False,
     )
 
     assert plan.short_circuit is False
@@ -98,14 +98,14 @@ def test_args_remap_migrated_caller_short_circuits() -> None:
         wrapper_fn=wrapper,
         source=identity_value,
         target=TargetMode.ARGS_REMAP,
-        _target=TargetMode.ARGS_REMAP,
+        normalized_target=TargetMode.ARGS_REMAP,
         args=(),
         kwargs={"x": 7},  # caller already migrated — uses new name
         dep_cfg=cfg,
         stream=None,
         num_warns=1,
         source_has_var_positional=False,
-        _source_is_stacked=False,
+        source_is_stacked=False,
     )
 
     assert plan.short_circuit is True
@@ -127,14 +127,14 @@ def test_notify_mode_returns_none_target_func() -> None:
         wrapper_fn=wrapper,
         source=identity_value,
         target=TargetMode.NOTIFY,
-        _target=TargetMode.NOTIFY,
+        normalized_target=TargetMode.NOTIFY,
         args=(),
         kwargs={"x": 5},
         dep_cfg=cfg,
         stream=None,
         num_warns=1,
         source_has_var_positional=False,
-        _source_is_stacked=False,
+        source_is_stacked=False,
     )
 
     assert plan.short_circuit is False

--- a/tests/unittests/test_call_plan.py
+++ b/tests/unittests/test_call_plan.py
@@ -1,0 +1,150 @@
+"""Unit tests for the internal :func:`deprecate.deprecation._build_call_plan` helper.
+
+``_build_call_plan`` is the shared dispatch core used by both the sync ``wrapped_fn`` and the async
+``async_wrapped_fn`` produced by :func:`deprecate.deprecation.deprecated`.  It is normally invoked
+from within ``packing()``'s closure, but its signature accepts every dependency explicitly so it can
+be tested in isolation here.  These tests pin the public dispatch contract:
+
+- callable-target round-trip resolves ``target_func`` and returns the warning-emitted plan;
+- ``skip_if=True`` is handled by the *wrapper*, not by ``_build_call_plan``, so we instead pin the
+  short-circuit branch when the caller already uses the new arg name (migrated-caller fast path);
+- :attr:`~deprecate.TargetMode.NOTIFY` returns ``target_func=None`` and leaves the source body to
+  the wrapper.
+
+Each test constructs a minimal wrapper stub carrying the ``_state`` and ``__deprecated__``
+attributes that :func:`_build_call_plan` reads, plus a fresh :class:`~deprecate._types.DeprecationConfig`.
+
+"""
+
+from typing import Any, Callable
+
+from deprecate import TargetMode
+from deprecate._types import DeprecationConfig, _DeprecatedCallable, _WrapperState
+from deprecate.deprecation import _build_call_plan
+
+
+def _make_wrapper_stub(source: Callable[..., Any], dep_cfg: DeprecationConfig) -> _DeprecatedCallable:
+    """Return a minimal callable shaped like a ``@deprecated`` wrapper for unit testing.
+
+    The real wrapper carries mutable ``_state`` and frozen ``__deprecated__`` attributes that
+    :func:`_build_call_plan` reads via :class:`~deprecate._types._DeprecatedCallable`.  Wrapping the
+    bare ``source`` here suffices because the helper never invokes ``wrapper_fn`` itself — it only
+    reads ``wrapper_fn._state``.
+
+    """
+
+    def _stub(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401 - signature mirrors real wrappers
+        return source(*args, **kwargs)
+
+    _stub._state = _WrapperState()  # type: ignore[attr-defined]
+    _stub.__deprecated__ = dep_cfg  # type: ignore[attr-defined]
+    return _stub  # type: ignore[return-value]
+
+
+def _double(x: int) -> int:
+    return x * 2
+
+
+def _identity(x: int = 0) -> int:
+    return x
+
+
+# ---------------------------------------------------------------------------
+# Callable-target dispatch — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_callable_target_round_trip_returns_target_func() -> None:
+    """Callable target with matching kwargs returns ``short_circuit=False`` and the resolved ``target_func``."""
+    cfg = DeprecationConfig(deprecated_in="1.0", remove_in="2.0", name="src", target=_double)
+    wrapper = _make_wrapper_stub(_double, cfg)
+    plan = _build_call_plan(
+        wrapper_fn=wrapper,
+        source=_double,
+        target=_double,
+        _target=_double,
+        args=(),
+        kwargs={"x": 3},
+        dep_cfg=cfg,
+        stream=None,  # suppress real warning emission
+        num_warns=1,
+        source_has_var_positional=False,
+        _source_is_stacked=False,
+    )
+
+    assert plan.short_circuit is False
+    assert plan.target_func is _double
+    assert plan.resolved_kwargs == {"x": 3}
+    assert plan.reason_argument == {}
+    # State must be bumped exactly once per call.
+    assert wrapper._state.called == 1  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Short-circuit branch — caller using the new name with no extras
+# ---------------------------------------------------------------------------
+
+
+def test_args_remap_migrated_caller_short_circuits() -> None:
+    """When the caller passes only the new arg name and no extras are configured the plan short-circuits.
+
+    The short-circuit branch is the documented "migrated caller using the new arg name" fast path:
+    no warning fires, no remap runs, no target lookup happens.  The wrapper then invokes the source
+    directly with ``resolved_kwargs``.
+
+    """
+    cfg = DeprecationConfig(
+        deprecated_in="1.0",
+        remove_in="2.0",
+        name="src",
+        target=TargetMode.ARGS_REMAP,
+        args_mapping={"old_x": "x"},
+    )
+    wrapper = _make_wrapper_stub(_identity, cfg)
+    plan = _build_call_plan(
+        wrapper_fn=wrapper,
+        source=_identity,
+        target=TargetMode.ARGS_REMAP,
+        _target=TargetMode.ARGS_REMAP,
+        args=(),
+        kwargs={"x": 7},  # caller already migrated — uses new name
+        dep_cfg=cfg,
+        stream=None,
+        num_warns=1,
+        source_has_var_positional=False,
+        _source_is_stacked=False,
+    )
+
+    assert plan.short_circuit is True
+    assert plan.target_func is None
+    assert plan.reason_argument == {}
+    assert plan.resolved_kwargs == {"x": 7}
+
+
+# ---------------------------------------------------------------------------
+# NOTIFY mode — body runs in the wrapper; ``target_func`` is always None
+# ---------------------------------------------------------------------------
+
+
+def test_notify_mode_returns_none_target_func() -> None:
+    """:attr:`TargetMode.NOTIFY` never resolves a target; the wrapper must execute the source body."""
+    cfg = DeprecationConfig(deprecated_in="1.0", remove_in="2.0", name="src", target=TargetMode.NOTIFY)
+    wrapper = _make_wrapper_stub(_identity, cfg)
+    plan = _build_call_plan(
+        wrapper_fn=wrapper,
+        source=_identity,
+        target=TargetMode.NOTIFY,
+        _target=TargetMode.NOTIFY,
+        args=(),
+        kwargs={"x": 5},
+        dep_cfg=cfg,
+        stream=None,
+        num_warns=1,
+        source_has_var_positional=False,
+        _source_is_stacked=False,
+    )
+
+    assert plan.short_circuit is False
+    assert plan.target_func is None
+    # NOTIFY always treats every call as a callable-deprecation reason — no per-arg reason fires.
+    assert plan.reason_argument == {}


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- Add `async def async_wrapped_fn` branch in `packing()` for `iscoroutinefunction(source)` — mirrors sync wrapper exactly, awaits target; sync targets under async source invoked directly
- Add B2 guard: `isasyncgenfunction(source)` emits `UserWarning` at decoration time (async gen support N4 still pending)
- Add `pytest-asyncio >=0.21` to test deps; 8 new async tests + 1 B2 test in `test_callable_kinds.py`
- Add async targets and wrappers to collection files (3 TargetModes)
- Docs: `## Async` section in `use-cases.md`, concurrency FAQ in `troubleshooting.md`, JSON-LD FAQ entry, `llms.txt` async notes

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
