### PR TITLE
docs: async warning timing reference and CI visibility guide

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -213,8 +213,17 @@ pydeprecate all src/
 - `@deprecated` works with `@classmethod`, `@staticmethod`, `@property`, and `@cached_property` in either decorator order — `@classmethod @deprecated` and `@deprecated @classmethod` both produce `classmethod(deprecated_wrapper)`; `@staticmethod @deprecated` and `@deprecated @staticmethod` both produce `staticmethod(deprecated_wrapper)`. Both fire `FutureWarning` at call time.
 - `@property` with `@deprecated` in either order: warning fires on attribute access (`obj.prop` triggers it, not `obj.prop()`).
 - `@cached_property` with `@deprecated` in either order: warning fires on **first access only** — subsequent accesses hit the cached value and do not emit a warning.
-- `@deprecated` on `async def` functions: the wrapper is `async def`; `inspect.iscoroutinefunction(wrapper)` returns `True`. All three TargetModes work. Warning fires when the coroutine is awaited, not when the wrapper is called — `coro = wrapper(x=1)` produces no warning; `await coro` fires it.
+- `@deprecated` on `async def` functions: the wrapper is `async def`; `inspect.iscoroutinefunction(wrapper)` returns `True`. All three TargetModes work. Warning fires when the coroutine is awaited, not when the wrapper is called — `coro = wrapper(x=1)` produces no warning; `await coro` fires it. **CI visibility**: if coroutines are scheduled via `asyncio.create_task` or third-party schedulers, warnings fire in the scheduler's context — use `stream=logging.warning` for guaranteed log output. In tests, `pytest.warns()` must wrap the `await`, not just the call.
 - `@deprecated` on async generator functions (`async def` + `yield`): the wrapper is **sync** (`inspect.iscoroutinefunction(wrapper)` is `False`); calling the wrapper fires the deprecation warning eagerly and returns the async generator object. Callers iterate with `async for item in wrapper(...):`. All three TargetModes work — NOTIFY runs the source body, ARGS_REMAP remaps args before iterating the source body, and `target=<async_gen_callable>` forwards to a replacement async generator. The warning fires at sync call time, before the first `__anext__`.
+
+Warning timing quick reference — all callable kinds:
+
+| Callable kind | Warning fires at | `iscoroutinefunction(wrapper)` |
+|---|---|---|
+| Sync function | call time | N/A (sync) |
+| Generator (`def` + `yield`) | call time (before first `next()`) | N/A (sync) |
+| Async generator (`async def` + `yield`) | call time — sync wrapper (before first `async for`) | `False` |
+| Async function (`async def`) | `await` time (inside coroutine body) | `True` |
 
 ## Anti-Patterns
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -268,6 +268,14 @@
             "@type": "Answer",
             "text": "_WrapperState fields (called, warned_calls, warned_args) are plain Python dataclass fields with no asyncio lock. Concurrent coroutines sharing one deprecated wrapper race on the warning counter, causing fewer warnings than num_warns specifies to be emitted. Workaround: set num_warns=-1 to bypass the count gate entirely — the warning then fires unconditionally on every call regardless of scheduling."
           }
+        },
+        {
+          "@type": "Question",
+          "name": "Why does my deprecated async def warning not appear in CI or test output?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "For async def functions, the deprecation warning fires when the coroutine is awaited, not when the wrapper is called. coro = old_fn(x=1) produces no warning; await coro fires it. Common silent-loss scenarios: asyncio.create_task schedules the coroutine so the warning fires in the event loop after your catch_warnings block exits; third-party schedulers (Celery, arq, anyio) run the coroutine in a different context; pytest.warns() wrapping only the call captures nothing. Fix 1 (recommended): use stream=logging.warning — logging bypasses Python warning filters and always appears in CI logs. Fix 2 (tests): wrap the await, not just the call, inside pytest.warns(FutureWarning)."
+          }
         }
       ]
     }

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -274,7 +274,7 @@
           "name": "Why does my deprecated async def warning not appear in CI or test output?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "For async def functions, the deprecation warning fires when the coroutine is awaited, not when the wrapper is called. coro = old_fn(x=1) produces no warning; await coro fires it. Common silent-loss scenarios: asyncio.create_task schedules the coroutine so the warning fires in the event loop after your catch_warnings block exits; third-party schedulers (Celery, arq, anyio) run the coroutine in a different context; pytest.warns() wrapping only the call captures nothing. Fix 1 (recommended): use stream=logging.warning — logging bypasses Python warning filters and always appears in CI logs. Fix 2 (tests): wrap the await, not just the call, inside pytest.warns(FutureWarning)."
+            "text": "For async def functions, the deprecation warning fires when the coroutine is awaited, not when the wrapper is called. coro = old_fn(x=1) produces no warning; await coro fires it. Common silent-loss scenarios: asyncio.create_task or tasks scheduled via fixtures/library hooks — the warning fires when the event loop executes the coroutine, which may be outside any active catch_warnings context (e.g., in background workers or test setup code); third-party schedulers (Celery, arq, anyio) run the coroutine in a different context; pytest.warns() wrapping only the call captures nothing. Fix 1 (recommended): use stream=logging.warning — logging bypasses Python warning filters and always appears in CI logs. Fix 2 (tests): wrap the await, not just the call, inside pytest.warns(FutureWarning)."
           }
         }
       ]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -981,7 +981,7 @@ async def new_fetch(url: str) -> bytes:
     return url.encode()
 
 
-@deprecated(target=new_fetch, deprecated_in="0.9", remove_in="1.0", stream=logging.warning, num_warns=-1)
+@deprecated(target=new_fetch, deprecated_in="0.9", remove_in="1.0", stream=logging.warning)
 async def old_fetch(url: str) -> bytes:
     pass
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 id: troubleshooting
-description: 'Fix common pyDeprecate errors: missing deprecation notices, TypeError mapping failures, class deprecation notices, bool return errors, cross-module path issues, proxy limitations on primitives, and redirecting deprecation output to a logger.'
+description: 'Fix common pyDeprecate errors: missing deprecation notices, async warning not appearing in CI, TypeError mapping failures, class deprecation notices, bool return errors, cross-module path issues, proxy limitations on primitives, and redirecting deprecation output to a logger.'
 ---
 
 # Troubleshooting
@@ -927,6 +927,82 @@ assert asyncio.run(main()) is None
 ```
 
 If you need to assert exactly one warning fires in a test, run the deprecated coroutines sequentially rather than with `asyncio.gather`.
+
+______________________________________________________________________
+
+## My deprecated `async def` warning does not appear in CI
+
+**Q:** I decorated an `async def` function with `@deprecated` but the deprecation notice never shows up in my CI logs or test output. Why, and how do I fix it?
+
+**A:** For `async def` functions, the deprecation warning fires when the coroutine is **awaited**, not when the wrapper is called. Creating the coroutine object — `coro = old_fn(x=1)` — produces no warning; `await coro` is what triggers it.
+
+This means warnings can be silently lost in these common scenarios:
+
+- **`asyncio.create_task(old_fn(x=1))`** — the task is created synchronously; the warning fires when the event loop runs the task. If CI captures warnings from the test body but the task runs after the `catch_warnings` block exits, the warning is missed.
+- **Third-party schedulers** (Celery, arq, anyio task groups) — the coroutine is handed off and the warning fires in the scheduler's execution context, not the caller's, and may be routed to a different warning filter.
+- **`pytest.warns(FutureWarning)` wrapping only the call** — `with pytest.warns(FutureWarning): coro = old_fn()` captures nothing because no warning fires at call time. The block must wrap the `await`.
+
+```python
+import asyncio
+import warnings
+from deprecate import deprecated
+
+
+async def new_fetch(url: str) -> bytes:
+    return url.encode()
+
+
+@deprecated(target=new_fetch, deprecated_in="0.9", remove_in="1.0")
+async def old_fetch(url: str) -> bytes:
+    pass
+
+
+async def captured_correctly():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = await old_fetch("https://example.com")  # warning fires here, inside block
+    assert len(w) == 1
+    return result
+
+
+asyncio.run(captured_correctly())
+```
+
+**Fix 1 — use `stream=logging.warning`** (recommended for CI):
+
+Logging bypasses Python's warning filter state entirely. The deprecation message appears in your log output regardless of when or where the coroutine is awaited.
+
+```python
+import logging
+from deprecate import deprecated
+
+
+async def new_fetch(url: str) -> bytes:
+    return url.encode()
+
+
+@deprecated(target=new_fetch, deprecated_in="0.9", remove_in="1.0", stream=logging.warning, num_warns=-1)
+async def old_fetch(url: str) -> bytes:
+    pass
+```
+
+**Fix 2 — wrap the `await` in tests**, not just the call:
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_old_fetch_warns():
+    with pytest.warns(FutureWarning):
+        await old_fetch("https://example.com")  # correct: await inside the warns block
+```
+
+!!! note "Async warning timing is by design"
+
+    The `async def` wrapper is a true coroutine (`inspect.iscoroutinefunction(wrapper)` returns `True`), so the deprecation warning fires inside the coroutine body when execution begins — on `await`. Warnings for generators and async generators fire eagerly at call time; async functions are the exception because the wrapper itself is a coroutine.
+
+______________________________________________________________________
 
 ## I wrapped a `functools.partial` of an `async def` and the wrapper is not async
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -938,7 +938,7 @@ ______________________________________________________________________
 
 This means warnings can be silently lost in these common scenarios:
 
-- **`asyncio.create_task(old_fn(x=1))`** — the task is created synchronously; the warning fires when the event loop runs the task. If CI captures warnings from the test body but the task runs after the `catch_warnings` block exits, the warning is missed.
+- **`asyncio.create_task(old_fn(x=1))`** or **tasks scheduled via fixtures or library hooks** — the warning fires when the event loop executes the coroutine, which may happen outside any active `catch_warnings` context (e.g., in application startup code, background workers, or test fixtures that schedule work on the event loop).
 - **Third-party schedulers** (Celery, arq, anyio task groups) — the coroutine is handed off and the warning fires in the scheduler's execution context, not the caller's, and may be routed to a different warning filter.
 - **`pytest.warns(FutureWarning)` wrapping only the call** — `with pytest.warns(FutureWarning): coro = old_fn()` captures nothing because no warning fires at call time. The block must wrap the `await`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ quiet-level = 3
 #  https://github.com/codespell-project/codespell/issues/2839#issuecomment-1731601603
 # also adding links until they ignored by its: nature
 #  https://github.com/codespell-project/codespell/issues/2243#issuecomment-1732019960
+# reserved: async generator .asend() protocol — codespell flags it as an "ascend" typo
 ignore-words-list = "asend"
 
 [tool.docformatter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,12 @@ lint.pydocstyle.convention = "google"
 [tool.codespell]
 # skip = '*.py'
 quiet-level = 3
-
 # comma separated list of words; waiting for:
 #  https://github.com/codespell-project/codespell/issues/2839#issuecomment-1731601603
 # also adding links until they ignored by its: nature
 #  https://github.com/codespell-project/codespell/issues/2243#issuecomment-1732019960
-# ignore-words-list = ""
+ignore-words-list = "asend"
+
 [tool.docformatter]
 recursive = true
 # Match the repository's 120-character line length for docstrings, including raw triple-quoted ones.


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- Add troubleshooting section explaining async def warning fires on await, not call; covers create_task, third-party schedulers, and pytest.warns pitfalls; recommends stream=logging.warning for guaranteed CI visibility
- Add warning timing quick-reference table to llms.txt Agent Notes (all four callable kinds in one place)
- Extend llms.txt async def Agent Note with CI visibility guidance and stream=logging.warning recommendation
- Add FAQPage JSON-LD entry for async CI visibility question in docs/overrides/main.html
- Add asend to codespell ignore-words-list (valid Python async generator protocol method name)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
