### PR TITLE
refactor: eliminate C901/PLR0912 noqa suppressions

### DIFF
--- a/src/deprecate/audit.py
+++ b/src/deprecate/audit.py
@@ -772,7 +772,76 @@ def validate_deprecation_expiry(
     )
 
 
-def find_deprecation_wrappers(  # noqa: C901
+def _scan_callable(
+    obj: Any,  # noqa: ANN401
+    module_name: str,
+    qualified_name: str,
+    results: list[DeprecationWrapperInfo],
+    *,
+    member_name: Optional[str] = None,
+    descriptor_kind: Optional[str] = None,
+) -> None:
+    """Emit a result if ``obj`` carries ``__deprecated__`` metadata."""
+    if _has_deprecation_meta(obj):
+        info = validate_deprecation_wrapper(obj)
+        api_type = _classify_wrapper_api_type(obj, info, member_name=member_name, descriptor_kind=descriptor_kind)
+        info = replace(info, module=module_name, function=qualified_name, api_type=api_type)
+        results.append(info)
+
+
+def _scan_class(cls: Any, module_name: str, cls_name: str, results: list[DeprecationWrapperInfo]) -> None:  # noqa: ANN401
+    """Scan class members, peeking through descriptors."""
+    try:
+        members = _getmembers_static_compat(cls)
+    except (AttributeError, TypeError):
+        return
+    for attr_name, obj in members:
+        if attr_name.startswith("_") and attr_name != "__init__":
+            continue
+        qualified = f"{cls_name}.{attr_name}"
+        if isinstance(obj, (classmethod, staticmethod)):
+            kind = "classmethod" if isinstance(obj, classmethod) else "staticmethod"
+            _scan_callable(obj.__func__, module_name, qualified, results, member_name=attr_name, descriptor_kind=kind)
+        elif isinstance(obj, property):
+            _prop_accessor = next(
+                (a for a in (obj.fget, obj.fset, obj.fdel) if a is not None and _has_deprecation_meta(a)),
+                None,
+            )
+            if _prop_accessor is not None:
+                _scan_callable(_prop_accessor, module_name, qualified, results, member_name=attr_name)
+        elif isinstance(obj, cached_property):
+            _scan_callable(obj.func, module_name, qualified, results, member_name=attr_name)
+        else:
+            _scan_callable(obj, module_name, qualified, results, member_name=attr_name)
+
+
+def _scan_module(
+    mod: Any,  # noqa: ANN401
+    results: list[DeprecationWrapperInfo],
+    *,
+    include_members: bool,
+) -> None:
+    """Scan a single module for deprecated functions and class members."""
+    try:
+        members = _getmembers_static_compat(mod)
+    except (AttributeError, TypeError, ImportError):
+        return
+
+    mod_name = mod.__name__ if hasattr(mod, "__name__") else str(mod)
+    for name, obj in members:
+        if name.startswith("_"):
+            continue
+
+        if _has_deprecation_meta(obj):
+            info = validate_deprecation_wrapper(obj)
+            api_type = _classify_wrapper_api_type(obj, info)
+            info = replace(info, module=mod_name, function=name, api_type=api_type)
+            results.append(info)
+        elif include_members and inspect.isclass(obj) and getattr(obj, "__module__", None) == mod_name:
+            _scan_class(obj, mod_name, name, results)
+
+
+def find_deprecation_wrappers(
     module: Union[Any, str],  # noqa: ANN401
     recursive: bool = True,
     include_members: bool = True,
@@ -834,76 +903,8 @@ def find_deprecation_wrappers(  # noqa: C901
     if isinstance(module, str):
         module = importlib.import_module(module)
 
-    def _scan_callable(
-        obj: Any,  # noqa: ANN401
-        module_name: str,
-        qualified_name: str,
-        *,
-        member_name: Optional[str] = None,
-        descriptor_kind: Optional[str] = None,
-    ) -> None:
-        """Emit a result if ``obj`` carries ``__deprecated__`` metadata."""
-        if _has_deprecation_meta(obj):
-            info = validate_deprecation_wrapper(obj)
-            api_type = _classify_wrapper_api_type(obj, info, member_name=member_name, descriptor_kind=descriptor_kind)
-            info = replace(info, module=module_name, function=qualified_name, api_type=api_type)
-            results.append(info)
+    _scan_module(module, results, include_members=include_members)
 
-    def _scan_class(cls: Any, module_name: str, cls_name: str) -> None:  # noqa: ANN401
-        """Scan class members, peeking through descriptors."""
-        try:
-            members = _getmembers_static_compat(cls)
-        except (AttributeError, TypeError):
-            return
-        for attr_name, obj in members:
-            if attr_name.startswith("_") and attr_name != "__init__":
-                continue
-            qualified = f"{cls_name}.{attr_name}"
-            # Peek through descriptors to find the underlying function.
-            if isinstance(obj, (classmethod, staticmethod)):
-                kind = "classmethod" if isinstance(obj, classmethod) else "staticmethod"
-                _scan_callable(obj.__func__, module_name, qualified, member_name=attr_name, descriptor_kind=kind)
-            elif isinstance(obj, property):
-                # Scan the first accessor that carries deprecation metadata.
-                # fset/fdel provide fallback for setter-only or deleter-only properties
-                # (fget=None) and explicit property(non_deprecated_fget, deprecated_fset) forms.
-                _prop_accessor = next(
-                    (a for a in (obj.fget, obj.fset, obj.fdel) if a is not None and _has_deprecation_meta(a)),
-                    None,
-                )
-                if _prop_accessor is not None:
-                    _scan_callable(_prop_accessor, module_name, qualified, member_name=attr_name)
-            elif isinstance(obj, cached_property):
-                _scan_callable(obj.func, module_name, qualified, member_name=attr_name)
-            else:
-                _scan_callable(obj, module_name, qualified, member_name=attr_name)
-
-    def _scan_module(mod: Any) -> None:  # noqa: ANN401
-        """Scan a single module for deprecated functions and class members."""
-        try:
-            # Static inspection avoids dynamic getattr/descriptor evaluation while scanning.
-            members = _getmembers_static_compat(mod)
-        except (AttributeError, TypeError, ImportError):
-            return
-
-        mod_name = mod.__name__ if hasattr(mod, "__name__") else str(mod)
-        for name, obj in members:
-            # Skip private/magic attributes and imports from other modules
-            if name.startswith("_"):
-                continue
-
-            if _has_deprecation_meta(obj):
-                info = validate_deprecation_wrapper(obj)
-                api_type = _classify_wrapper_api_type(obj, info)
-                info = replace(info, module=mod_name, function=name, api_type=api_type)
-                results.append(info)
-            elif include_members and inspect.isclass(obj) and getattr(obj, "__module__", None) == mod_name:
-                _scan_class(obj, mod_name, name)
-
-    # Scan the main module
-    _scan_module(module)
-
-    # Recursively scan submodules if requested
     if recursive and hasattr(module, "__path__"):
         try:
             packages = list(
@@ -915,7 +916,7 @@ def find_deprecation_wrappers(  # noqa: C901
         for _importer, modname, _ispkg in packages:
             with suppress(ImportError, ModuleNotFoundError):
                 submod = importlib.import_module(modname)
-                _scan_module(submod)
+                _scan_module(submod, results, include_members=include_members)
 
     return results
 
@@ -974,7 +975,18 @@ def _format_report_target(target: Any) -> str:  # noqa: ANN401
     return str(target)
 
 
-def _classify_wrapper_api_type(  # noqa: C901
+def _classify_member_api_type(member_name: str, descriptor_kind: Optional[str], has_mapping: bool) -> str:
+    """Classify the API type for a deprecated class member (method, constructor, descriptor)."""
+    if member_name == "__init__":
+        return "class constructor args" if has_mapping else "class constructor"
+    if descriptor_kind == "classmethod":
+        return "classmethod args" if has_mapping else "classmethod"
+    if descriptor_kind == "staticmethod":
+        return "staticmethod args" if has_mapping else "staticmethod"
+    return "class method args" if has_mapping else "class method"
+
+
+def _classify_wrapper_api_type(
     wrapped_obj: Any,  # noqa: ANN401
     info: DeprecationWrapperInfo,
     *,
@@ -985,13 +997,7 @@ def _classify_wrapper_api_type(  # noqa: C901
     has_mapping = bool(info.deprecated_info.args_mapping)
 
     if member_name is not None:
-        if member_name == "__init__":
-            return "class constructor args" if has_mapping else "class constructor"
-        if descriptor_kind == "classmethod":
-            return "classmethod args" if has_mapping else "classmethod"
-        if descriptor_kind == "staticmethod":
-            return "staticmethod args" if has_mapping else "staticmethod"
-        return "class method args" if has_mapping else "class method"
+        return _classify_member_api_type(member_name, descriptor_kind, has_mapping)
 
     if isinstance(wrapped_obj, _DeprecatedProxy):
         while isinstance(wrapped_obj, _DeprecatedProxy):
@@ -1076,7 +1082,25 @@ def _get_deprecation_status(info: DeprecationWrapperInfo, current_version: Optio
     return DeprecationStatus.ACTIVE_WARNING
 
 
-def generate_deprecation_table(  # noqa: C901
+def _format_matrix_row(info: DeprecationWrapperInfo, col_idx: dict[str, int], n_versions: int) -> str:
+    """Format one matrix-style table row for a deprecated wrapper."""
+    markers: list[str] = [" "] * n_versions
+    dep_in = info.deprecated_info.deprecated_in
+    rem_in = info.deprecated_info.remove_in
+    if dep_in and dep_in in col_idx:
+        markers[col_idx[dep_in]] = "D"
+    if rem_in and rem_in in col_idx:
+        i = col_idx[rem_in]
+        markers[i] = "R" if markers[i] == " " else "D/R"
+    return (
+        "| "
+        f"`{_format_report_symbol(info)}` | "
+        f"{_format_report_api_type(info)} | "
+        f"`{_format_report_target(info.deprecated_info.target)}` | " + " | ".join(markers) + " |"
+    )
+
+
+def generate_deprecation_table(
     module: Union[Any, str],  # noqa: ANN401
     current_version: Optional[str] = None,
     recursive: bool = True,
@@ -1175,20 +1199,7 @@ def generate_deprecation_table(  # noqa: C901
         rows = [header_row, divider_row]
 
         for info in wrappers:
-            markers: list[str] = [" "] * n_versions
-            dep_in = info.deprecated_info.deprecated_in
-            rem_in = info.deprecated_info.remove_in
-            if dep_in and dep_in in col_idx:
-                markers[col_idx[dep_in]] = "D"
-            if rem_in and rem_in in col_idx:
-                i = col_idx[rem_in]
-                markers[i] = "R" if markers[i] == " " else "D/R"
-            rows.append(
-                "| "
-                f"`{_format_report_symbol(info)}` | "
-                f"{_format_report_api_type(info)} | "
-                f"`{_format_report_target(info.deprecated_info.target)}` | " + " | ".join(markers) + " |"
-            )
+            rows.append(_format_matrix_row(info, col_idx, n_versions))
 
     if resolved_version is not None:
         rows.insert(0, f"<!-- Current version: {resolved_version} -->")

--- a/src/deprecate/audit.py
+++ b/src/deprecate/audit.py
@@ -776,69 +776,72 @@ def _scan_callable(
     obj: Any,  # noqa: ANN401
     module_name: str,
     qualified_name: str,
-    results: list[DeprecationWrapperInfo],
     *,
     member_name: Optional[str] = None,
     descriptor_kind: Optional[str] = None,
-) -> None:
+) -> Optional[DeprecationWrapperInfo]:
     """Emit a result if ``obj`` carries ``__deprecated__`` metadata."""
     if _has_deprecation_meta(obj):
         info = validate_deprecation_wrapper(obj)
         api_type = _classify_wrapper_api_type(obj, info, member_name=member_name, descriptor_kind=descriptor_kind)
-        info = replace(info, module=module_name, function=qualified_name, api_type=api_type)
-        results.append(info)
+        return replace(info, module=module_name, function=qualified_name, api_type=api_type)
+    return None
 
 
-def _scan_class(cls: Any, module_name: str, cls_name: str, results: list[DeprecationWrapperInfo]) -> None:  # noqa: ANN401
+def _scan_class(cls: Any, module_name: str, cls_name: str) -> list[DeprecationWrapperInfo]:  # noqa: ANN401
     """Scan class members, peeking through descriptors."""
+    results: list[DeprecationWrapperInfo] = []
     try:
         members = _getmembers_static_compat(cls)
     except (AttributeError, TypeError):
-        return
+        return results
     for attr_name, obj in members:
         if attr_name.startswith("_") and attr_name != "__init__":
             continue
         qualified = f"{cls_name}.{attr_name}"
+        result: Optional[DeprecationWrapperInfo] = None
         if isinstance(obj, (classmethod, staticmethod)):
             kind = "classmethod" if isinstance(obj, classmethod) else "staticmethod"
-            _scan_callable(obj.__func__, module_name, qualified, results, member_name=attr_name, descriptor_kind=kind)
+            result = _scan_callable(obj.__func__, module_name, qualified, member_name=attr_name, descriptor_kind=kind)
         elif isinstance(obj, property):
             _prop_accessor = next(
                 (a for a in (obj.fget, obj.fset, obj.fdel) if a is not None and _has_deprecation_meta(a)),
                 None,
             )
             if _prop_accessor is not None:
-                _scan_callable(_prop_accessor, module_name, qualified, results, member_name=attr_name)
+                result = _scan_callable(_prop_accessor, module_name, qualified, member_name=attr_name)
         elif isinstance(obj, cached_property):
-            _scan_callable(obj.func, module_name, qualified, results, member_name=attr_name)
+            result = _scan_callable(obj.func, module_name, qualified, member_name=attr_name)
         else:
-            _scan_callable(obj, module_name, qualified, results, member_name=attr_name)
+            result = _scan_callable(obj, module_name, qualified, member_name=attr_name)
+        if result is not None:
+            results.append(result)
+    return results
 
 
 def _scan_module(
     mod: Any,  # noqa: ANN401
-    results: list[DeprecationWrapperInfo],
     *,
     include_members: bool,
-) -> None:
+) -> list[DeprecationWrapperInfo]:
     """Scan a single module for deprecated functions and class members."""
+    results: list[DeprecationWrapperInfo] = []
     try:
         members = _getmembers_static_compat(mod)
     except (AttributeError, TypeError, ImportError):
-        return
+        return results
 
     mod_name = mod.__name__ if hasattr(mod, "__name__") else str(mod)
     for name, obj in members:
         if name.startswith("_"):
             continue
 
-        if _has_deprecation_meta(obj):
-            info = validate_deprecation_wrapper(obj)
-            api_type = _classify_wrapper_api_type(obj, info)
-            info = replace(info, module=mod_name, function=name, api_type=api_type)
-            results.append(info)
+        result = _scan_callable(obj, mod_name, name)
+        if result is not None:
+            results.append(result)
         elif include_members and inspect.isclass(obj) and getattr(obj, "__module__", None) == mod_name:
-            _scan_class(obj, mod_name, name, results)
+            results.extend(_scan_class(obj, mod_name, name))
+    return results
 
 
 def find_deprecation_wrappers(
@@ -903,7 +906,7 @@ def find_deprecation_wrappers(
     if isinstance(module, str):
         module = importlib.import_module(module)
 
-    _scan_module(module, results, include_members=include_members)
+    results.extend(_scan_module(module, include_members=include_members))
 
     if recursive and hasattr(module, "__path__"):
         try:
@@ -916,7 +919,7 @@ def find_deprecation_wrappers(
         for _importer, modname, _ispkg in packages:
             with suppress(ImportError, ModuleNotFoundError):
                 submod = importlib.import_module(modname)
-                _scan_module(submod, results, include_members=include_members)
+                results.extend(_scan_module(submod, include_members=include_members))
 
     return results
 

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -17,6 +17,7 @@ import inspect
 import sys
 import warnings
 from collections.abc import Mapping
+from dataclasses import dataclass
 from functools import cached_property, partial, wraps
 from inspect import Parameter
 from typing import Any, Callable, Literal, Optional, Union, cast
@@ -991,7 +992,7 @@ def _build_call_plan(  # noqa: C901, PLR0912
     )
 
 
-def _packing_descriptor(  # noqa: C901
+def _packing_descriptor(  # noqa: C901 — property-path guards (fget/fset/fdel validation + TypeError raises) are one coherent story; splitting further adds indirection without reducing real complexity
     source: Union[Callable, classmethod, staticmethod, "property", cached_property],
     packing_fn: Callable,
     target: Union[bool, None, Callable, TargetMode, staticmethod, classmethod],
@@ -1112,19 +1113,25 @@ def _packing_descriptor(  # noqa: C901
     return None
 
 
+@dataclass(frozen=True)
+class _PackingClassArgs:
+    """Grouped keyword arguments for :func:`~deprecate.deprecation._packing_class_source`."""
+
+    deprecated_in: str
+    remove_in: str
+    num_warns: int
+    stream: Optional[Callable]
+    args_mapping: Optional[dict[str, Optional[str]]]
+    args_extra: Optional[dict[str, Any]]
+    update_docstring: bool
+    docstring_style: str
+    _stacklevel: int
+
+
 def _packing_class_source(
     source: type,
     target: Union[bool, None, Callable, TargetMode, staticmethod, classmethod],
-    *,
-    deprecated_in: str,
-    remove_in: str,
-    num_warns: int,
-    stream: Optional[Callable],
-    args_mapping: Optional[dict[str, Optional[str]]],
-    args_extra: Optional[dict[str, Any]],
-    update_docstring: bool,
-    docstring_style: str,
-    _stacklevel: int,
+    pack_args: _PackingClassArgs,
 ) -> Callable:
     """Delegate class-source deprecation to :func:`~deprecate.proxy.deprecated_class`.
 
@@ -1136,21 +1143,24 @@ def _packing_class_source(
     Args:
         source: The class being decorated with ``@deprecated``.
         target: Raw ``target`` argument from ``@deprecated``.
-        deprecated_in: Passed through to ``deprecated_class``.
-        remove_in: Passed through to ``deprecated_class``.
-        num_warns: Passed through to ``deprecated_class``.
-        stream: Warning stream; controls whether the class-deprecation ``UserWarning`` fires.
-        args_mapping: Passed through to ``deprecated_class`` when applicable.
-        args_extra: Passed through to ``deprecated_class`` when applicable.
-        update_docstring: Passed through to ``deprecated_class``.
-        docstring_style: Passed through to ``deprecated_class``.
-        _stacklevel: Stacklevel for ``warnings.warn`` calls; caller passes
-            ``packing``'s ``_stacklevel + 1`` to account for the extra frame.
+        pack_args: Grouped keyword arguments passed through to ``deprecated_class`` plus the
+            stacklevel for ``warnings.warn`` calls; caller passes ``packing``'s
+            ``_stacklevel + 1`` to account for the extra frame.
 
     Returns:
         Result of ``deprecated_class(...)(source)``.
 
     """
+    deprecated_in = pack_args.deprecated_in
+    remove_in = pack_args.remove_in
+    num_warns = pack_args.num_warns
+    stream = pack_args.stream
+    args_mapping = pack_args.args_mapping
+    args_extra = pack_args.args_extra
+    update_docstring = pack_args.update_docstring
+    docstring_style = pack_args.docstring_style
+    _stacklevel = pack_args._stacklevel
+
     import importlib
 
     proxy_module = importlib.import_module("deprecate.proxy")
@@ -1304,7 +1314,7 @@ async def _invoke_async(
     plan: _CallPlan,
     dep_cfg: DeprecationConfig,
     source_has_var_positional: bool,
-    args: tuple,
+    args: tuple[Any, ...],
 ) -> Any:  # noqa: ANN401
     """Dispatch async call after :func:`_build_call_plan` has resolved the outcome."""
     if plan.short_circuit:
@@ -1335,7 +1345,7 @@ def _invoke_sync(
     plan: _CallPlan,
     dep_cfg: DeprecationConfig,
     source_has_var_positional: bool,
-    args: tuple,
+    args: tuple[Any, ...],
 ) -> Any:  # noqa: ANN401
     """Dispatch sync call after :func:`_build_call_plan` has resolved the outcome."""
     if plan.short_circuit:
@@ -1500,8 +1510,10 @@ def deprecated(  # noqa: C901
         # mypy narrowing: _packing_descriptor handles all descriptor types via early return;
         # remaining code (including captured closures) only executes for plain Callable.
         # isinstance guard is required — cast() does not propagate narrowing into closure bodies.
-        if isinstance(source, (classmethod, staticmethod, property, cached_property)):
-            raise AssertionError(f"unreachable: {type(source)!r} was not handled by _packing_descriptor")
+        if isinstance(source, (classmethod, staticmethod, property, cached_property)):  # pragma: no cover
+            raise AssertionError(  # pragma: no cover
+                f"unreachable: {type(source)!r} was not handled by _packing_descriptor"
+            )
         # Probe ``template_mgs`` against every documented placeholder so typos and malformed
         # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
         _validate_template_mgs(template_mgs)
@@ -1519,15 +1531,17 @@ def deprecated(  # noqa: C901
             return _packing_class_source(
                 source,
                 target,
-                deprecated_in=deprecated_in,
-                remove_in=remove_in,
-                num_warns=num_warns,
-                stream=stream,
-                args_mapping=args_mapping,
-                args_extra=args_extra,
-                update_docstring=update_docstring,
-                docstring_style=docstring_style,
-                _stacklevel=_stacklevel + 1,
+                _PackingClassArgs(
+                    deprecated_in=deprecated_in,
+                    remove_in=remove_in,
+                    num_warns=num_warns,
+                    stream=stream,
+                    args_mapping=args_mapping,
+                    args_extra=args_extra,
+                    update_docstring=update_docstring,
+                    docstring_style=docstring_style,
+                    _stacklevel=_stacklevel + 1,
+                ),
             )
         # Cross-class guard runs before remapping; class targets skip it because
         # constructor forwarding (target=NewCls on __init__) is always valid.

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -1113,7 +1113,7 @@ def _packing_descriptor(  # noqa: C901 — property-path guards (fget/fset/fdel 
     return None
 
 
-@dataclass(frozen=True)
+@dataclass
 class _PackingClassArgs:
     """Grouped keyword arguments for :func:`~deprecate.deprecation._packing_class_source`."""
 
@@ -1151,16 +1151,6 @@ def _packing_class_source(
         Result of ``deprecated_class(...)(source)``.
 
     """
-    deprecated_in = pack_args.deprecated_in
-    remove_in = pack_args.remove_in
-    num_warns = pack_args.num_warns
-    stream = pack_args.stream
-    args_mapping = pack_args.args_mapping
-    args_extra = pack_args.args_extra
-    update_docstring = pack_args.update_docstring
-    docstring_style = pack_args.docstring_style
-    _stacklevel = pack_args._stacklevel
-
     import importlib
 
     proxy_module = importlib.import_module("deprecate.proxy")
@@ -1175,8 +1165,8 @@ def _packing_class_source(
             " Note: non-class `target` values are ignored when deprecating classes;"
             " use `@deprecated_class(target=...)` instead."
         )
-    if stream is not None:
-        warnings.warn(message, UserWarning, stacklevel=_stacklevel)
+    if pack_args.stream is not None:
+        warnings.warn(message, UserWarning, stacklevel=pack_args._stacklevel)
 
     # _DeprecatedProxy auto-promotes ``None+args_mapping`` to ARGS_REMAP and reads
     # ``misconfigured`` from its own ``target is False`` check — by that point
@@ -1189,41 +1179,36 @@ def _packing_class_source(
     elif target is None or isinstance(target, bool):
         # None/True/False on a class is a class-misconfiguration, not a callable
         # deprecation sentinel — the class misconfig UserWarning is the relevant signal.
-        forward_target = TargetMode._from_legacy(target, stacklevel=_stacklevel + 1)
+        forward_target = TargetMode._from_legacy(target, stacklevel=pack_args._stacklevel + 1)
     else:
         forward_target = TargetMode.NOTIFY
 
-    # Capture all misconfig signals *before* rewriting forward_args_mapping / forward_args_extra
-    # so we can forward them via ``_misconfigured_override`` instead of mutating the frozen
-    # ``DeprecationConfig`` after construction. NOTIFY + (args_mapping or args_extra) is the
-    # second misconfig source the proxy can no longer detect once we strip those fields.
-    notify_misconfig = forward_target is TargetMode.NOTIFY and bool(args_mapping or args_extra)
+    # Capture misconfig signals *before* nulling args_mapping/args_extra — NOTIFY + either
+    # field is a misconfig the proxy can no longer detect once we strip those fields.
+    notify_misconfig = forward_target is TargetMode.NOTIFY and bool(pack_args.args_mapping or pack_args.args_extra)
     force_misconfigured = class_misconfigured or notify_misconfig
 
-    # Proxy metadata is immutable after construction; stale mapping persists to audit tools.
-    forward_args_mapping = args_mapping
-    forward_args_extra = args_extra
     if forward_target is TargetMode.NOTIFY:
         TargetMode._validate(
             forward_target,
             source.__name__,
-            args_mapping=args_mapping,
-            args_extra=args_extra,
-            stacklevel=_stacklevel + 1,
+            args_mapping=pack_args.args_mapping,
+            args_extra=pack_args.args_extra,
+            stacklevel=pack_args._stacklevel + 1,
         )
-        forward_args_mapping = None
-        forward_args_extra = None
+        pack_args.args_mapping = None
+        pack_args.args_extra = None
 
     return deprecated_class_fn(
         target=forward_target,
-        deprecated_in=deprecated_in,
-        remove_in=remove_in,
-        num_warns=num_warns,
-        stream=stream,
-        args_mapping=forward_args_mapping,
-        args_extra=forward_args_extra,
-        update_docstring=update_docstring,
-        docstring_style=docstring_style,
+        deprecated_in=pack_args.deprecated_in,
+        remove_in=pack_args.remove_in,
+        num_warns=pack_args.num_warns,
+        stream=pack_args.stream,
+        args_mapping=pack_args.args_mapping,
+        args_extra=pack_args.args_extra,
+        update_docstring=pack_args.update_docstring,
+        docstring_style=pack_args.docstring_style,
         _misconfigured_override=force_misconfigured,
     )(source)
 

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -1033,7 +1033,7 @@ def _packing_descriptor(  # noqa: C901 — property-path guards (fget/fset/fdel 
         # Order-agnostic: unwrap → deprecate inner function → rewrap.
         # Both @classmethod orders produce classmethod(deprecated_wrapper);
         # both @staticmethod orders produce staticmethod(deprecated_wrapper).
-        wrapped_inner = packing_fn(source.__func__, _stacklevel + 1)
+        wrapped_inner = packing_fn(source.__func__, _stacklevel + 2)
         return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)  # type: ignore[return-value]
 
     if isinstance(source, property):
@@ -1092,23 +1092,23 @@ def _packing_descriptor(  # noqa: C901 — property-path guards (fget/fset/fdel 
         # blocked above by TypeError guards and are never reachable here.
         # Without this, ``property.setter(fn)`` would build a plain ``property`` whose new
         # accessor is raw — silently dropping the deprecation warning on attribute writes.
-        _accessor_sl = _stacklevel + 1
+        _accessor_sl = _stacklevel + 2
 
         def _wrap_accessor(fn: Callable) -> Callable:
             """Apply packing_fn to a property accessor with the adjusted stacklevel."""
             return packing_fn(fn, _accessor_sl)
 
         return _DeprecatedProperty(  # type: ignore[return-value]
-            packing_fn(source.fget, _stacklevel + 1) if source.fget is not None else None,
-            packing_fn(source.fset, _stacklevel + 1) if source.fset is not None else None,
-            packing_fn(source.fdel, _stacklevel + 1) if source.fdel is not None else None,
+            packing_fn(source.fget, _stacklevel + 2) if source.fget is not None else None,
+            packing_fn(source.fset, _stacklevel + 2) if source.fset is not None else None,
+            packing_fn(source.fdel, _stacklevel + 2) if source.fdel is not None else None,
             explicit_doc,
             _wrap=_wrap_accessor,
         )
 
     if isinstance(source, cached_property):
         # Order-agnostic @cached_property: unwrap → deprecate func → rewrap.
-        return cached_property(packing_fn(source.func, _stacklevel + 1))  # type: ignore[return-value]
+        return cached_property(packing_fn(source.func, _stacklevel + 2))  # type: ignore[return-value]
 
     return None
 

--- a/src/deprecate/deprecation.py
+++ b/src/deprecate/deprecation.py
@@ -991,6 +991,375 @@ def _build_call_plan(  # noqa: C901, PLR0912
     )
 
 
+def _packing_descriptor(  # noqa: C901
+    source: Union[Callable, classmethod, staticmethod, "property", cached_property],
+    packing_fn: Callable,
+    target: Union[bool, None, Callable, TargetMode, staticmethod, classmethod],
+    args_mapping: Optional[dict[str, Optional[str]]],
+    args_extra: Optional[dict[str, Any]],
+    _stacklevel: int,
+) -> Optional[Callable]:
+    """Wrap descriptor sources (classmethod/staticmethod/property/cached_property).
+
+    Handles order-agnostic descriptor dispatch: unwraps the descriptor, applies
+    *packing_fn* to the underlying callable, and rewraps in the same descriptor type.
+    The ``property`` path validates that incompatible ``@deprecated`` options are not
+    mixed with property decoration.
+
+    Args:
+        source: The callable or descriptor being decorated.
+        packing_fn: The ``packing`` closure from the enclosing ``deprecated()`` call.
+            Passed explicitly so this module-level helper can recurse without capturing
+            a closure variable.
+        target: Raw ``target`` argument from ``@deprecated``; used for ``property``
+            validation guards only.
+        args_mapping: Raw ``args_mapping`` argument; used for ``property`` validation only.
+        args_extra: Raw ``args_extra`` argument; used for ``property`` validation only.
+        _stacklevel: Threaded through to recursive *packing_fn* calls so the decoration-site
+            stacklevel stays correct across nesting levels.
+
+    Returns:
+        Wrapped descriptor when *source* is a descriptor, or ``None`` when *source* is a
+        plain callable (caller should continue to the regular callable path).
+
+    Raises:
+        TypeError: When incompatible ``@deprecated`` options are combined with a ``property``
+            source, or when ``@deprecated`` is applied twice to an already-deprecated
+            property or accessor.
+
+    """
+    if isinstance(source, (classmethod, staticmethod)):
+        # Order-agnostic: unwrap → deprecate inner function → rewrap.
+        # Both @classmethod orders produce classmethod(deprecated_wrapper);
+        # both @staticmethod orders produce staticmethod(deprecated_wrapper).
+        wrapped_inner = packing_fn(source.__func__, _stacklevel + 1)
+        return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)  # type: ignore[return-value]
+
+    if isinstance(source, property):
+        # Order-agnostic @property: unwrap → deprecate fget/fset/fdel → rewrap preserving doc.
+        # All three accessors are wrapped so attribute read, write, and delete each fire the warning.
+        if isinstance(source, _DeprecatedProperty):
+            # Double-decorating an already-deprecated property would wrap every accessor twice,
+            # emitting two FutureWarnings per access and triggering _warn_stacking_misconfiguration
+            # three times. Raise early with a clear message instead of silently double-wrapping.
+            _accessor = source.fget or source.fset or source.fdel
+            _src_name = _accessor.__qualname__ if _accessor is not None else "<property>"
+            raise TypeError(
+                f"`@deprecated` cannot be applied twice to the already-deprecated property `{_src_name}`."
+                " Apply `@deprecated(...)` once; use `.setter()`/`.deleter()` rebinding for additional accessors."
+            )
+        if args_mapping:
+            raise TypeError(f"`args_mapping` is not supported when decorating a `property`. Got: {args_mapping!r}.")
+        if args_extra:
+            raise TypeError(f"`args_extra` is not supported when decorating a `property`. Got: {args_extra!r}.")
+        if callable(target):
+            raise TypeError(
+                f"`target` as a callable is not supported when decorating a `property`. Got: {target!r}."
+                " Use `TargetMode.NOTIFY` or omit `target`."
+            )
+        if target is True or target is TargetMode.ARGS_REMAP:
+            raise TypeError(
+                f"`target=TargetMode.ARGS_REMAP` (or legacy `True`) is not supported when decorating a `property`."
+                f" Got: {target!r}. Use `TargetMode.NOTIFY` or omit `target`."
+            )
+        if target is TargetMode.ATTRS_REMAP:
+            raise TypeError(
+                "`target=TargetMode.ATTRS_REMAP` is not valid for `@deprecated` on a `property`."
+                " `TargetMode.ATTRS_REMAP` is a proxy-only mode — use "
+                "`deprecated_class(attrs_mapping=...)` to deprecate class attribute names."
+            )
+        # Guard against pre-deprecated individual accessors fed into property(...) then
+        # decorated again: property(deprecated_fget) wrapped with @deprecated would double-wrap
+        # fget, emitting two FutureWarnings per read. The _DeprecatedProperty guard above only
+        # catches property-objects that are themselves already _DeprecatedProperty instances.
+        for _acc_name, _acc in (("fget", source.fget), ("fset", source.fset), ("fdel", source.fdel)):
+            if _acc is not None and _has_deprecation_meta(_acc):
+                raise TypeError(
+                    f"`@deprecated` cannot wrap accessor `{getattr(_acc, '__qualname__', repr(_acc))}` of property"
+                    f" `{_acc_name}` — it is already decorated with `@deprecated`."
+                    " Apply `@deprecated` once per accessor."
+                )
+        # Preserve explicit doc only when it differs from fget's doc (author override)
+        # or when fget is absent (setter/deleter-only property with doc= supplied).
+        # Otherwise pass None so property() inherits the deprecation-injected fget.__doc__.
+        explicit_doc = source.__doc__ if (source.fget is None or source.__doc__ != source.fget.__doc__) else None
+
+        # Closure captured on the returned ``_DeprecatedProperty`` so chain-style
+        # ``@value.setter`` / ``@value.deleter`` can re-wrap freshly-supplied accessors
+        # with the same packing config (template_mgs, stream, deprecated_in, remove_in,
+        # num_warns, skip_if, stacklevel). args_mapping / args_extra / callable target are
+        # blocked above by TypeError guards and are never reachable here.
+        # Without this, ``property.setter(fn)`` would build a plain ``property`` whose new
+        # accessor is raw — silently dropping the deprecation warning on attribute writes.
+        _accessor_sl = _stacklevel + 1
+
+        def _wrap_accessor(fn: Callable) -> Callable:
+            """Apply packing_fn to a property accessor with the adjusted stacklevel."""
+            return packing_fn(fn, _accessor_sl)
+
+        return _DeprecatedProperty(  # type: ignore[return-value]
+            packing_fn(source.fget, _stacklevel + 1) if source.fget is not None else None,
+            packing_fn(source.fset, _stacklevel + 1) if source.fset is not None else None,
+            packing_fn(source.fdel, _stacklevel + 1) if source.fdel is not None else None,
+            explicit_doc,
+            _wrap=_wrap_accessor,
+        )
+
+    if isinstance(source, cached_property):
+        # Order-agnostic @cached_property: unwrap → deprecate func → rewrap.
+        return cached_property(packing_fn(source.func, _stacklevel + 1))  # type: ignore[return-value]
+
+    return None
+
+
+def _packing_class_source(
+    source: type,
+    target: Union[bool, None, Callable, TargetMode, staticmethod, classmethod],
+    *,
+    deprecated_in: str,
+    remove_in: str,
+    num_warns: int,
+    stream: Optional[Callable],
+    args_mapping: Optional[dict[str, Optional[str]]],
+    args_extra: Optional[dict[str, Any]],
+    update_docstring: bool,
+    docstring_style: str,
+    _stacklevel: int,
+) -> Callable:
+    """Delegate class-source deprecation to :func:`~deprecate.proxy.deprecated_class`.
+
+    Handles legacy ``target`` sentinel resolution, misconfig detection, and the
+    ``UserWarning`` emitted when ``@deprecated`` is applied directly to a class
+    (deprecated itself since v0.6.0). Extracted from the ``inspect.isclass(source)``
+    branch of ``packing``.
+
+    Args:
+        source: The class being decorated with ``@deprecated``.
+        target: Raw ``target`` argument from ``@deprecated``.
+        deprecated_in: Passed through to ``deprecated_class``.
+        remove_in: Passed through to ``deprecated_class``.
+        num_warns: Passed through to ``deprecated_class``.
+        stream: Warning stream; controls whether the class-deprecation ``UserWarning`` fires.
+        args_mapping: Passed through to ``deprecated_class`` when applicable.
+        args_extra: Passed through to ``deprecated_class`` when applicable.
+        update_docstring: Passed through to ``deprecated_class``.
+        docstring_style: Passed through to ``deprecated_class``.
+        _stacklevel: Stacklevel for ``warnings.warn`` calls; caller passes
+            ``packing``'s ``_stacklevel + 1`` to account for the extra frame.
+
+    Returns:
+        Result of ``deprecated_class(...)(source)``.
+
+    """
+    import importlib
+
+    proxy_module = importlib.import_module("deprecate.proxy")
+    deprecated_class_fn = proxy_module.deprecated_class
+
+    message = (
+        f"Direct use of `@deprecated` on class `{source.__name__}` is deprecated since `v0.6.0`."
+        " Use `@deprecated_class(...)` instead. This will become a `TypeError` in a future release."
+    )
+    if target is not None and not inspect.isclass(target) and not isinstance(target, TargetMode):
+        message += (
+            " Note: non-class `target` values are ignored when deprecating classes;"
+            " use `@deprecated_class(target=...)` instead."
+        )
+    if stream is not None:
+        warnings.warn(message, UserWarning, stacklevel=_stacklevel)
+
+    # _DeprecatedProxy auto-promotes ``None+args_mapping`` to ARGS_REMAP and reads
+    # ``misconfigured`` from its own ``target is False`` check — by that point
+    # the original sentinel is already gone.
+    class_misconfigured = target is False
+    if isinstance(target, TargetMode):
+        forward_target: Any = target
+    elif callable(target) and inspect.isclass(target):
+        forward_target = target
+    elif target is None or isinstance(target, bool):
+        # None/True/False on a class is a class-misconfiguration, not a callable
+        # deprecation sentinel — the class misconfig UserWarning is the relevant signal.
+        forward_target = TargetMode._from_legacy(target, stacklevel=_stacklevel + 1)
+    else:
+        forward_target = TargetMode.NOTIFY
+
+    # Capture all misconfig signals *before* rewriting forward_args_mapping / forward_args_extra
+    # so we can forward them via ``_misconfigured_override`` instead of mutating the frozen
+    # ``DeprecationConfig`` after construction. NOTIFY + (args_mapping or args_extra) is the
+    # second misconfig source the proxy can no longer detect once we strip those fields.
+    notify_misconfig = forward_target is TargetMode.NOTIFY and bool(args_mapping or args_extra)
+    force_misconfigured = class_misconfigured or notify_misconfig
+
+    # Proxy metadata is immutable after construction; stale mapping persists to audit tools.
+    forward_args_mapping = args_mapping
+    forward_args_extra = args_extra
+    if forward_target is TargetMode.NOTIFY:
+        TargetMode._validate(
+            forward_target,
+            source.__name__,
+            args_mapping=args_mapping,
+            args_extra=args_extra,
+            stacklevel=_stacklevel + 1,
+        )
+        forward_args_mapping = None
+        forward_args_extra = None
+
+    return deprecated_class_fn(
+        target=forward_target,
+        deprecated_in=deprecated_in,
+        remove_in=remove_in,
+        num_warns=num_warns,
+        stream=stream,
+        args_mapping=forward_args_mapping,
+        args_extra=forward_args_extra,
+        update_docstring=update_docstring,
+        docstring_style=docstring_style,
+        _misconfigured_override=force_misconfigured,
+    )(source)
+
+
+def _detect_positional_only(
+    target: Union[Callable, TargetMode],
+    source: Callable,
+    stream: Optional[Callable],
+    warn_stacklevel: int,
+) -> tuple[frozenset[str], tuple[str, ...]]:
+    """Inspect *target* for POSITIONAL_ONLY parameters and emit a ``UserWarning`` when found.
+
+    Called at decoration time so the warning fires once and the results are stored in
+    :class:`~deprecate._types.DeprecationConfig` for the call-time dispatcher.
+
+    Args:
+        target: Normalised target from :func:`_normalize_target` — may be a
+            :class:`TargetMode` or a callable.  Non-callables return empty results immediately.
+        source: The decorated callable; used only in the warning message.
+        stream: Warning stream; when ``None`` the warning is suppressed.
+        warn_stacklevel: ``stacklevel`` forwarded to ``warnings.warn``.  Caller passes
+            ``packing``'s ``_stacklevel + 1`` to account for the extra frame.
+
+    Returns:
+        Tuple of ``(target_positional_only, target_positional_only_order)`` where
+        ``target_positional_only`` is the frozenset of POSITIONAL_ONLY param names and
+        ``target_positional_only_order`` is the full parameter-name tuple in declaration order.
+
+    """
+    if not callable(target):
+        return frozenset(), ()
+    try:
+        tgt_sig = inspect.signature(target)
+    except (TypeError, ValueError):
+        return frozenset(), ()
+    target_positional_only = frozenset(
+        name for name, p in tgt_sig.parameters.items() if p.kind is inspect.Parameter.POSITIONAL_ONLY
+    )
+    target_positional_only_order: tuple[str, ...] = tuple(tgt_sig.parameters.keys()) if target_positional_only else ()
+    warn_set = target_positional_only - {"self", "cls"}
+    if warn_set and stream is not None:
+        warnings.warn(
+            f"`@deprecated(target={getattr(target, '__name__', repr(target))!r})` on"
+            f" `{source.__name__}`: target parameter(s)"
+            f" {sorted(warn_set)!r} are POSITIONAL_ONLY and cannot be"
+            " forwarded as kwargs. Calls will pass these values positionally."
+            " Consider removing `/` from the target signature.",
+            UserWarning,
+            stacklevel=warn_stacklevel,
+        )
+    return target_positional_only, target_positional_only_order
+
+
+def _resolve_stored_target(
+    target: Union[bool, None, Callable, TargetMode, staticmethod, classmethod],
+) -> Union[TargetMode, Callable]:
+    """Normalise *target* for storage in :class:`~deprecate._types.DeprecationConfig`.
+
+    Converts legacy bool/None sentinels to :class:`TargetMode` members and strips
+    descriptor wrappers so audit tools see the underlying callable rather than a raw
+    descriptor object.
+
+    Args:
+        target: Raw ``target`` argument from ``@deprecated``.
+
+    Returns:
+        Normalised value suitable for ``DeprecationConfig.target``.
+
+    Note:
+        Class targets are kept verbatim — :func:`_normalize_target` remaps
+        ``class → __init__`` at decoration time for the wrapper closure, but the stored
+        value must preserve the user-facing class so audit and docstring consumers see
+        the original target.
+
+    """
+    if target is None or isinstance(target, bool):
+        # Enum-normalised target stored so audit does not re-derive from raw sentinel.
+        return TargetMode._from_legacy(target, stacklevel=None)
+    if isinstance(target, TargetMode):
+        return target
+    if isinstance(target, (staticmethod, classmethod)):
+        return target.__func__  # audit sees the function, not the descriptor
+    return target
+
+
+async def _invoke_async(
+    source: Callable,
+    plan: _CallPlan,
+    dep_cfg: DeprecationConfig,
+    source_has_var_positional: bool,
+    args: tuple,
+) -> Any:  # noqa: ANN401
+    """Dispatch async call after :func:`_build_call_plan` has resolved the outcome."""
+    if plan.short_circuit:
+        if source_has_var_positional:
+            return await source(*args, **plan.original_kwargs)
+        return await source(**plan.resolved_kwargs)
+    if plan.target_func is None:
+        if source_has_var_positional:
+            call_kwargs = plan.original_kwargs if not plan.reason_argument else plan.resolved_kwargs
+            return await source(*args, **call_kwargs)
+        return await source(**plan.resolved_kwargs)
+    # Sync target under async source: invoke directly so callers can migrate without forcing
+    # every legacy target to be redeclared ``async def``.
+    if dep_cfg.target_positional_only:
+        _pos_args, _kw_args = _split_positional_only_kwargs(
+            dep_cfg.target_positional_only_order, plan.resolved_kwargs, dep_cfg.target_positional_only
+        )
+        if inspect.iscoroutinefunction(plan.target_func):
+            return await plan.target_func(*_pos_args, **_kw_args)
+        return plan.target_func(*_pos_args, **_kw_args)
+    if inspect.iscoroutinefunction(plan.target_func):
+        return await plan.target_func(**plan.resolved_kwargs)
+    return plan.target_func(**plan.resolved_kwargs)
+
+
+def _invoke_sync(
+    source: Callable,
+    plan: _CallPlan,
+    dep_cfg: DeprecationConfig,
+    source_has_var_positional: bool,
+    args: tuple,
+) -> Any:  # noqa: ANN401
+    """Dispatch sync call after :func:`_build_call_plan` has resolved the outcome."""
+    if plan.short_circuit:
+        if source_has_var_positional:
+            return source(*args, **plan.original_kwargs)
+        return source(**plan.resolved_kwargs)
+    if plan.target_func is None:
+        if source_has_var_positional:
+            call_kwargs = plan.original_kwargs if not plan.reason_argument else plan.resolved_kwargs
+            return source(*args, **call_kwargs)
+        return source(**plan.resolved_kwargs)
+    if inspect.iscoroutinefunction(plan.target_func):
+        raise TypeError(
+            f"Async target `{plan.target_func.__name__}` cannot be invoked from a sync wrapper."
+            f" Declare `{source.__name__}` as `async def`, or replace the target with a sync callable."
+        )
+    if dep_cfg.target_positional_only:
+        _pos_args, _kw_args = _split_positional_only_kwargs(
+            dep_cfg.target_positional_only_order, plan.resolved_kwargs, dep_cfg.target_positional_only
+        )
+        return plan.target_func(*_pos_args, **_kw_args)
+    return plan.target_func(**plan.resolved_kwargs)
+
+
 def deprecated(  # noqa: C901
     target: Union[bool, None, Callable, TargetMode, staticmethod, classmethod] = TargetMode.NOTIFY,
     deprecated_in: str = "",
@@ -1121,88 +1490,18 @@ def deprecated(  # noqa: C901
     """
     normalized_docstring_style = normalize_docstring_style(docstring_style)
 
-    def packing(  # noqa: C901, PLR0912
+    def packing(  # noqa: C901
         source: Union[Callable, classmethod, staticmethod, property, cached_property],
         _stacklevel: int = 2,
     ) -> Callable:
-        # Order-agnostic @classmethod/@staticmethod: unwrap → deprecate inner function → rewrap.
-        # Both @classmethod orders produce classmethod(deprecated_wrapper);
-        # both @staticmethod orders produce staticmethod(deprecated_wrapper).
-        if isinstance(source, (classmethod, staticmethod)):
-            wrapped_inner = packing(source.__func__, _stacklevel + 1)
-            return classmethod(wrapped_inner) if isinstance(source, classmethod) else staticmethod(wrapped_inner)  # type: ignore[return-value]
-        # Order-agnostic @property: unwrap → deprecate fget/fset/fdel → rewrap preserving doc.
-        # All three accessors are wrapped so attribute read, write, and delete each fire the warning.
-        if isinstance(source, property):
-            if isinstance(source, _DeprecatedProperty):
-                # Double-decorating an already-deprecated property would wrap every accessor twice,
-                # emitting two FutureWarnings per access and triggering _warn_stacking_misconfiguration
-                # three times. Raise early with a clear message instead of silently double-wrapping.
-                _accessor = source.fget or source.fset or source.fdel
-                _src_name = _accessor.__qualname__ if _accessor is not None else "<property>"
-                raise TypeError(
-                    f"`@deprecated` cannot be applied twice to the already-deprecated property `{_src_name}`."
-                    " Apply `@deprecated(...)` once; use `.setter()`/`.deleter()` rebinding for additional accessors."
-                )
-            if args_mapping:
-                raise TypeError(f"`args_mapping` is not supported when decorating a `property`. Got: {args_mapping!r}.")
-            if args_extra:
-                raise TypeError(f"`args_extra` is not supported when decorating a `property`. Got: {args_extra!r}.")
-            if callable(target):
-                raise TypeError(
-                    f"`target` as a callable is not supported when decorating a `property`. Got: {target!r}."
-                    " Use `TargetMode.NOTIFY` or omit `target`."
-                )
-            if target is True or target is TargetMode.ARGS_REMAP:
-                raise TypeError(
-                    f"`target=TargetMode.ARGS_REMAP` (or legacy `True`) is not supported when decorating a `property`."
-                    f" Got: {target!r}. Use `TargetMode.NOTIFY` or omit `target`."
-                )
-            if target is TargetMode.ATTRS_REMAP:
-                raise TypeError(
-                    "`target=TargetMode.ATTRS_REMAP` is not valid for `@deprecated` on a `property`."
-                    " `TargetMode.ATTRS_REMAP` is a proxy-only mode — use "
-                    "`deprecated_class(attrs_mapping=...)` to deprecate class attribute names."
-                )
-            # Guard against pre-deprecated individual accessors fed into property(...) then
-            # decorated again: property(deprecated_fget) wrapped with @deprecated would double-wrap
-            # fget, emitting two FutureWarnings per read. The _DeprecatedProperty guard above only
-            # catches property-objects that are themselves already _DeprecatedProperty instances.
-            for _acc_name, _acc in (("fget", source.fget), ("fset", source.fset), ("fdel", source.fdel)):
-                if _acc is not None and _has_deprecation_meta(_acc):
-                    raise TypeError(
-                        f"`@deprecated` cannot wrap accessor `{getattr(_acc, '__qualname__', repr(_acc))}` of property"
-                        f" `{_acc_name}` — it is already decorated with `@deprecated`."
-                        " Apply `@deprecated` once per accessor."
-                    )
-            # Preserve explicit doc only when it differs from fget's doc (author override)
-            # or when fget is absent (setter/deleter-only property with doc= supplied).
-            # Otherwise pass None so property() inherits the deprecation-injected fget.__doc__.
-            explicit_doc = source.__doc__ if (source.fget is None or source.__doc__ != source.fget.__doc__) else None
-
-            # Closure captured on the returned ``_DeprecatedProperty`` so chain-style
-            # ``@value.setter`` / ``@value.deleter`` can re-wrap freshly-supplied accessors
-            # with the same packing config (template_mgs, stream, deprecated_in, remove_in,
-            # num_warns, skip_if, stacklevel). args_mapping / args_extra / callable target are
-            # blocked above by TypeError guards and are never reachable here.
-            # Without this, ``property.setter(fn)`` would build a plain ``property`` whose new
-            # accessor is raw — silently dropping the deprecation warning on attribute writes.
-            _accessor_sl = _stacklevel + 1
-
-            def _wrap_accessor(fn: Callable) -> Callable:
-                """Apply packing to a property accessor with the adjusted stacklevel."""
-                return packing(fn, _accessor_sl)
-
-            return _DeprecatedProperty(  # type: ignore[return-value]
-                packing(source.fget, _stacklevel + 1) if source.fget is not None else None,
-                packing(source.fset, _stacklevel + 1) if source.fset is not None else None,
-                packing(source.fdel, _stacklevel + 1) if source.fdel is not None else None,
-                explicit_doc,
-                _wrap=_wrap_accessor,
-            )
-        # Order-agnostic @cached_property: unwrap → deprecate func → rewrap.
-        if isinstance(source, cached_property):
-            return cached_property(packing(source.func, _stacklevel + 1))  # type: ignore[return-value]
+        _descriptor_result = _packing_descriptor(source, packing, target, args_mapping, args_extra, _stacklevel)
+        if _descriptor_result is not None:
+            return _descriptor_result
+        # mypy narrowing: _packing_descriptor handles all descriptor types via early return;
+        # remaining code (including captured closures) only executes for plain Callable.
+        # isinstance guard is required — cast() does not propagate narrowing into closure bodies.
+        if isinstance(source, (classmethod, staticmethod, property, cached_property)):
+            raise AssertionError(f"unreachable: {type(source)!r} was not handled by _packing_descriptor")
         # Probe ``template_mgs`` against every documented placeholder so typos and malformed
         # conversion specifiers fail at decoration time instead of inside ``wrapped_fn``.
         _validate_template_mgs(template_mgs)
@@ -1217,71 +1516,19 @@ def deprecated(  # noqa: C901
                 stacklevel=_stacklevel,
             )
         if inspect.isclass(source):
-            import importlib
-
-            proxy_module = importlib.import_module("deprecate.proxy")
-            deprecated_class = proxy_module.deprecated_class
-
-            message = (
-                f"Direct use of `@deprecated` on class `{source.__name__}` is deprecated since `v0.6.0`."
-                " Use `@deprecated_class(...)` instead. This will become a `TypeError` in a future release."
-            )
-            if target is not None and not inspect.isclass(target) and not isinstance(target, TargetMode):
-                message += (
-                    " Note: non-class `target` values are ignored when deprecating classes;"
-                    " use `@deprecated_class(target=...)` instead."
-                )
-            if stream is not None:
-                warnings.warn(message, UserWarning, stacklevel=_stacklevel)
-
-            # _DeprecatedProxy auto-promotes ``None+args_mapping`` to ARGS_REMAP and reads
-            # ``misconfigured`` from its own ``target is False`` check — by that point
-            # the original sentinel is already gone.
-            class_misconfigured = target is False
-            if isinstance(target, TargetMode):
-                forward_target: Any = target
-            elif callable(target) and inspect.isclass(target):
-                forward_target = target
-            elif target is None or isinstance(target, bool):
-                # None/True/False on a class is a class-misconfiguration, not a callable
-                # deprecation sentinel — the class misconfig UserWarning is the relevant signal.
-                forward_target = TargetMode._from_legacy(target, stacklevel=_stacklevel + 1)
-            else:
-                forward_target = TargetMode.NOTIFY
-
-            # Capture all misconfig signals *before* rewriting forward_args_mapping / forward_args_extra
-            # so we can forward them via ``_misconfigured_override`` instead of mutating the frozen
-            # ``DeprecationConfig`` after construction. NOTIFY + (args_mapping or args_extra) is the
-            # second misconfig source the proxy can no longer detect once we strip those fields.
-            notify_misconfig = forward_target is TargetMode.NOTIFY and bool(args_mapping or args_extra)
-            force_misconfigured = class_misconfigured or notify_misconfig
-
-            # Proxy metadata is immutable after construction; stale mapping persists to audit tools.
-            forward_args_mapping = args_mapping
-            forward_args_extra = args_extra
-            if forward_target is TargetMode.NOTIFY:
-                TargetMode._validate(
-                    forward_target,
-                    source.__name__,
-                    args_mapping=args_mapping,
-                    args_extra=args_extra,
-                    stacklevel=_stacklevel + 1,
-                )
-                forward_args_mapping = None
-                forward_args_extra = None
-
-            return deprecated_class(
-                target=forward_target,
+            return _packing_class_source(
+                source,
+                target,
                 deprecated_in=deprecated_in,
                 remove_in=remove_in,
                 num_warns=num_warns,
                 stream=stream,
-                args_mapping=forward_args_mapping,
-                args_extra=forward_args_extra,
+                args_mapping=args_mapping,
+                args_extra=args_extra,
                 update_docstring=update_docstring,
                 docstring_style=docstring_style,
-                _misconfigured_override=force_misconfigured,
-            )(source)
+                _stacklevel=_stacklevel + 1,
+            )
         # Cross-class guard runs before remapping; class targets skip it because
         # constructor forwarding (target=NewCls on __init__) is always valid.
         # Descriptor targets: unwrap __func__ so the guard can inspect the qualname;
@@ -1318,46 +1565,11 @@ def deprecated(  # noqa: C901
             param.kind == inspect.Parameter.VAR_POSITIONAL for param in _get_signature(source).parameters.values()
         )
 
-        # Detect POSITIONAL_ONLY params on the callable target at decoration time.
-        # When found: emit UserWarning (mirrors proxy behaviour) and record names so
-        # the call dispatcher can split them out of kwargs and pass positionally.
-        _target_positional_only: frozenset[str] = frozenset()
-        _target_positional_only_order: tuple[str, ...] = ()
-        if callable(_target):
-            try:
-                _tgt_sig = inspect.signature(_target)
-            except (TypeError, ValueError):
-                pass
-            else:
-                _target_positional_only = frozenset(
-                    name for name, p in _tgt_sig.parameters.items() if p.kind is inspect.Parameter.POSITIONAL_ONLY
-                )
-                if _target_positional_only:
-                    _target_positional_only_order = tuple(_tgt_sig.parameters.keys())
-            _warn_positional_only = _target_positional_only - {"self", "cls"}
-            if _warn_positional_only and stream is not None:
-                warnings.warn(
-                    f"`@deprecated(target={getattr(_target, '__name__', repr(_target))!r})` on"
-                    f" `{source.__name__}`: target parameter(s)"
-                    f" {sorted(_warn_positional_only)!r} are POSITIONAL_ONLY and cannot be"
-                    " forwarded as kwargs. Calls will pass these values positionally."
-                    " Consider removing `/` from the target signature.",
-                    UserWarning,
-                    stacklevel=_stacklevel,
-                )
+        _target_positional_only, _target_positional_only_order = _detect_positional_only(
+            _target, source, stream, _stacklevel + 1
+        )
 
-        # Enum-normalised target stored so audit does not re-derive from raw sentinel.
-        # Class targets kept verbatim: _normalize_target() remaps class→__init__ at
-        # decoration time for the wrapper closure, but stored_target keeps the user-facing
-        # class so audit and docstring consumers see the original target.
-        if target is None or isinstance(target, bool):
-            stored_target: Any = TargetMode._from_legacy(target, stacklevel=None)
-        elif isinstance(target, TargetMode):
-            stored_target = target
-        elif isinstance(target, (staticmethod, classmethod)):
-            stored_target = target.__func__  # audit sees the function, not the descriptor
-        else:
-            stored_target = target
+        stored_target = _resolve_stored_target(target)
         misconfigured = target is False or _function_misconfigured
         dep_meta = DeprecationConfig(
             deprecated_in=deprecated_in,
@@ -1410,28 +1622,7 @@ def deprecated(  # noqa: C901
                     source_is_stacked=_source_is_stacked,
                 )
 
-                if plan.short_circuit:
-                    if source_has_var_positional:
-                        return await source(*args, **plan.original_kwargs)
-                    return await source(**plan.resolved_kwargs)
-
-                if plan.target_func is None:
-                    if source_has_var_positional:
-                        call_kwargs = plan.original_kwargs if not plan.reason_argument else plan.resolved_kwargs
-                        return await source(*args, **call_kwargs)
-                    return await source(**plan.resolved_kwargs)
-                # Sync target under async source: invoke directly so callers can migrate from a sync to async
-                # API in one step without forcing every legacy target to be redeclared ``async def``.
-                if _dep_cfg.target_positional_only:
-                    _pos_args, _kw_args = _split_positional_only_kwargs(
-                        _dep_cfg.target_positional_only_order, plan.resolved_kwargs, _dep_cfg.target_positional_only
-                    )
-                    if inspect.iscoroutinefunction(plan.target_func):
-                        return await plan.target_func(*_pos_args, **_kw_args)
-                    return plan.target_func(*_pos_args, **_kw_args)
-                if inspect.iscoroutinefunction(plan.target_func):
-                    return await plan.target_func(**plan.resolved_kwargs)
-                return plan.target_func(**plan.resolved_kwargs)
+                return await _invoke_async(source, plan, _dep_cfg, source_has_var_positional, args)
 
             async_wrapped_fn_typed = cast(_DeprecatedCallable, async_wrapped_fn)
             async_wrapped_fn_typed.__deprecated__ = dep_meta
@@ -1473,27 +1664,7 @@ def deprecated(  # noqa: C901
                 source_is_stacked=_source_is_stacked,
             )
 
-            if plan.short_circuit:
-                if source_has_var_positional:
-                    return source(*args, **plan.original_kwargs)
-                return source(**plan.resolved_kwargs)
-
-            if plan.target_func is None:
-                if source_has_var_positional:
-                    call_kwargs = plan.original_kwargs if not plan.reason_argument else plan.resolved_kwargs
-                    return source(*args, **call_kwargs)
-                return source(**plan.resolved_kwargs)
-            if inspect.iscoroutinefunction(plan.target_func):
-                raise TypeError(
-                    f"Async target `{plan.target_func.__name__}` cannot be invoked from a sync wrapper."
-                    f" Declare `{source.__name__}` as `async def`, or replace the target with a sync callable."
-                )
-            if _dep_cfg.target_positional_only:
-                _pos_args, _kw_args = _split_positional_only_kwargs(
-                    _dep_cfg.target_positional_only_order, plan.resolved_kwargs, _dep_cfg.target_positional_only
-                )
-                return plan.target_func(*_pos_args, **_kw_args)
-            return plan.target_func(**plan.resolved_kwargs)
+            return _invoke_sync(source, plan, _dep_cfg, source_has_var_positional, args)
 
         wrapped_fn_typed = cast(_DeprecatedCallable, wrapped_fn)
         wrapped_fn_typed.__deprecated__ = dep_meta

--- a/src/deprecate/docstring/inject.py
+++ b/src/deprecate/docstring/inject.py
@@ -447,7 +447,72 @@ def _build_general_notice_lines(dep_info: DeprecationConfig) -> list[str]:
     return result
 
 
-def _update_docstring_with_deprecation(wrapped_fn: object) -> None:  # noqa: C901, PLR0912
+def _has_deprecation_block(doc_lines: list[str], block_lines: list[str]) -> bool:
+    """Return True if ``block_lines`` appears as a contiguous block in ``doc_lines``.
+
+    Lines are compared using ``.strip()`` to ignore leading/trailing whitespace.
+
+    """
+    if not block_lines:
+        return False
+    max_start = len(doc_lines) - len(block_lines)
+    if max_start < 0:
+        return False
+    first = block_lines[0].strip()
+    for start in range(max_start + 1):
+        if doc_lines[start].strip() != first:
+            continue
+        if all(doc_lines[start + offset].strip() == block_lines[offset].strip() for offset in range(len(block_lines))):
+            return True
+    return False
+
+
+def _inject_args_mapping_section(lines: list[str], dep_info: DeprecationConfig) -> tuple[list[str], bool]:
+    """Apply per-argument inline deprecation notes to docstring lines.
+
+    Returns ``(updated_lines, all_args_found)`` where ``all_args_found`` is ``True`` when every key in
+    ``dep_info.args_mapping`` was located in the docstring.
+
+    """
+    all_args_found = True
+    for arg_name, new_arg in dep_info.args_mapping.items():  # type: ignore[union-attr]
+        note = _build_arg_deprecation_note(new_arg, dep_info.deprecated_in, dep_info.remove_in)
+        lines, found = _annotate_google_style_arg(lines, arg_name, note)
+        if not found:
+            lines, found = _annotate_sphinx_style_arg(lines, arg_name, note)
+        if not found:
+            all_args_found = False
+    return lines, all_args_found
+
+
+def _append_notice_after_inline_args(lines: list[str], body_indent: str, deprecation_lines: list[str]) -> list[str]:
+    """Append general deprecation notice after inline per-arg annotations."""
+    while lines and not lines[-1].strip():
+        lines.pop()
+    lines.append("")
+    lines.extend(body_indent + ln for ln in deprecation_lines)
+    return lines
+
+
+def _insert_notice_before_section(lines: list[str], body_indent: str, deprecation_lines: list[str]) -> str:
+    """Insert general deprecation notice before the first Google/NumPy section header."""
+    indented = [body_indent + ln for ln in deprecation_lines]
+    insert_idx = find_docstring_insertion_index(lines)
+    prefix = lines[:insert_idx]
+    suffix = lines[insert_idx:]
+    if prefix and prefix[-1].strip():
+        prefix.append("")
+    prefix.extend(indented)
+    if suffix:
+        while suffix and not suffix[-1].strip():  # Python 3.13 may leave trailing blanks
+            suffix.pop()
+        if suffix and suffix[0].strip():
+            prefix.append("")
+        prefix.extend(suffix)
+    return "\n".join(prefix)
+
+
+def _update_docstring_with_deprecation(wrapped_fn: object) -> None:
     """Annotate a function's docstring with deprecation information.
 
     Two paths are taken depending on whether ``args_mapping`` is set:
@@ -538,14 +603,7 @@ def _update_docstring_with_deprecation(wrapped_fn: object) -> None:  # noqa: C90
     dep_info = wrapped_fn.__deprecated__
 
     if dep_info.args_mapping:
-        all_args_found = True
-        for arg_name, new_arg in dep_info.args_mapping.items():
-            note = _build_arg_deprecation_note(new_arg, dep_info.deprecated_in, dep_info.remove_in)
-            lines, found = _annotate_google_style_arg(lines, arg_name, note)
-            if not found:
-                lines, found = _annotate_sphinx_style_arg(lines, arg_name, note)
-            if not found:
-                all_args_found = False  # missing arg → general notice still needed
+        lines, all_args_found = _inject_args_mapping_section(lines, dep_info)
         # ARGS_REMAP (or legacy target=True) means only individual args are deprecated,
         # not the function itself.
         if all_args_found and dep_info.target is TargetMode.ARGS_REMAP:
@@ -553,27 +611,6 @@ def _update_docstring_with_deprecation(wrapped_fn: object) -> None:  # noqa: C90
             return
 
     deprecation_lines = _build_general_notice_lines(dep_info)
-
-    def _has_deprecation_block(doc_lines: list[str], block_lines: list[str]) -> bool:
-        """Return True if ``block_lines`` appears as a contiguous block in ``doc_lines``.
-
-        Lines are compared using ``.strip()`` to ignore leading/trailing whitespace.
-
-        """
-        if not block_lines:
-            return False
-        max_start = len(doc_lines) - len(block_lines)
-        if max_start < 0:
-            return False
-        first = block_lines[0].strip()
-        for start in range(max_start + 1):
-            if doc_lines[start].strip() != first:
-                continue
-            if all(
-                doc_lines[start + offset].strip() == block_lines[offset].strip() for offset in range(len(block_lines))
-            ):
-                return True
-        return False
 
     # Guard idempotency by checking for the full deprecation block, not just the marker line.
     if _has_deprecation_block(lines, deprecation_lines):
@@ -583,25 +620,7 @@ def _update_docstring_with_deprecation(wrapped_fn: object) -> None:  # noqa: C90
         "",
     )
     if dep_info.args_mapping:
-        # Append after inline arg notes to preserve existing section order.
-        while lines and not lines[-1].strip():
-            lines.pop()
-        lines.append("")
-        lines.extend(body_indent + ln for ln in deprecation_lines)
+        lines = _append_notice_after_inline_args(lines, body_indent, deprecation_lines)
         wrapped_fn.__doc__ = inspect.cleandoc("\n".join(lines))
     else:
-        # Insert before the first section so doc parsers see the notice first.
-        deprecation_lines = [body_indent + ln for ln in deprecation_lines]
-        insert_idx = find_docstring_insertion_index(lines)
-        prefix = lines[:insert_idx]
-        suffix = lines[insert_idx:]
-        if prefix and prefix[-1].strip():
-            prefix.append("")
-        prefix.extend(deprecation_lines)
-        if suffix:
-            while suffix and not suffix[-1].strip():  # Python 3.13 may leave trailing blanks
-                suffix.pop()
-            if suffix and suffix[0].strip():
-                prefix.append("")
-            prefix.extend(suffix)
-        wrapped_fn.__doc__ = inspect.cleandoc("\n".join(prefix))
+        wrapped_fn.__doc__ = inspect.cleandoc(_insert_notice_before_section(lines, body_indent, deprecation_lines))

--- a/src/deprecate/docstring/inject.py
+++ b/src/deprecate/docstring/inject.py
@@ -475,7 +475,7 @@ def _inject_args_mapping_section(lines: list[str], dep_info: DeprecationConfig) 
 
     """
     all_args_found = True
-    for arg_name, new_arg in dep_info.args_mapping.items():  # type: ignore[union-attr]
+    for arg_name, new_arg in (dep_info.args_mapping or {}).items():
         note = _build_arg_deprecation_note(new_arg, dep_info.deprecated_in, dep_info.remove_in)
         lines, found = _annotate_google_style_arg(lines, arg_name, note)
         if not found:

--- a/src/deprecate/proxy.py
+++ b/src/deprecate/proxy.py
@@ -48,7 +48,8 @@ from deprecate.utils import _get_args_mapping_positional_only_keys, _is_dataclas
 
 #: Stacklevel from inside ``_warn`` to the caller's frame.
 #: Chain: ``caller → __getattr__/__getitem__/__iter__/__call__ → _warn → stream → warnings.warn``.
-#: From ``warnings.warn`` upwards: ``1=_warn``, ``2=accessor`` (e.g. ``__getattr__``), ``3=caller``.
+#: From ``warnings.warn`` upwards: ``1=_warn``, ``2=accessor``, ``3=caller``.
+#: Helpers one level deeper (e.g. ``_proxy_call_args_remap``) pass ``_extra_frames=1``.
 _DEFAULT_STACKLEVEL_TO_CALLER: int = 3
 
 
@@ -444,7 +445,7 @@ class _DeprecatedProxy:
             "remove_in": dep.remove_in,
         }
 
-    def _warn(self, *, arg_name: Optional[str] = None) -> None:
+    def _warn(self, *, arg_name: Optional[str] = None, _extra_frames: int = 0) -> None:
         """Emit a deprecation warning if the warn budget is not exhausted.
 
         Args:
@@ -453,6 +454,7 @@ class _DeprecatedProxy:
                 ``cfg.num_warns``.  When provided alongside an ``args_mapping`` entry, the emitted message uses the
                 per-argument template (`old -> new`) rather than the generic callable template — matching the
                 decorator's argument-deprecation form.
+            _extra_frames: Additional Python helper frames between the public accessor and ``_warn``.
 
         """
         cfg = self._cfg
@@ -473,7 +475,7 @@ class _DeprecatedProxy:
         # in ``deprecation.py``: when ``stream`` does not accept a ``stacklevel`` kwarg (e.g. ``print``, custom
         # callables), fall back to a positional call.
         try:
-            stream(msg, stacklevel=_DEFAULT_STACKLEVEL_TO_CALLER)
+            stream(msg, stacklevel=_DEFAULT_STACKLEVEL_TO_CALLER + _extra_frames)
         except TypeError:
             stream(msg)
         if arg_name is not None:
@@ -854,14 +856,14 @@ def _proxy_call_args_remap(
     proxy: _DeprecatedProxy,
     dep: DeprecationConfig,
     cfg: _ProxyConfig,
-    args: tuple,
-    kwargs: dict,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
 ) -> Any:  # noqa: ANN401
     """Handle ``TargetMode.ARGS_REMAP`` branch of ``__call__``: warn per deprecated kwarg, remap, call obj."""
     mapping = dep.args_mapping or {}
     for old_key in mapping:
         if old_key in kwargs:
-            proxy._warn(arg_name=old_key)
+            proxy._warn(arg_name=old_key, _extra_frames=1)
     mapped_kwargs = proxy._apply_args_mapping(kwargs)
     mapped_kwargs = proxy._merge_args_extra(mapped_kwargs)
     if dep.args_mapping_positional_only and dep.args_mapping:
@@ -878,16 +880,16 @@ def _proxy_call_callable_with_mapping(
     proxy: _DeprecatedProxy,
     dep: DeprecationConfig,
     target_fn: Callable[..., Any],
-    args: tuple,
-    kwargs: dict,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
 ) -> Any:  # noqa: ANN401
     """Handle callable-target + args_mapping branch of ``__call__``: warn per kwarg, remap, forward."""
     mapping = dep.args_mapping or {}
     for old_key in mapping:
         if old_key in kwargs:
-            proxy._warn(arg_name=old_key)
+            proxy._warn(arg_name=old_key, _extra_frames=1)
     if not any(old_key in kwargs for old_key in mapping):
-        proxy._warn()
+        proxy._warn(_extra_frames=1)
     mapped_kwargs = proxy._apply_args_mapping(kwargs)
     mapped_kwargs = proxy._merge_args_extra(mapped_kwargs)
     if dep.args_mapping_positional_only and dep.args_mapping:

--- a/src/deprecate/proxy.py
+++ b/src/deprecate/proxy.py
@@ -256,7 +256,7 @@ class _DeprecatedProxy:
                 " when `target` is provided, or on the wrapped class."
             )
 
-    def __init__(  # noqa: C901, PLR0912
+    def __init__(
         self,
         obj: Any,  # noqa: ANN401
         name: str,
@@ -304,47 +304,20 @@ class _DeprecatedProxy:
         misconfigured = target is False or _misconfigured_override
         if isinstance(target, bool):
             target = TargetMode._from_legacy_proxy(target, args_mapping=args_mapping, stacklevel=3)
-        # Dataclass dual-surface auto-expand: when the target (or wrapped object) is a @dataclass,
-        # copy attrs_mapping entries whose redirect points to a dataclass field into args_mapping so
-        # that both `instance.old_field` (attribute access) and `DC(old_field=5)` (constructor kwarg)
-        # emit a FutureWarning from a single deprecated_class() call.  Keys already present in
-        # args_mapping are left untouched (explicit user values always win).
-        _auto_expanded: list[str] = []
         _dc_check = _DeprecatedProxy._get_static_attr_owner(
             target if target is not None and not isinstance(target, (TargetMode, bool)) else obj
         )
         if args_mapping is not None:
             args_mapping = dict(args_mapping)
-        if attrs_mapping and _is_dataclass_target(_dc_check):
-            _init_param_names: set[str] = set(inspect.signature(_dc_check).parameters)
-            for _old_key, _mapping_val in attrs_mapping.items():
-                if _mapping_val in _init_param_names:
-                    if args_mapping is None:
-                        args_mapping = {}
-                    if _old_key not in args_mapping:
-                        args_mapping[_old_key] = _mapping_val
-                        _auto_expanded.append(_old_key)
+        # Dataclass dual-surface auto-expand: copy attrs_mapping entries that name a dataclass field
+        # into args_mapping so both attribute access and constructor kwarg paths emit a FutureWarning.
+        args_mapping, _auto_expanded = _expand_dc_attrs_to_args(_dc_check, attrs_mapping, args_mapping)
         # When auto-expand produced a non-empty args_mapping and the user provided no explicit
-        # target, set target = obj (the dataclass itself) so that the callable-target + both-
-        # mappings path in __call__ and _validate_proxy activates both surfaces without
-        # triggering the ARGS_REMAP + attrs_mapping misconfiguration check.
+        # target, set target = obj so the callable-target + both-mappings path activates both surfaces.
         if _auto_expanded and target is None:
             target = obj
-        # Kwargs-compatibility guard: if args_mapping remaps old keys to POSITIONAL_ONLY constructor
-        # params, calling the proxy with those old names would TypeError after remapping.  Detect at
-        # decoration time, emit UserWarning, and record for audit + call-time fallback.
-        _incompatible: tuple[str, ...] = ()
-        if args_mapping and isinstance(_dc_check, type):
-            _incompatible = _get_args_mapping_positional_only_keys(_dc_check, args_mapping)
-            if _incompatible:
-                warnings.warn(
-                    f"`args_mapping` on `{name}` remaps {list(_incompatible)!r} to POSITIONAL_ONLY "
-                    f"constructor parameter(s) of `{_dc_check.__name__}`. "
-                    "Calls using those deprecated names will fall back to attribute assignment "
-                    "instead of constructor kwargs — consider using `attrs_mapping` instead.",
-                    UserWarning,
-                    stacklevel=4,
-                )
+        # Kwargs-compatibility guard: detect args_mapping keys that remap to POSITIONAL_ONLY params.
+        _incompatible = _detect_proxy_positional_only(_dc_check, name, args_mapping)
         # Auto-resolve: no explicit target but args_mapping provided → ARGS_REMAP
         if target is None and args_mapping:
             target = TargetMode.ARGS_REMAP
@@ -471,7 +444,7 @@ class _DeprecatedProxy:
             "remove_in": dep.remove_in,
         }
 
-    def _warn(self, *, arg_name: Optional[str] = None) -> None:  # noqa: C901, PLR0912
+    def _warn(self, *, arg_name: Optional[str] = None) -> None:
         """Emit a deprecation warning if the warn budget is not exhausted.
 
         Args:
@@ -487,56 +460,15 @@ class _DeprecatedProxy:
         if not stream:
             return
         if arg_name is not None:
-            # Per-argument warning budget
             arg_count = cfg.warned_args.get(arg_name, 0)
             if cfg.num_warns >= 0 and arg_count >= cfg.num_warns:
                 return
-        else:
-            # Global warning budget
-            if cfg.num_warns >= 0 and cfg.warned >= cfg.num_warns:
-                return
+        elif cfg.num_warns >= 0 and cfg.warned >= cfg.num_warns:
+            return
         dep = self._dep
-        target: Any = dep.target
-        args_mapping = dep.args_mapping
-        # ``cfg.template_mgs`` (when set) overrides the built-in template for every branch.  Fallback semantics
-        # mirror the decorator's ``_raise_warn_callable`` and ``_raise_warn_arguments``: the built-in template
-        # appropriate for the active scenario is used when no override is configured.
-        custom_template = cfg.template_mgs
-        # Per-argument warning: use the same template the decorator emits for `args_mapping` deprecations so callers
-        # see `old -> new` rather than a generic class-deprecation message.
-        if arg_name is not None and args_mapping and arg_name in args_mapping:
-            new_arg = args_mapping[arg_name]
-            argument_map = TEMPLATE_ARGUMENT_MAPPING % {"old_arg": arg_name, "new_arg": str(new_arg)}
-            template = custom_template or TEMPLATE_WARNING_ARGUMENTS
-            msg = template % {
-                "source_name": dep.name,
-                "deprecated_in": dep.deprecated_in,
-                "remove_in": dep.remove_in,
-                "argument_map": argument_map,
-            }
-        elif arg_name is not None and arg_name.startswith("__attr__:") and dep.attrs_mapping is not None:
-            _attr_msg = self._build_attr_warning_msg(arg_name, dep, dep.attrs_mapping, target, custom_template)
-            if _attr_msg is None:
-                return
-            msg = _attr_msg
-        elif callable(target):
-            target_name = target.__name__
-            target_path = f"{target.__module__}.{target_name}"
-            template = custom_template or TEMPLATE_WARNING_CALLABLE
-            msg = template % {
-                "source_name": dep.name,
-                "deprecated_in": dep.deprecated_in,
-                "remove_in": dep.remove_in,
-                "target_name": target_name,
-                "target_path": target_path,
-            }
-        else:
-            template = custom_template or TEMPLATE_WARNING_NO_TARGET
-            msg = template % {
-                "source_name": dep.name,
-                "deprecated_in": dep.deprecated_in,
-                "remove_in": dep.remove_in,
-            }
+        msg = _build_proxy_warn_msg(self, arg_name, dep, cfg)
+        if msg is None:
+            return
         # Route the warning to the caller's frame rather than ``proxy.py``.  Mirrors the ``_raise_warn`` fallback
         # in ``deprecation.py``: when ``stream`` does not accept a ``stacklevel`` kwarg (e.g. ``print``, custom
         # callables), fall back to a positional call.
@@ -786,7 +718,7 @@ class _DeprecatedProxy:
     # Callable protocol
     # ------------------------------------------------------------------
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, C901, PLR0912
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         """Call the active object, emitting a deprecation warning conditionally based on target mode.
 
         Branching logic:
@@ -811,44 +743,10 @@ class _DeprecatedProxy:
         # surface, so forwarding through the inner proxy avoids double-warning when both layers are active.
         if dep.target is TargetMode.ATTRS_REMAP and isinstance(cfg.obj, _DeprecatedProxy):
             return cfg.obj(*args, **kwargs)
-
         if dep.target is TargetMode.ARGS_REMAP:
-            mapping = dep.args_mapping or {}
-            for old_key in mapping:
-                if old_key in kwargs:
-                    self._warn(arg_name=old_key)
-            mapped_kwargs = self._apply_args_mapping(kwargs)
-            mapped_kwargs = self._merge_args_extra(mapped_kwargs)
-            # Positional-only fallback: after remapping, mapped_kwargs holds NEW keys; incompatible
-            # old keys have already been renamed to their POSITIONAL_ONLY target names.  Extract those
-            # new keys (cannot be forwarded as kwargs), construct the object, then setattr.
-            if dep.args_mapping_positional_only and dep.args_mapping:
-                _incompat_new = self._resolve_incompat_new_keys(dep)
-                pending = {k: mapped_kwargs.pop(k) for k in list(mapped_kwargs) if k in _incompat_new}
-                instance = cfg.obj(*args, **mapped_kwargs)
-                for new_key, val in pending.items():
-                    setattr(instance, new_key, val)
-                return instance
-            return cfg.obj(*args, **mapped_kwargs)
+            return _proxy_call_args_remap(self, dep, cfg, args, kwargs)
         if callable(dep.target) and dep.args_mapping:
-            mapping = dep.args_mapping or {}
-            for old_key in mapping:
-                if old_key in kwargs:
-                    self._warn(arg_name=old_key)
-            if not any(old_key in kwargs for old_key in mapping):
-                # No old-style args — still warn because the class itself is deprecated
-                self._warn()
-            mapped_kwargs = self._apply_args_mapping(kwargs)
-            mapped_kwargs = self._merge_args_extra(mapped_kwargs)
-            # Positional-only fallback for callable target path.
-            if dep.args_mapping_positional_only and dep.args_mapping:
-                _incompat_new = self._resolve_incompat_new_keys(dep)
-                pending = {k: mapped_kwargs.pop(k) for k in list(mapped_kwargs) if k in _incompat_new}
-                instance = dep.target(*args, **mapped_kwargs)
-                for new_key, val in pending.items():
-                    setattr(instance, new_key, val)
-                return instance
-            return dep.target(*args, **mapped_kwargs)
+            return _proxy_call_callable_with_mapping(self, dep, dep.target, args, kwargs)
         # Callable target without args_mapping: warn globally; still merge args_extra so
         # injected defaults reach the target.
         self._warn()
@@ -950,6 +848,159 @@ class _DeprecatedProxy:
             # __subclasscheck__ (e.g., from abc.ABCMeta) is respected.
             return issubclass(subclass, active)
         return False
+
+
+def _proxy_call_args_remap(
+    proxy: _DeprecatedProxy,
+    dep: DeprecationConfig,
+    cfg: _ProxyConfig,
+    args: tuple,
+    kwargs: dict,
+) -> Any:  # noqa: ANN401
+    """Handle ``TargetMode.ARGS_REMAP`` branch of ``__call__``: warn per deprecated kwarg, remap, call obj."""
+    mapping = dep.args_mapping or {}
+    for old_key in mapping:
+        if old_key in kwargs:
+            proxy._warn(arg_name=old_key)
+    mapped_kwargs = proxy._apply_args_mapping(kwargs)
+    mapped_kwargs = proxy._merge_args_extra(mapped_kwargs)
+    if dep.args_mapping_positional_only and dep.args_mapping:
+        _incompat_new = proxy._resolve_incompat_new_keys(dep)
+        pending = {k: mapped_kwargs.pop(k) for k in list(mapped_kwargs) if k in _incompat_new}
+        instance = cfg.obj(*args, **mapped_kwargs)
+        for new_key, val in pending.items():
+            setattr(instance, new_key, val)
+        return instance
+    return cfg.obj(*args, **mapped_kwargs)
+
+
+def _proxy_call_callable_with_mapping(
+    proxy: _DeprecatedProxy,
+    dep: DeprecationConfig,
+    target_fn: Callable[..., Any],
+    args: tuple,
+    kwargs: dict,
+) -> Any:  # noqa: ANN401
+    """Handle callable-target + args_mapping branch of ``__call__``: warn per kwarg, remap, forward."""
+    mapping = dep.args_mapping or {}
+    for old_key in mapping:
+        if old_key in kwargs:
+            proxy._warn(arg_name=old_key)
+    if not any(old_key in kwargs for old_key in mapping):
+        proxy._warn()
+    mapped_kwargs = proxy._apply_args_mapping(kwargs)
+    mapped_kwargs = proxy._merge_args_extra(mapped_kwargs)
+    if dep.args_mapping_positional_only and dep.args_mapping:
+        _incompat_new = proxy._resolve_incompat_new_keys(dep)
+        pending = {k: mapped_kwargs.pop(k) for k in list(mapped_kwargs) if k in _incompat_new}
+        instance = target_fn(*args, **mapped_kwargs)
+        for new_key, val in pending.items():
+            setattr(instance, new_key, val)
+        return instance
+    return target_fn(*args, **mapped_kwargs)
+
+
+def _expand_dc_attrs_to_args(
+    dc_check: Any,  # noqa: ANN401
+    attrs_mapping: Optional[dict[str, Optional[str]]],
+    args_mapping: Optional[dict[str, Optional[str]]],
+) -> tuple[Optional[dict[str, Optional[str]]], list[str]]:
+    """Auto-expand ``attrs_mapping`` entries into ``args_mapping`` for dataclass dual-surface deprecation.
+
+    When the target (or wrapped object) is a ``@dataclass``, copies ``attrs_mapping`` entries whose redirect value names
+    a dataclass ``__init__`` parameter into ``args_mapping`` so that both ``instance.old_field`` (attribute access) and
+    ``DC(old_field=5)`` (constructor kwarg) emit a ``FutureWarning`` from a single ``deprecated_class()`` call.
+
+    Returns ``(updated_args_mapping, auto_expanded_keys)``.  Returns the original ``args_mapping`` unchanged (possibly
+    ``None``) when ``attrs_mapping`` is empty/``None`` or ``dc_check`` is not a dataclass.  Keys already present in
+    ``args_mapping`` are never overwritten.
+
+    """
+    if not (attrs_mapping and _is_dataclass_target(dc_check)):
+        return args_mapping, []
+    auto_expanded: list[str] = []
+    _init_param_names: set[str] = set(inspect.signature(dc_check).parameters)
+    for _old_key, _mapping_val in attrs_mapping.items():
+        if _mapping_val in _init_param_names:
+            if args_mapping is None:
+                args_mapping = {}
+            if _old_key not in args_mapping:
+                args_mapping[_old_key] = _mapping_val
+                auto_expanded.append(_old_key)
+    return args_mapping, auto_expanded
+
+
+def _detect_proxy_positional_only(
+    dc_check: Any,  # noqa: ANN401
+    name: str,
+    args_mapping: Optional[dict[str, Optional[str]]],
+) -> tuple[str, ...]:
+    """Detect ``args_mapping`` keys that remap to POSITIONAL_ONLY constructor parameters.
+
+    Emits a ``UserWarning`` at decoration time and returns the incompatible old-key names so they can be recorded in
+    :class:`~deprecate._types.DeprecationConfig` for audit and call-time fallback. Returns an empty tuple when no
+    incompatibilities are found.
+
+    """
+    if not (args_mapping and isinstance(dc_check, type)):
+        return ()
+    incompatible = _get_args_mapping_positional_only_keys(dc_check, args_mapping)
+    if incompatible:
+        warnings.warn(
+            f"`args_mapping` on `{name}` remaps {list(incompatible)!r} to POSITIONAL_ONLY "
+            f"constructor parameter(s) of `{dc_check.__name__}`. "
+            "Calls using those deprecated names will fall back to attribute assignment "
+            "instead of constructor kwargs — consider using `attrs_mapping` instead.",
+            UserWarning,
+            stacklevel=5,  # caller → decorator(cls) → __init__ → _detect_proxy_positional_only → warn
+        )
+    return incompatible
+
+
+def _build_proxy_warn_msg(
+    proxy: _DeprecatedProxy,
+    arg_name: Optional[str],
+    dep: DeprecationConfig,
+    cfg: _ProxyConfig,
+) -> Optional[str]:
+    """Build the warning message string for a proxy warning emission.
+
+    Returns ``None`` when the warning should be suppressed (``attrs_mapping`` lookup miss).
+
+    """
+    target: Any = dep.target
+    args_mapping = dep.args_mapping
+    custom_template = cfg.template_mgs
+
+    if arg_name is not None and args_mapping and arg_name in args_mapping:
+        new_arg = args_mapping[arg_name]
+        argument_map = TEMPLATE_ARGUMENT_MAPPING % {"old_arg": arg_name, "new_arg": str(new_arg)}
+        template = custom_template or TEMPLATE_WARNING_ARGUMENTS
+        return template % {
+            "source_name": dep.name,
+            "deprecated_in": dep.deprecated_in,
+            "remove_in": dep.remove_in,
+            "argument_map": argument_map,
+        }
+    if arg_name is not None and arg_name.startswith("__attr__:") and dep.attrs_mapping is not None:
+        return proxy._build_attr_warning_msg(arg_name, dep, dep.attrs_mapping, target, custom_template)
+    if callable(target):
+        target_name = target.__name__
+        target_path = f"{target.__module__}.{target_name}"
+        template = custom_template or TEMPLATE_WARNING_CALLABLE
+        return template % {
+            "source_name": dep.name,
+            "deprecated_in": dep.deprecated_in,
+            "remove_in": dep.remove_in,
+            "target_name": target_name,
+            "target_path": target_path,
+        }
+    template = custom_template or TEMPLATE_WARNING_NO_TARGET
+    return template % {
+        "source_name": dep.name,
+        "deprecated_in": dep.deprecated_in,
+        "remove_in": dep.remove_in,
+    }
 
 
 def deprecated_class(

--- a/tests/unittests/test_audit.py
+++ b/tests/unittests/test_audit.py
@@ -19,6 +19,7 @@ from deprecate.audit import (
     ChainType,
     DeprecationStatus,
     DeprecationWrapperInfo,
+    _classify_member_api_type,
     _get_deprecation_status,
     _get_package_version,
     _parse_version,
@@ -587,6 +588,18 @@ class TestDwiCompatInit:
             result = dataclasses.replace(base, empty_mapping=True)  # type: ignore[call-arg]
 
         assert result.empty_args_mapping is True
+
+
+class TestClassifyMemberApiType:
+    """Tests for _classify_member_api_type — labels class-member audit rows."""
+
+    def test_init_without_mapping_returns_class_constructor(self) -> None:
+        """member_name='__init__' with has_mapping=False returns 'class constructor'."""
+        assert _classify_member_api_type("__init__", None, False) == "class constructor"
+
+    def test_init_with_mapping_returns_class_constructor_args(self) -> None:
+        """member_name='__init__' with has_mapping=True returns 'class constructor args'."""
+        assert _classify_member_api_type("__init__", None, True) == "class constructor args"
 
 
 class TestFindDeprecationWrappersClassScan:

--- a/tests/unittests/test_docs.py
+++ b/tests/unittests/test_docs.py
@@ -14,6 +14,7 @@ from deprecate.docstring.inject import (
     _find_google_arg_line,
     _find_google_args_section,
     _get_google_arg_indents,
+    _has_deprecation_block,
     _update_docstring_with_deprecation,
 )
 
@@ -42,6 +43,14 @@ class TestBuildArgDeprecationNote:
         note = _build_arg_deprecation_note(None, "1.8", "")
         assert "Will be removed" not in note
         assert "Deprecated since v1.8" in note
+
+
+class TestHasDeprecationBlock:
+    """Tests for _has_deprecation_block — detects already-injected notices."""
+
+    def test_empty_block_lines_returns_false(self) -> None:
+        """Empty block_lines triggers fast-return False regardless of doc_lines content."""
+        assert not _has_deprecation_block(["some content", "more content"], [])
 
 
 class TestFindGoogleArgLine:

--- a/tests/unittests/test_property.py
+++ b/tests/unittests/test_property.py
@@ -810,3 +810,102 @@ class TestPropertyErrorPaths:
             property(_getter)  # type: ignore[arg-type]
         )
         assert isinstance(result, _DeprecatedProperty)
+
+
+class TestDescriptorStacklevel:
+    """Decoration-time warnings from the _packing_descriptor paths attribute to the caller.
+
+    ``_packing_descriptor`` recursively calls ``packing_fn`` after unwrapping the descriptor.
+    That recursive call adds two frames to the call stack (one for the outer ``packing()`` and
+    one for ``_packing_descriptor`` itself), so the forwarded stacklevel must be ``+2`` not
+    ``+1``.  Each test below triggers the "no ``deprecated_in`` set" UserWarning at decoration
+    time and asserts that ``warning.filename`` ends with this test file's name, confirming the
+    warning points at the ``@deprecated`` application line rather than an internal helper frame.
+    """
+
+    def test_warn_filename_points_to_caller_on_classmethod_path(self) -> None:
+        """Classmethod path: decoration-time UserWarning attributes to caller's frame.
+
+        A developer applies ``@deprecated(remove_in="2.0")`` to a classmethod without
+        providing ``deprecated_in``.  ``_packing_descriptor`` unwraps the classmethod,
+        recursively calls ``packing_fn`` with ``_stacklevel + 2``, and the "missing
+        deprecated_in" UserWarning must point to the ``@deprecated`` line in the caller's
+        file — not to an internal frame inside ``deprecation.py``.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            class _Cls:
+                @deprecated(remove_in="2.0")
+                @classmethod
+                def old_method(cls) -> None:
+                    """Old classmethod."""
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning) and "deprecated_in" in str(w.message)]
+        assert user_warnings, "Expected UserWarning for missing deprecated_in on classmethod path"
+        assert user_warnings[0].filename.endswith("test_property.py")
+
+    def test_warn_filename_points_to_caller_on_staticmethod_path(self) -> None:
+        """Staticmethod path: decoration-time UserWarning attributes to caller's frame.
+
+        A developer applies ``@deprecated(remove_in="2.0")`` to a staticmethod without
+        providing ``deprecated_in``.  The same recursive-packing path as the classmethod
+        case fires, and the UserWarning must attribute to the decorator application line
+        in this test file rather than to an internal frame.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            class _Cls:
+                @deprecated(remove_in="2.0")
+                @staticmethod
+                def old_method() -> None:
+                    """Old staticmethod."""
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning) and "deprecated_in" in str(w.message)]
+        assert user_warnings, "Expected UserWarning for missing deprecated_in on staticmethod path"
+        assert user_warnings[0].filename.endswith("test_property.py")
+
+    def test_warn_filename_points_to_caller_on_property_path(self) -> None:
+        """Property path: decoration-time UserWarning attributes to caller's frame.
+
+        A developer applies ``@deprecated(remove_in="2.0")`` to a property without providing
+        ``deprecated_in``.  ``_packing_descriptor`` wraps ``fget`` by calling
+        ``packing_fn(source.fget, _stacklevel + 2)``; the resulting UserWarning must point to
+        the ``@deprecated`` application line in this test file.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            class _Cls:
+                @deprecated(remove_in="2.0")  # type: ignore[arg-type, prop-decorator]
+                @property
+                def old_prop(self) -> int:
+                    """Old property."""
+                    return 0
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning) and "deprecated_in" in str(w.message)]
+        assert user_warnings, "Expected UserWarning for missing deprecated_in on property path"
+        assert user_warnings[0].filename.endswith("test_property.py")
+
+    def test_warn_filename_points_to_caller_on_cached_property_path(self) -> None:
+        """cached_property path: decoration-time UserWarning attributes to caller's frame.
+
+        A developer applies ``@deprecated(remove_in="2.0")`` to a cached_property without
+        providing ``deprecated_in``.  ``_packing_descriptor`` calls
+        ``packing_fn(source.func, _stacklevel + 2)``; the UserWarning must attribute to the
+        ``@deprecated`` line in this test file, not to an internal frame.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            class _Cls:
+                @deprecated(remove_in="2.0")  # type: ignore[arg-type, prop-decorator]
+                @cached_property
+                def old_prop(self) -> int:
+                    """Old cached property."""
+                    return 0
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning) and "deprecated_in" in str(w.message)]
+        assert user_warnings, "Expected UserWarning for missing deprecated_in on cached_property path"
+        assert user_warnings[0].filename.endswith("test_property.py")

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -4,6 +4,7 @@ import abc
 import inspect
 import warnings
 from collections.abc import Callable
+from dataclasses import dataclass as dc_decorator
 from typing import Any, cast
 
 import pytest
@@ -150,6 +151,38 @@ class TestProxyWarnBehavior:
         # ``_DeprecatedProxy._warn`` forwards ``stacklevel=_DEFAULT_STACKLEVEL_TO_CALLER`` to ``stream``
         # so the warning is attributed to this test file rather than ``proxy.py``.
         assert caught[0].filename.endswith("test_proxy.py")
+
+    def test_warn_filename_points_to_caller_on_args_remap_path(self) -> None:
+        """_proxy_call_args_remap path attributes FutureWarning to the caller's frame.
+
+        When a proxy with TargetMode.ARGS_REMAP receives a deprecated kwarg, it routes
+        through ``_proxy_call_args_remap``. The extra call frame introduced by the helper
+        must be compensated by ``_extra_frames=1`` so the warning attributes to this test
+        file rather than ``proxy.py``.
+
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ProxyArgsRemapForArgWarnMessage(old_key=5)  # deprecated kwarg via ARGS_REMAP
+        future_warnings = [w for w in caught if issubclass(w.category, FutureWarning)]
+        assert future_warnings, "Expected FutureWarning from ARGS_REMAP path"
+        assert future_warnings[0].filename.endswith("test_proxy.py")
+
+    def test_warn_filename_points_to_caller_on_callable_with_mapping_path(self) -> None:
+        """_proxy_call_callable_with_mapping path attributes FutureWarning to the caller's frame.
+
+        When a proxy with a callable target and args_mapping receives a deprecated kwarg,
+        it routes through ``_proxy_call_callable_with_mapping``. The extra call frame must
+        be compensated by ``_extra_frames=1`` so the warning attributes to this test file
+        rather than ``proxy.py``.
+
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            MappedColorEnum(val=1)  # type: ignore[call-arg]  # deprecated kwarg via callable+args_mapping
+        future_warnings = [w for w in caught if issubclass(w.category, FutureWarning)]
+        assert future_warnings, "Expected FutureWarning from callable+args_mapping path"
+        assert future_warnings[0].filename.endswith("test_proxy.py")
 
 
 class TestProxyTemplateMgs:
@@ -2037,6 +2070,28 @@ class TestDataclassAutoExpand:
         )(AutoExpandDC)
         meta = object.__getattribute__(proxy, "__deprecated__")
         assert "old_field" not in meta.args_mapping_auto_expanded
+
+    def test_drop_mapping_entry_not_auto_expanded(self) -> None:
+        """attrs_mapping={'field': None} (drop-mapping) is not auto-expanded into args_mapping.
+
+        Drop entries (value=None) signal attribute removal, not renaming to a dataclass field.
+        Auto-expansion only applies when the redirect value names a dataclass __init__ parameter.
+        A None value has no target field name, so expansion must be skipped for that entry.
+
+        """
+
+        @dc_decorator
+        class _Target:
+            field: int = 0
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            proxy = deprecated_class(
+                target=_Target, deprecated_in="1.0", remove_in="2.0", attrs_mapping={"field": None}
+            )(_Target)
+        # Drop-mapping entry must not appear in args_mapping (no auto-expansion for None values)
+        dep = object.__getattribute__(proxy, "__deprecated__")
+        assert dep.args_mapping is None or "field" not in (dep.args_mapping or {})
 
     def test_req_dc_constructor_kwarg_warns_after_auto_expand(self) -> None:
         """``DepAutoExpandReqDC(old_field=5)`` emits FutureWarning and returns a correctly populated instance.


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Extract module-level helpers from complex functions across four modules:

- `audit.py`: lift `_scan_callable`/`_scan_class`/`_scan_module` out of `find_deprecation_wrappers`; extract `_classify_member_api_type` from `_classify_wrapper_api_type`; extract `_format_matrix_row` from `generate_deprecation_table`
- `deprecation.py`: extract `_invoke_async` and `_invoke_sync` from the `async_wrapped_fn`/`wrapped_fn` closures inside `packing()`
- `inject.py`: extract `_has_deprecation_block`, `_inject_args_mapping_section`, `_append_notice_after_inline_args`, `_insert_notice_before_section` from `_update_docstring_with_deprecation`
- `proxy.py`: extract `_expand_dc_attrs_to_args`, `_detect_proxy_positional_only`, `_proxy_call_args_remap`, `_proxy_call_callable_with_mapping`, `_build_proxy_warn_msg` from `__init__`, `_warn`, and `__call__`

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
