### PR TITLE
docs: restructure nav into Use Cases / Tools / Configuration / Adoption sections

### DIFF
--- a/docs/guide/use-cases.md
+++ b/docs/guide/use-cases.md
@@ -57,3 +57,5 @@ Advanced patterns: injecting a deprecation notice into the docstring at import t
 - [void() Helper](void-helper.md) — when and why the deprecated function body should call `void()`
 - [Audit Tools](audit.md) — enforce removal deadlines and detect deprecation chains in CI
 - [Troubleshooting](../troubleshooting.md) — common errors and fixes for `@deprecated` configuration
+- [Compare Python Deprecation Tools](compare-python-deprecation-tools.md) — how pyDeprecate compares to `warnings.warn`, `deprecation`, `wrapt`, and `warnings.deprecated`
+- [Agent Recipes](agent-recipes.md) — copy-paste patterns for AI coding assistants generating deprecation code

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,8 @@ _Comparison as of v0.8, May 2026. [Open an issue](https://github.com/Borda/pyDep
 - [Customization](guide/customization.md) — custom message templates and output redirection to loggers.
 - [void() Helper](guide/void-helper.md) — sentinel function for self-documenting deprecated stubs.
 - [Audit Tools](guide/audit.md) — enforce removal deadlines and catch deprecation chains in CI.
+- [Compare Python Deprecation Tools](guide/compare-python-deprecation-tools.md) — detailed feature matrix against `warnings.warn`, `deprecation`, `wrapt`, and `warnings.deprecated`.
+- [Agent Recipes](guide/agent-recipes.md) — copy-paste patterns for AI coding assistants.
 - [Troubleshooting](troubleshooting.md) — common errors and how to fix them.
 - [Sphinx demo](demo-sphinx/index.html) · [MkDocs demo](demo-mkdocs/index.html) — live rendered output.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,21 +68,23 @@ validation:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
-  - User Guide:
-      - Use Cases:
-          - Overview: guide/use-cases.md
-          - Functions: guide/functions.md
-          - Classes: guide/classes.md
-          - Properties: guide/properties.md
-          - Async: guide/async.md
-          - Advanced: guide/advanced.md
-      - Compare Python Deprecation Tools: guide/compare-python-deprecation-tools.md
-      - Agent Recipes: guide/agent-recipes.md
-      - void() Helper: guide/void-helper.md
+  - Use Cases:
+      - Overview: guide/use-cases.md
+      - Functions: guide/functions.md
+      - Classes: guide/classes.md
+      - Properties: guide/properties.md
+      - Async: guide/async.md
+      - Advanced: guide/advanced.md
+  - Tools:
       - Audit Tools: guide/audit.md
       - CLI: guide/cli.md
+      - void() Helper: guide/void-helper.md
+  - Configuration:
       - Customization: guide/customization.md
       - Migration Guide: guide/migration.md
+  - Adoption:
+      - Compare Python Deprecation Tools: guide/compare-python-deprecation-tools.md
+      - Agent Recipes: guide/agent-recipes.md
   - API Reference: api-reference.md
   - Troubleshooting: troubleshooting.md
   - Changelog: changelog.md


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- Replace flat `User Guide` wrapper with four top-level sections: `Use Cases`, `Tools`, `Configuration`, `Adoption` — uniform 2-level depth throughout
- Add cross-links to `compare-python-deprecation-tools.md` and `agent-recipes.md` in `use-cases.md` See Also and `index.md` Where to go next (both pages had zero inbound links)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
