### PR TITLE
chore(packaging,CI,tests,docs): hygiene

### DIFF
--- a/.github/workflows/ci_check-links.yml
+++ b/.github/workflows/ci_check-links.yml
@@ -11,10 +11,10 @@ on:
 permissions:
   contents: read
 
-# cancel superseded runs on the same ref so rapid pushes don't queue redundant link checks
+# cancel superseded runs only on PRs; never cancel pushes to protected branches or scheduled runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   links-check:

--- a/.github/workflows/ci_check-links.yml
+++ b/.github/workflows/ci_check-links.yml
@@ -11,6 +11,11 @@ on:
 permissions:
   contents: read
 
+# cancel superseded runs on the same ref so rapid pushes don't queue redundant link checks
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   links-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_install-pkg.yml
+++ b/.github/workflows/ci_install-pkg.yml
@@ -10,6 +10,11 @@ on: # Trigger the workflow on push or pull request, but only for the main branch
 permissions:
   contents: read
 
+# cancel superseded runs on the same ref so rapid pushes don't queue the full matrix repeatedly
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
@@ -62,6 +67,12 @@ jobs:
           pip install '${{ env.PKG_WHEEL }}' --force-reinstall
           pip list
           python -c "import deprecate as pkg; print(f'version: {pkg.__version__}')"
+
+      - name: 🖥️ Smoke-test console script (cli extra)
+        working-directory: dist
+        run: |
+          pip install "${{ env.PKG_WHEEL }}[cli]" --force-reinstall
+          pydeprecate --help
 
       - name: 📦 Install and check package (sdist)
         working-directory: dist

--- a/.github/workflows/ci_install-pkg.yml
+++ b/.github/workflows/ci_install-pkg.yml
@@ -10,10 +10,10 @@ on: # Trigger the workflow on push or pull request, but only for the main branch
 permissions:
   contents: read
 
-# cancel superseded runs on the same ref so rapid pushes don't queue the full matrix repeatedly
+# cancel superseded runs only on PRs; never cancel pushes to protected branches
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:

--- a/.github/workflows/ci_makefile.yml
+++ b/.github/workflows/ci_makefile.yml
@@ -11,6 +11,11 @@ on:
 permissions:
   contents: read
 
+# cancel superseded runs on the same ref so rapid pushes don't queue the full matrix repeatedly
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PYTHON_DEFAULT: "3.13"
 

--- a/.github/workflows/ci_makefile.yml
+++ b/.github/workflows/ci_makefile.yml
@@ -11,10 +11,10 @@ on:
 permissions:
   contents: read
 
-# cancel superseded runs on the same ref so rapid pushes don't queue the full matrix repeatedly
+# cancel superseded runs only on PRs; never cancel pushes to protected branches
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   PYTHON_DEFAULT: "3.13"

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -10,10 +10,10 @@ on: # Trigger the workflow on push or pull request, but only for the main branch
 permissions:
   contents: read
 
-# cancel superseded runs on the same ref so rapid pushes don't queue the full matrix repeatedly
+# cancel superseded runs only on PRs; never cancel pushes to protected branches
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pytester:

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -10,6 +10,11 @@ on: # Trigger the workflow on push or pull request, but only for the main branch
 permissions:
   contents: read
 
+# cancel superseded runs on the same ref so rapid pushes don't queue the full matrix repeatedly
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytester:
     runs-on: ${{ matrix.os }}
@@ -55,7 +60,7 @@ jobs:
         if: success()
         continue-on-error: true
         with:
-          # token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: pytest,python${{ matrix.python-version }}
           fail_ci_if_error: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "10 10 * * 6"
 
+# cancel superseded runs on the same ref so rapid pushes don't queue redundant scans
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,10 +8,11 @@ on:
   schedule:
     - cron: "10 10 * * 6"
 
-# cancel superseded runs on the same ref so rapid pushes don't queue redundant scans
+# cancel superseded runs on the same ref so rapid pushes don't queue redundant scans;
+# scheduled scans excluded from cancel to avoid interruption by a coincident push to main
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,11 +8,10 @@ on:
   schedule:
     - cron: "10 10 * * 6"
 
-# cancel superseded runs on the same ref so rapid pushes don't queue redundant scans;
-# scheduled scans excluded from cancel to avoid interruption by a coincident push to main
+# cancel superseded runs only on PRs; never cancel pushes to protected branches or scheduled scans
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 default_language_version:
-  python: python3.10
+  # generic python3 so hooks run under the local interpreter; docformatter keeps its own
+  # python3.10 pin below (wheel/compat workaround) until a release supports 3.12+
+  python: python3
 
 ci:
   autofix_prs: true

--- a/README.md
+++ b/README.md
@@ -245,12 +245,13 @@ Not sure which API to reach for? Start here.
 | `remove_in`        | `""`                        | Version when removed (e.g. `"2.0"`)                                                                        |
 |                    | **Advanced: ~10% of cases** |                                                                                                            |
 | `stream`           | `deprecation_warning`       | Warning sink callable (set `None` to silence warnings)                                                     |
-| `num_warns`        | `1`                         | `1` once · `-1` always · `N` exactly N times                                                               |
+| `num_warns`        | `1`                         | `0` never · `1` once · `-1` always · `N` exactly N times                                                   |
 | `args_mapping`     | `None`                      | `{"old": "new"}` rename · `{"old": None}` drop                                                             |
 | `template_mgs`     | `None`                      | Custom warning message template (`%`-style placeholders)                                                   |
 | `args_extra`       | `None`                      | Fixed kwargs injected into the target call                                                                 |
 | `skip_if`          | `False`                     | `bool` or `Callable → bool`; skip deprecation when true                                                    |
 | `update_docstring` | `False`                     | Append Sphinx `.. deprecated::` notice to docstring                                                        |
+| `docstring_style`  | `"auto"`                    | Docstring notice format: `auto` · `rst` · `mkdocs`/`markdown`                                              |
 
 > [!TIP]
 > `@deprecated_class()` shares `target`, `deprecated_in`, `remove_in`, `num_warns`, `stream`, `args_mapping`, `attrs_mapping`, `args_extra`, `template_mgs`, `update_docstring`, and `docstring_style`.

--- a/docs/guide/classes.md
+++ b/docs/guide/classes.md
@@ -762,10 +762,10 @@ proxy = deprecated_class(
 )(TrainLoop)
 
 
-val1 = proxy.num_iters  # warns: FutureWarning — deprecated v1.0 name
+val1 = proxy.num_iters  # warns: FutureWarning — num_iters deprecated in v2.0 (→ num_steps)
 print(val1)
 
-val2 = proxy.num_steps  # warns: FutureWarning — deprecated v2.0 name
+val2 = proxy.num_steps  # warns: FutureWarning — num_steps deprecated in v2.0 (→ max_steps)
 print(val2)
 
 val3 = proxy.max_steps  # silent — canonical name

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -44,7 +44,7 @@ print(my_func(2))
 
 </details>
 
-`TargetMode.NOTIFY` emits a deprecation notice on every call and then executes the function body as normal.
+`TargetMode.NOTIFY` emits a deprecation notice (subject to `num_warns` — once by default, not on every call) and then executes the function body as normal.
 
 ### `target=True` → `TargetMode.ARGS_REMAP`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ description: >-
 
 Every time you rename a function or retire an argument, you end up writing the same boilerplate: a wrapper, a `warnings.warn` call with the right category and `stacklevel`, manual argument forwarding, and no way to enforce the removal deadline when it arrives. **pyDeprecate** replaces all of that with a single decorator and gives you CI tools to make sure deprecated code does not quietly outlive its deadline.
 
-> **pyDeprecate is downloaded over 700,000 times per month** from PyPI (source: [pepy.tech](https://pepy.tech/project/pyDeprecate)) — used across production Python projects that need reliable API deprecation without adding runtime dependencies.
+> **pyDeprecate is downloaded over 700,000 times per month** (as of mid-2026) from PyPI (source: [pepy.tech](https://pepy.tech/project/pyDeprecate)) — used across production Python projects that need reliable API deprecation without adding runtime dependencies.
 >
 > **Read:** [Mastering API Deprecation in Python — the pain points and how pyDeprecate can help](https://medium.com/codex/mastering-api-deprecation-in-python-the-pain-points-and-how-pydeprecate-can-help-1dbfd90e2b62) — CodeX / Medium
 
@@ -139,7 +139,7 @@ Recent PyPI download statistics show broad production use; see pepy.tech for cur
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Python versions              | Project metadata currently supports Python 3.9+; Borda-maintained development policy targets Python 3.10+ because Python 3.9 reached end of life in October 2025. |
 | Runtime dependencies         | None.                                                                                                                                                             |
-| Optional audit extra         | `packaging`.                                                                                                                                                      |
+| Optional audit extra         | `packaging` (plus `tomli` on Python < 3.11 for `pyproject.toml` version detection).                                                                               |
 | Optional CLI extra           | `fire`, `rich`.                                                                                                                                                   |
 | Docs engines                 | Sphinx and MkDocs compatible.                                                                                                                                     |
 | Type checker static warnings | Prefer `warnings.deprecated` for Python 3.13+ static-checker-only cases.                                                                                          |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -106,19 +106,19 @@ class OldModel:
 from deprecate import TargetMode, deprecated_class
 
 
-class Config:
-    colour: str = "red"
+class NewClass:
+    new_attr: str = "value"
 
 
-# Only "color" warns and redirects to "colour"; other attributes pass through silently.
+# Only "old_attr" warns and redirects to "new_attr"; other attributes pass through silently.
 # Passing attrs_mapping alone auto-resolves to TargetMode.ATTRS_REMAP; the explicit target= form is equivalent.
-# Use None as the value for warn-only with no rename: attrs_mapping={"size": None}.
-DeprecatedConfig = deprecated_class(
+# Use None as the value for warn-only with no rename: attrs_mapping={"other_attr": None}.
+OldClass = deprecated_class(
     target=TargetMode.ATTRS_REMAP,
-    attrs_mapping={"color": "colour"},
+    attrs_mapping={"old_attr": "new_attr"},
     deprecated_in="1.2",
     remove_in="2.0",
-)(Config)
+)(NewClass)
 ```
 
 ### Object alias

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -17,10 +17,13 @@
 | Deprecate a class | `deprecated_class` |
 | Deprecate an object alias | `deprecated_instance` |
 | Argument rename/drop mode | `TargetMode.ARGS_REMAP` |
+| Selective per-attribute deprecation on a class | `TargetMode.ATTRS_REMAP` + `attrs_mapping` |
 | Warning-only mode | `TargetMode.NOTIFY` |
 | Validate expired deprecations | `validate_deprecation_expiry` |
 | Validate wrapper chains | `validate_deprecation_chains` |
+| Detect POSITIONAL_ONLY-remap incompatibilities | `validate_mapping_compatibility` |
 | Discover wrappers | `find_deprecation_wrappers` |
+| Generate a markdown deprecation table | `generate_deprecation_table` |
 
 ## Canonical Recipes
 
@@ -97,6 +100,27 @@ class OldModel:
     pass
 ```
 
+### Selective attribute deprecation (`ATTRS_REMAP`)
+
+```python
+from deprecate import TargetMode, deprecated_class
+
+
+class Config:
+    colour: str = "red"
+
+
+# Only "color" warns and redirects to "colour"; other attributes pass through silently.
+# Passing attrs_mapping alone auto-resolves to TargetMode.ATTRS_REMAP; the explicit target= form is equivalent.
+# Use None as the value for warn-only with no rename: attrs_mapping={"size": None}.
+DeprecatedConfig = deprecated_class(
+    target=TargetMode.ATTRS_REMAP,
+    attrs_mapping={"color": "colour"},
+    deprecated_in="1.2",
+    remove_in="2.0",
+)(Config)
+```
+
 ### Object alias
 
 ```python
@@ -124,6 +148,8 @@ validate_deprecation_expiry("my_package", current_version="2.0")
 ```
 
 `validate_deprecation_expiry` includes class members by default (`include_members=True`); recursive scans warn-and-skip submodules that fail to import (`UserWarning: audit: skipped <module>: <exc>`) instead of aborting.
+
+Two more audit helpers: `validate_mapping_compatibility("my_package")` flags `deprecated_class` wrappers whose `args_mapping` remaps to POSITIONAL_ONLY constructor params (a silent `setattr` fallback), and `generate_deprecation_table("my_package", style="matrix")` renders a docs-friendly markdown summary of every wrapper's lifecycle.
 
 The CLI accepts directory paths and resolves them to packages:
 
@@ -162,5 +188,5 @@ pydeprecate all src/
 - Use Cases: https://borda.github.io/pyDeprecate/stable/guide/use-cases.html
 - Agent Recipes: https://borda.github.io/pyDeprecate/stable/guide/agent-recipes.html
 - API Migration CI: https://borda.github.io/pyDeprecate/stable/guide/audit.html
-- Class and Object Deprecation: https://borda.github.io/pyDeprecate/stable/guide/use-cases.html
+- Class and Object Deprecation: https://borda.github.io/pyDeprecate/stable/guide/classes.html
 - Compare Python Deprecation Tools: https://borda.github.io/pyDeprecate/stable/guide/compare-python-deprecation-tools.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-  "setuptools",
-  "wheel",
+  "setuptools>=70",
 ]
 
 [tool.ruff]
@@ -126,6 +125,8 @@ ini_options.junit_duration_report = "call"
 run.parallel = true
 run.relative_files = true
 report.exclude_lines = [
-  "pass",
+  # anchored so only a bare `pass` statement is excluded — a substring `pass` would also drop
+  # lines containing `passed`, `password`, etc. and overstate coverage
+  "^\\s*pass\\s*$",
   "pragma: no cover",
 ]

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,8 @@ setup(
             "packaging>=20.0",
             "tomli>=2.0; python_version<'3.11'",  # tomllib stdlib in 3.11+
         ],  # For validate_deprecation_expiry and pyproject.toml version detection
-        "cli": ["fire", "rich"],  # For pydeprecate CLI command and Rich output support
+        # floors pin the oldest CI-tested releases; Fire's arg-parsing semantics vary across releases
+        "cli": ["fire>=0.6.0", "rich>=13.0.0"],  # For pydeprecate CLI command and Rich output support
     },
     project_urls={
         "Documentation": ABOUT.__homepage__,

--- a/src/deprecate/__about__.py
+++ b/src/deprecate/__about__.py
@@ -5,7 +5,7 @@ code.
 
 """
 
-__version__ = "0.11.0.dev"
+__version__ = "0.11.0.dev0"
 __docs__ = "Python deprecation decorator: call forwarding, argument mapping, class proxying, CI audit. Zero deps."
 __author__ = "Jiri Borovec"
 __author_email__ = "j.borovec+github[at]gmail.com"

--- a/src/deprecate/_pkg.py
+++ b/src/deprecate/_pkg.py
@@ -6,7 +6,7 @@ Version resolution uses a local ``pyproject.toml`` (development checkout) when a
 distribution metadata via ``importlib.metadata``.
 
 TOML parsing uses ``tomllib`` (stdlib on Python 3.11+) or ``tomli`` (backport, via ``pip install 'pyDeprecate[audit]'``
-on Python 3.10). When not available the helpers return ``None`` and callers fall back to ``importlib.metadata``.
+on Python 3.9-3.10). When not available the helpers return ``None`` and callers fall back to ``importlib.metadata``.
 
 This module is private (no ``__all__``); its surface may change without notice.
 

--- a/src/deprecate/audit.py
+++ b/src/deprecate/audit.py
@@ -1,12 +1,16 @@
 """Audit tools for deprecation lifecycle management.
 
-This module provides three complementary utilities for verifying the health of deprecated callables across a codebase.
-All three are designed to be called from pytest or a CI script against an imported package.
+This module provides several complementary utilities for verifying the health of deprecated callables across a
+codebase. All are designed to be called from pytest or a CI script against an imported package.
 
 **Wrapper configuration** (:func:`~deprecate.audit.validate_deprecation_wrapper`,
 :func:`~deprecate.audit.find_deprecation_wrappers`):
     Detect wrappers that have zero impact — invalid ``args_mapping`` keys, identity mappings, empty mappings, or a
     ``target`` pointing back to the same wrapper.
+
+**Mapping compatibility** (:func:`~deprecate.audit.validate_mapping_compatibility`):
+    Detect :func:`~deprecate.proxy.deprecated_class` wrappers whose ``args_mapping`` remaps to POSITIONAL_ONLY
+    constructor params, silently degrading to ``setattr`` at call time.
 
 **Expiry enforcement** (:func:`~deprecate.audit.validate_deprecation_expiry`):
     Detect wrappers whose ``remove_in`` version has been reached or passed, preventing zombie code from shipping past
@@ -531,7 +535,7 @@ def validate_deprecation_wrapper(func: Callable) -> DeprecationWrapperInfo:
             :class:`~deprecate._types.DeprecationConfig`).
 
     Example:
-        >>> from deprecate import deprecated, validate_deprecation_wrapper
+        >>> from deprecate import TargetMode, deprecated, validate_deprecation_wrapper
         >>> def new_implementation(value: int) -> int:
         ...     return value * 2
         >>>
@@ -546,7 +550,7 @@ def validate_deprecation_wrapper(func: Callable) -> DeprecationWrapperInfo:
         >>> result.invalid_args
         []
 
-        >>> @deprecated(target=True, deprecated_in="1.0", args_mapping={"arg": "arg"})
+        >>> @deprecated(target=TargetMode.ARGS_REMAP, deprecated_in="1.0", args_mapping={"arg": "arg"})
         ... def identity_func(arg: int) -> int:
         ...     return arg
         >>>
@@ -1433,9 +1437,9 @@ def validate_deprecation_chains(
 
     1. **TARGET chains**: The ``target`` argument points to another deprecated callable instead of the final
        non-deprecated implementation.
-    2. **STACKED chains**: Multiple ``@deprecated(True, ...)`` decorators are stacked on the same function with
-       argument mappings that should be collapsed, or a callable ``target`` is itself a self-deprecation
-       (``target=True``) requiring mapping composition.
+    2. **STACKED chains**: Multiple ``@deprecated(target=TargetMode.ARGS_REMAP, ...)`` decorators are stacked on the
+       same function with argument mappings that should be collapsed, or a callable ``target`` is itself a
+       self-deprecation (``target=TargetMode.ARGS_REMAP``) requiring mapping composition.
 
     Both types are wasteful: wrappers should point directly to the final (non-deprecated) implementation with
     composed argument mappings.

--- a/tests/integration/test_audit.py
+++ b/tests/integration/test_audit.py
@@ -8,7 +8,7 @@ import pkgutil
 import types
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +19,7 @@ import tests.collection_deprecate as proxy_module
 import tests.collection_misconfigured as sample_module
 from deprecate import (
     DeprecatedCallableInfo,
+    TableStyle,
     TargetMode,
     deprecated,
     find_deprecated_callables,
@@ -165,13 +166,13 @@ class TestMisconfiguredTarget:
             "args_only_no_mapping_deprecation",
         ],
     )
-    def test_misconfigured_target_true(self, func_name: str) -> None:
+    def test_target_true(self, func_name: str) -> None:
         """Invalid target configurations are flagged as misconfigured_target=True."""
         result = validate_deprecation_wrapper(getattr(sample_module, func_name))
         assert result.misconfigured_target is True
 
     @pytest.mark.parametrize("func_name", ["whole_clean_deprecation", "args_only_clean_deprecation"])
-    def test_misconfigured_target_false_for_valid_configs(self, func_name: str) -> None:
+    def test_target_false_for_valid_configs(self, func_name: str) -> None:
         """Correctly configured TargetMode wrappers have misconfigured_target=False."""
         result = validate_deprecation_wrapper(getattr(sample_module, func_name))
         assert result.misconfigured_target is False
@@ -181,7 +182,7 @@ class TestMisconfiguredTarget:
         result = validate_deprecation_wrapper(proxy_module.decorated_pow_self)
         assert result.misconfigured_target is False
 
-    def test_misconfigured_flag_detected_when_target_false_used(self) -> None:
+    def test_flag_detected_when_target_false_used(self) -> None:
         """Audit flags misconfigured_target=True when legacy target=False was passed, even after normalisation."""
         result = validate_deprecation_wrapper(sample_module.target_false_deprecation)
         assert result.misconfigured_target is True
@@ -643,9 +644,21 @@ class TestGenerateDeprecationMarkdown:
         assert data_rows == []
 
     @_requires_packaging
-    def test_markdown_matrix_style_marks_deprecate_and_remove_versions(self) -> None:
-        """Matrix style adds version columns and D/R markers per symbol lifecycle."""
-        report = generate_deprecation_table(proxy_module, current_version="1.5", recursive=False, style="matrix")
+    @pytest.mark.parametrize(
+        "style",
+        [
+            pytest.param("matrix", id="str"),
+            pytest.param(TableStyle.MATRIX, id="enum"),
+        ],
+    )
+    def test_markdown_matrix_style_marks_deprecate_and_remove_versions(self, style: Union[str, TableStyle]) -> None:
+        """Matrix style adds version columns and D/R markers per symbol lifecycle.
+
+        A caller may pass the style either as the ``"matrix"`` string alias or as the ``TableStyle.MATRIX`` enum
+        member — both are accepted by ``generate_deprecation_table`` and must yield the same report, so the enum
+        surface is exercised (not only string coercion) the way a downstream user importing ``TableStyle`` would use it.
+        """
+        report = generate_deprecation_table(proxy_module, current_version="1.5", recursive=False, style=style)
         assert "| Original API | API Type | New API |" in report
         assert "v1.0" in report
         assert "v2.0" in report

--- a/tests/integration/test_target_mode.py
+++ b/tests/integration/test_target_mode.py
@@ -287,14 +287,14 @@ class TestArgsRemapMode:
 class TestDefaultTarget:
     """Omitting `target` defaults to TargetMode.NOTIFY — warn-only, no forwarding."""
 
-    def test_default_target_resolves_to_notify(self) -> None:
+    def test_resolves_to_notify(self) -> None:
         """Omitting target stores TargetMode.NOTIFY in __deprecated__.target."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             fn = make_default_target_with_versions()
         assert cast(_DeprecatedCallable, fn).__deprecated__.target is TargetMode.NOTIFY
 
-    def test_default_target_no_decoration_time_future_warning(self) -> None:
+    def test_no_decoration_time_future_warning(self) -> None:
         """Omitting target emits no FutureWarning at decoration time (unlike target=None)."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -302,7 +302,7 @@ class TestDefaultTarget:
         future_warns = [w for w in caught if issubclass(w.category, FutureWarning)]
         assert future_warns == []
 
-    def test_default_target_warns_on_call(self) -> None:
+    def test_warns_on_call(self) -> None:
         """Omitting target still emits FutureWarning when the decorated function is called."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -310,7 +310,7 @@ class TestDefaultTarget:
         with pytest.warns(FutureWarning):
             fn(1)
 
-    def test_default_target_executes_body(self) -> None:
+    def test_executes_body(self) -> None:
         """Omitting target executes the original function body and returns its value."""
         tracked_identity_calls.clear()
         with warnings.catch_warnings():

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,7 +6,6 @@ scikit-learn >=1.7.2; python_version > "3.9"
 pytest-asyncio >=1.2.0; python_version < "3.10"
 pytest-asyncio >=1.4.0; python_version > "3.9"
 phmdoctest >=1.4.0
-dataclasses  # needed for phmdoctest
 typing_extensions  # PEP 702 stacking regression tests
 packaging  # required for version-comparison audit tests
 

--- a/tests/unittests/test_deprecation.py
+++ b/tests/unittests/test_deprecation.py
@@ -547,6 +547,10 @@ class TestCrossClassMethodGuard:
             def old_method(self, x: int) -> int:
                 return void(x)
 
+        # Guard returned silently: decoration completed and attached deprecation metadata rather than raising.
+        # (The synthetic ``replacement`` fixture rejects the forwarded ``self``, so only decoration is asserted here.)
+        assert hasattr(RealOwner.old_method, "__deprecated__")
+
     def test_decorator_rewriting_source_qualname_same_class_no_warning(self) -> None:
         """Frame inspection resolves the FP when a decorator corrupts source qualname on a same-class forward.
 
@@ -569,6 +573,11 @@ class TestCrossClassMethodGuard:
             @rewrite_to_alien_class
             def old_method(self, x: int) -> int:
                 return void(x)
+
+        # Decoration succeeded and the wrapper forwards to the same-class target: calling it warns and returns 7.
+        with pytest.warns(FutureWarning):
+            result = MyClass().old_method(7)
+        assert result == 7
 
     def test_decorator_rewriting_qualname_raises_for_cross_class(self) -> None:
         """A pre-applied decorator rewriting source qualname to a genuinely different class still raises TypeError.

--- a/tests/unittests/test_proxy.py
+++ b/tests/unittests/test_proxy.py
@@ -792,7 +792,7 @@ class TestArgsExtra:
         """deprecated_class accepts args_extra without raising TypeError."""
         assert isinstance(ProxyClassWithArgsExtra, _DeprecatedProxy)
 
-    def test_args_extra_values_appear_in_forwarded_constructor_call(self) -> None:
+    def test_values_appear_in_forwarded_constructor_call(self) -> None:
         """Kwargs from args_extra are merged into the forwarded constructor call."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", FutureWarning)
@@ -800,7 +800,7 @@ class TestArgsExtra:
         assert instance.new_key == 7
         assert instance.injected == "from-extra"
 
-    def test_args_extra_merged_after_args_mapping_rename(self) -> None:
+    def test_merged_after_args_mapping_rename(self) -> None:
         """args_extra is applied after args_mapping renames kwargs."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

PR of the full-review P3 backlog — packaging, CI, test and docs hygiene with no user-visible behavior change (no CHANGELOG entries).

### Packaging (PKG-1..4):
- __about__.py: __version__ 0.11.0.dev → 0.11.0.dev0 (canonical PEP 440)
- pyproject build-system: require setuptools>=70, drop obsolete wheel
- setup.py cli extra: floor fire>=0.6.0, rich>=13.0.0 (Fire parsing varies across releases)
- coverage exclude_lines: anchor bare pass as ^\s*pass\s*$ (substring matched passed/password)
- _pkg.py docstring: tomli backport note 3.10 → 3.9-3.10

### CI (CI-3..6):
- ci_testing: uncomment CODECOV_TOKEN
- ci_install-pkg: smoke-test the pydeprecate console script from the built wheel[cli]
- .pre-commit default_language_version python3.10 → python3 (docformatter keeps its own 3.10 pin)
- concurrency groups on PR-triggered workflows (ci_testing, ci_install-pkg, ci_check-links, ci_makefile, codeql)

### Tests (TEST-7..10):
- parametrize the markdown-table test over both "matrix" string and TableStyle.MATRIX enum
- rename 9 test methods that repeated their class name
- add call-time assertions to two assertion-free cross-class-guard tests
- drop obsolete dataclasses backport from tests/requirements.txt

### Docs (DOC-15..18):
- llms-full.txt: add ATTRS_REMAP/attrs_mapping + validate_mapping_compatibility/generate_deprecation_table to the API map, an attrs recipe, and audit-helper notes; retarget the class-deprecation link to classes.html
- README all-parameters table: document num_warns=0 (never) and add the docstring_style row
- audit.py module docstring: correct the utility count and add the mapping-compatibility group; replace legacy target=True with TargetMode.ARGS_REMAP in the chains/wrapper docstrings
- misc nits: migration.md num_warns clarification, index.md download as-of date + tomli audit-extra note, classes.md stale version comments

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
